### PR TITLE
feat(services): add service setup method

### DIFF
--- a/craft_application/services/base.py
+++ b/craft_application/services/base.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import abc
 import typing
 
+from craft_cli import emit
+
 if typing.TYPE_CHECKING:
     from craft_application import models
     from craft_application.application import AppMetadata
@@ -34,4 +36,5 @@ class BaseService(metaclass=abc.ABCMeta):  # noqa: B024
 
     def setup(self) -> None:
         """Application-specific service preparation."""
-        pass
+        emit.debug("setting up service")
+

--- a/craft_application/services/base.py
+++ b/craft_application/services/base.py
@@ -34,3 +34,4 @@ class BaseService(metaclass=abc.ABCMeta):  # noqa: B024
 
     def setup(self) -> None:
         """Application-specific service preparation."""
+        pass

--- a/craft_application/services/base.py
+++ b/craft_application/services/base.py
@@ -37,4 +37,3 @@ class BaseService(metaclass=abc.ABCMeta):  # noqa: B024
     def setup(self) -> None:
         """Application-specific service preparation."""
         emit.debug("setting up service")
-

--- a/craft_application/services/base.py
+++ b/craft_application/services/base.py
@@ -31,3 +31,6 @@ class BaseService(metaclass=abc.ABCMeta):  # noqa: B024
     def __init__(self, app: AppMetadata, project: models.Project) -> None:
         self._app = app
         self._project = project
+
+    def setup(self) -> None:
+        """Application-specific service preparation."""

--- a/craft_application/services/service_factory.py
+++ b/craft_application/services/service_factory.py
@@ -86,6 +86,7 @@ class ServiceFactory:
         if issubclass(cls, services.BaseService):
             kwargs = self._service_kwargs.get(service, {})
             instance = cls(self.app, self.project, **kwargs)
+            instance.setup()
             setattr(self, service, instance)
             # Mypy and pyright interpret this differently.
             # Pyright

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -19,6 +19,7 @@ from unittest import mock
 import pytest
 import pytest_check
 from craft_application import errors, services
+from craft_cli import emit
 
 
 @pytest.fixture()
@@ -116,3 +117,16 @@ def test_getattr_project_none(app_metadata, fake_package_service_class):
 
     with pytest.raises(errors.ApplicationError):
         _ = factory.package
+
+
+def test_service_setup(app_metadata, fake_project, fake_package_service_class, emitter):
+    class FakePackageService(fake_package_service_class):
+        def setup(self) -> None:
+            emit.debug("setting up package service")
+
+    factory = services.ServiceFactory(
+        app_metadata, project=fake_project, PackageClass=FakePackageService
+    )
+    _ = factory.package
+
+    assert emitter.assert_debug("setting up package service")


### PR DESCRIPTION
Service classes can override the `setup` method to run custom
preparation before service execution, such as downloading additional
assets or performing consistency checks.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
