### PR TITLE
fix: correctly represent yaml dumped multiline strings

### DIFF
--- a/tests/unit/models/project_models/full_project.yaml
+++ b/tests/unit/models/project_models/full_project.yaml
@@ -1,6 +1,8 @@
 base: core24
 contact: author@project.org
-description: A fully-defined craft-application project. (description)
+description: |
+  A fully-defined craft-application project.
+  With more than one line.
 issues: https://github.com/canonical/craft-application/issues
 license: LGPLv3
 name: full-project

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for BaseProject"""
 import pathlib
+from textwrap import dedent
 from typing import Optional
 
 import pytest
@@ -44,14 +45,19 @@ FULL_PROJECT = Project(
     issues="https://github.com/canonical/craft-application/issues",
     source_code="https://github.com/canonical/craft-application",  # pyright: ignore[reportGeneralTypeIssues]
     summary="A fully-defined craft-application project.",  # pyright: ignore[reportGeneralTypeIssues]
-    description="A fully-defined craft-application project. (description)",
+    description="A fully-defined craft-application project.\nWith more than one line.\n",
     license="LGPLv3",
     parts=PARTS_DICT,
 )
 FULL_PROJECT_DICT = {
     "base": "core24",
     "contact": "author@project.org",
-    "description": "A fully-defined craft-application project. (description)",
+    "description": dedent(
+        """\
+        A fully-defined craft-application project.
+        With more than one line.
+    """
+    ),
     "issues": "https://github.com/canonical/craft-application/issues",
     "license": "LGPLv3",
     "name": "full-project",


### PR DESCRIPTION
Add a representer as we do for other craft applications to correctly dump multi line strings.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
