### PR TITLE
fix: remove compulsory need for project on service configuration

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -16,6 +16,7 @@
 """Main application classes for a craft-application."""
 from __future__ import annotations
 
+import contextlib
 import functools
 import os
 import pathlib
@@ -124,12 +125,14 @@ class Application:
         Any child classes that override this must either call this directly or must
         provide a valid ``project`` to ``self.services``.
         """
-        self.services.project = self.project
+        # Workaround for canonical/craft-application#63
+        with contextlib.suppress(FileNotFoundError):
+            self.services.project = self.project
+
         self.services.set_kwargs(
             "lifecycle",
             cache_dir=self.cache_dir,
             work_dir=self._work_dir,
-            base=self.project.effective_base,
         )
 
     @functools.cached_property


### PR DESCRIPTION
Removed explicit references to <Application>.project during Application._configure_services to allow for non-lifecycle commands to be used.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
This is a workaround for canonical/craft-application#63