### PR TITLE
feat(commands): add version command

### DIFF
--- a/craft_application/commands/__init__.py
+++ b/craft_application/commands/__init__.py
@@ -18,9 +18,11 @@
 from craft_application.commands.base import AppCommand
 from craft_application.commands import lifecycle
 from craft_application.commands.lifecycle import get_lifecycle_command_group
+from craft_application.commands.other import get_other_command_group
 
 __all__ = [
     "AppCommand",
     "lifecycle",
     "get_lifecycle_command_group",
+    "get_other_command_group",
 ]

--- a/craft_application/commands/other.py
+++ b/craft_application/commands/other.py
@@ -45,7 +45,7 @@ class VersionCommand(base.AppCommand):
     common = True
 
     def run(
-        self, parsed_args: argparse.Namespace  # noqa:ARG002 (Unused method argument)
+        self, parsed_args: argparse.Namespace  # noqa: ARG002 (Unused method argument)
     ) -> None:
         """Run the command."""
         emit.message(f"{self._app.name} {self._app.version}")

--- a/craft_application/commands/other.py
+++ b/craft_application/commands/other.py
@@ -1,0 +1,48 @@
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Version command."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from craft_cli import CommandGroup, emit
+
+from craft_application.commands import base
+
+if TYPE_CHECKING:  # pragma: no cover
+    import argparse
+
+
+def get_other_command_group() -> CommandGroup:
+    """Return the lifecycle related command group."""
+    commands: list[type[base.AppCommand]] = [
+        VersionCommand,
+    ]
+
+    return CommandGroup(
+        "Other",
+        commands,
+    )
+
+class VersionCommand(base.AppCommand):
+    """Show the snapcraft version."""
+
+    name = "version"
+    help_msg = "Show the application version and exit"
+    overview = "Show the application version and exit"
+    common = True
+
+    def run(self, parsed_args: argparse.Namespace) -> None:  # noqa:ARG002 (Unused method argument)
+        """Run the command."""
+        emit.message(f"{self._app.name} {self._app.version}")

--- a/craft_application/commands/other.py
+++ b/craft_application/commands/other.py
@@ -11,7 +11,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Version command."""
+"""Miscellaneous commands in the 'Other' command group."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/craft_application/commands/other.py
+++ b/craft_application/commands/other.py
@@ -35,6 +35,7 @@ def get_other_command_group() -> CommandGroup:
         commands,
     )
 
+
 class VersionCommand(base.AppCommand):
     """Show the snapcraft version."""
 
@@ -43,6 +44,8 @@ class VersionCommand(base.AppCommand):
     overview = "Show the application version and exit"
     common = True
 
-    def run(self, parsed_args: argparse.Namespace) -> None:  # noqa:ARG002 (Unused method argument)
+    def run(
+        self, parsed_args: argparse.Namespace  # noqa:ARG002 (Unused method argument)
+    ) -> None:
         """Run the command."""
         emit.message(f"{self._app.name} {self._app.version}")

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -114,8 +114,6 @@ def test_project_managed(capsys, monkeypatch, tmp_path, project, app):
 
 
 def test_version(capsys, monkeypatch, app):
-    monkeypatch.setenv("CRAFT_DEBUG", "1")
-    monkeypatch.setenv("CRAFT_MANAGED_MODE", "1")
     monkeypatch.setattr("sys.argv", ["testcraft", "version"])
 
     app.run()

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -46,9 +46,11 @@ Global options:
     -V, --version:  Show the application version and exit
 
 Starter commands:
+          version:  Show the application version and exit
 
 Commands can be classified as follows:
         Lifecycle:  build, clean, pack, prime, pull, stage
+            Other:  version
 
 For more information about a command, run 'testcraft help <command>'.
 For a summary of all commands, run 'testcraft help --all'.
@@ -109,6 +111,17 @@ def test_project_managed(capsys, monkeypatch, tmp_path, project, app):
     assert (tmp_path / "package.tar.zst").exists()
     captured = capsys.readouterr()
     assert captured.out == (VALID_PROJECTS_DIR / project / "stdout").read_text()
+
+
+def test_version(capsys, monkeypatch, app):
+    monkeypatch.setenv("CRAFT_DEBUG", "1")
+    monkeypatch.setenv("CRAFT_MANAGED_MODE", "1")
+    monkeypatch.setattr("sys.argv", ["testcraft", "version"])
+
+    app.run()
+
+    captured = capsys.readouterr()
+    assert captured.out == "testcraft 3.14159\n"
 
 
 def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):

--- a/tests/unit/commands/test_other.py
+++ b/tests/unit/commands/test_other.py
@@ -1,0 +1,39 @@
+# This file is part of craft-application.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for lifecycle commands."""
+import argparse
+
+import pytest
+from craft_application.commands.other import VersionCommand, get_other_command_group
+
+OTHER_COMMANDS = {
+    VersionCommand,
+}
+
+
+@pytest.mark.parametrize("commands", [OTHER_COMMANDS])
+def test_get_other_command_group(commands):
+    actual = get_other_command_group()
+
+    assert set(actual.commands) == commands
+
+
+def test_version_run(app_metadata, tmp_path, mock_services, emitter):
+    parsed_args = argparse.Namespace(output=tmp_path)
+    command = VersionCommand({"app": app_metadata, "services": mock_services})
+    command.run(parsed_args)
+
+    assert emitter.assert_message("testcraft 3.14159")

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -54,8 +54,21 @@ def mock_dispatcher(monkeypatch):
 @pytest.mark.parametrize(
     ("added_groups", "expected"),
     [
-        ([], [commands.get_lifecycle_command_group()]),
-        ([[]], [commands.get_lifecycle_command_group(), EMPTY_COMMAND_GROUP]),
+        (
+            [],
+            [
+                commands.get_lifecycle_command_group(),
+                commands.get_other_command_group(),
+            ],
+        ),
+        (
+            [[]],
+            [
+                commands.get_lifecycle_command_group(),
+                commands.get_other_command_group(),
+                EMPTY_COMMAND_GROUP,
+            ],
+        ),
     ],
 )
 def test_add_get_command_groups(app, added_groups, expected):


### PR DESCRIPTION
Implement the `version` command with the same output as the `--version`
command-line option. Project loading is deferred to the point where
managed commands are executed.

Fixes #63

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
