### PR TITLE
fix: order the yaml output

### DIFF
--- a/craft_application/models/base.py
+++ b/craft_application/models/base.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Type, cast
 
 import pydantic
 import yaml
+from yaml.dumper import SafeDumper
 
 from craft_application import errors
 from craft_application.util import safe_yaml_load
@@ -97,4 +98,6 @@ class CraftBaseModel(pydantic.BaseModel):
             yaml.add_representer(
                 str, _repr_str, Dumper=cast(Type[yaml.Dumper], yaml.SafeDumper)
             )
-            yaml.safe_dump(self.marshal(), file)
+            yaml.dump(
+                data=self.marshal(), stream=file, Dumper=SafeDumper, sort_keys=False
+            )

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -38,14 +38,17 @@ class Project(CraftBaseModel):
 
     name: ProjectName
     title: Optional[ProjectTitle]
-    base: Optional[Any]
     version: VersionStr
+    summary: Optional[SummaryStr]
+    description: Optional[str]
+
+    base: Optional[Any]
+
     contact: Optional[Union[str, UniqueStrList]]
     issues: Optional[Union[str, UniqueStrList]]
     source_code: Optional[AnyUrl]
-    summary: Optional[SummaryStr]
-    description: Optional[str]
     license: Optional[str]
+
     parts: Dict[str, Dict[str, Any]]  # parts are handled by craft-parts
 
     @pydantic.validator("parts", each_item=True)

--- a/tests/unit/models/project_models/basic_project.yaml
+++ b/tests/unit/models/project_models/basic_project.yaml
@@ -1,5 +1,5 @@
 name: project-name
+version: '1.0'
 parts:
   my-part:
     plugin: nil
-version: '1.0'

--- a/tests/unit/models/project_models/full_project.yaml
+++ b/tests/unit/models/project_models/full_project.yaml
@@ -1,15 +1,15 @@
-base: core24
-contact: author@project.org
+name: full-project
+title: A fully-defined project
+version: 1.0.0.post64+git12345678
+summary: A fully-defined craft-application project.
 description: |
   A fully-defined craft-application project.
   With more than one line.
+base: core24
+contact: author@project.org
 issues: https://github.com/canonical/craft-application/issues
+source-code: https://github.com/canonical/craft-application
 license: LGPLv3
-name: full-project
 parts:
   my-part:
     plugin: nil
-source-code: https://github.com/canonical/craft-application
-summary: A fully-defined craft-application project.
-title: A fully-defined project
-version: 1.0.0.post64+git12345678


### PR DESCRIPTION
This follows the expectations for Craft Applications of having name, version, summary and description. Followed by the base/platform data, then closing with the metadatalinks. And finally, parts.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
