### PR TITLE
feat(application): enable build plans

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -146,6 +146,7 @@ class Application:
     def project(self) -> models.Project:
         """Get this application's Project metadata."""
         project_file = (self._work_dir / f"{self.app.name}.yaml").resolve()
+        craft_cli.emit.debug(f"Loading project file '{project_file!s}'")
         return self.app.ProjectClass.from_yaml_file(project_file)
 
     def run_managed(self, build_for: str | None) -> None:
@@ -268,6 +269,8 @@ class Application:
             if not command.run_managed:
                 # command runs in the outer instance
                 craft_cli.emit.debug(f"Running {self.app.name} {command.name} on host")
+                if command.always_load_project:
+                    self.services.project = self.project
                 return_code = dispatcher.run() or 0
             elif not self.services.ProviderClass.is_managed():
                 # command runs in inner instance, but this is the outer instance

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -47,7 +47,7 @@ class _Dispatcher(craft_cli.Dispatcher):
     @property
     def parsed_args(self) -> argparse.Namespace:
         """The map of parsed command-line arguments."""
-        return self._parsed_command_args
+        return self._parsed_command_args or argparse.Namespace()
 
 
 @final
@@ -129,7 +129,7 @@ class Application:
         # xdg types: https://github.com/python/typeshed/pull/10163
         return save_cache_path(self.app.name)  # type: ignore[no-any-return]
 
-    def _configure_services(self, build_for: str) -> None:
+    def _configure_services(self, build_for: str | None) -> None:
         """Configure additional keyword arguments for any service classes.
 
         Any child classes that override this must either call this directly or must

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -33,6 +33,9 @@ class AppCommand(BaseCommand):
     run_managed: bool = False
     """Whether this command should run in managed mode."""
 
+    always_load_project: bool = False
+    """The project is also loaded in non-managed mode."""
+
     def __init__(self, config: dict[str, Any]) -> None:
         super().__init__(config)
         self._app: application.AppMetadata = config["app"]

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -127,11 +127,7 @@ class _LifecycleStepCommand(_LifecyclePartsCommand):
     ) -> None:
         """Run a lifecycle step command."""
         super().run(parsed_args)
-
         step_name = step_name or self.name
-
-        # resolve build matrix, depending on the environment (managed/manager)
-
         self._services.lifecycle.run(
             step_name=step_name,
             part_names=parsed_args.parts,
@@ -272,6 +268,7 @@ class CleanCommand(_LifecyclePartsCommand):
         remove the packing environment.
         """
     )
+    always_load_project = True
 
     @override
     def run(self, parsed_args: argparse.Namespace) -> None:

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -14,6 +14,7 @@
 """Basic lifecycle commands for a Craft Application."""
 from __future__ import annotations
 
+import os
 import pathlib
 import textwrap
 from typing import TYPE_CHECKING
@@ -95,6 +96,13 @@ class _LifecycleStepCommand(_LifecyclePartsCommand):
             action="store_true",
             help="Shell into the environment after the step has run.",
         )
+        group.add_argument(
+            "--build-for",
+            type=str,
+            metavar="arch",
+            default=os.getenv("CRAFT_BUILD_FOR"),
+            help="Set architecture to build for",
+        )
 
     @override
     def get_managed_cmd(self, parsed_args: argparse.Namespace) -> list[str]:
@@ -122,7 +130,12 @@ class _LifecycleStepCommand(_LifecyclePartsCommand):
 
         step_name = step_name or self.name
 
-        self._services.lifecycle.run(step_name=step_name, part_names=parsed_args.parts)
+        # resolve build matrix, depending on the environment (managed/manager)
+
+        self._services.lifecycle.run(
+            step_name=step_name,
+            part_names=parsed_args.parts,
+        )
 
 
 class PullCommand(_LifecycleStepCommand):

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -96,7 +96,8 @@ class _LifecycleStepCommand(_LifecyclePartsCommand):
             action="store_true",
             help="Shell into the environment after the step has run.",
         )
-        group.add_argument(
+
+        parser.add_argument(
             "--build-for",
             type=str,
             metavar="arch",

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -24,11 +24,12 @@ from craft_application.models.constraints import (
     VersionStr,
 )
 from craft_application.models.metadata import BaseMetadata
-from craft_application.models.project import Project
+from craft_application.models.project import BuildInfo, Project
 
 
 __all__ = [
     "BaseMetadata",
+    "BuildInfo",
     "CraftBaseConfig",
     "CraftBaseModel",
     "Project",

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -17,9 +17,14 @@
 
 This defines the structure of the input file (e.g. snapcraft.yaml)
 """
-from typing import Any, Dict, Optional, Union
+from __future__ import annotations
+
+import abc
+import dataclasses
+from typing import Any, Dict, List, Optional, Union
 
 import craft_parts
+import craft_providers.bases
 import pydantic
 from pydantic import AnyUrl
 
@@ -31,6 +36,15 @@ from craft_application.models.constraints import (
     UniqueStrList,
     VersionStr,
 )
+
+
+@dataclasses.dataclass
+class BuildInfo:
+    """Platform build information."""
+
+    build_on: str
+    build_for: str
+    base: craft_providers.bases.BaseName
 
 
 class Project(CraftBaseModel):
@@ -67,3 +81,7 @@ class Project(CraftBaseModel):
         if self.base is not None:
             return self.base
         raise RuntimeError("Could not determine effective base")
+
+    @abc.abstractmethod
+    def get_build_plan(self) -> List[BuildInfo]:
+        """Obtain the list of architectures and bases from the project file."""

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -17,7 +17,6 @@
 
 This defines the structure of the input file (e.g. snapcraft.yaml)
 """
-import abc
 import dataclasses
 from typing import Any, Dict, List, Optional, Union
 
@@ -80,6 +79,6 @@ class Project(CraftBaseModel):
             return self.base
         raise RuntimeError("Could not determine effective base")
 
-    @abc.abstractmethod
     def get_build_plan(self) -> List[BuildInfo]:
         """Obtain the list of architectures and bases from the project file."""
+        raise NotImplementedError

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -17,8 +17,6 @@
 
 This defines the structure of the input file (e.g. snapcraft.yaml)
 """
-from __future__ import annotations
-
 import abc
 import dataclasses
 from typing import Any, Dict, List, Optional, Union

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -81,4 +81,4 @@ class Project(CraftBaseModel):
 
     def get_build_plan(self) -> List[BuildInfo]:
         """Obtain the list of architectures and bases from the project file."""
-        raise NotImplementedError
+        raise NotImplementedError(f"{self.__class__.__name__!s} must implement get_build_plan")

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -81,4 +81,6 @@ class Project(CraftBaseModel):
 
     def get_build_plan(self) -> List[BuildInfo]:
         """Obtain the list of architectures and bases from the project file."""
-        raise NotImplementedError(f"{self.__class__.__name__!s} must implement get_build_plan")
+        raise NotImplementedError(
+            f"{self.__class__.__name__!s} must implement get_build_plan"
+        )

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -24,6 +24,7 @@ from craft_parts import Action, ActionType, Features, LifecycleManager, PartsErr
 
 from craft_application import errors
 from craft_application.services import base
+from craft_application.util import convert_architecture_deb_to_platform
 
 if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
@@ -106,18 +107,20 @@ class LifecycleService(base.BaseService):
         LifecycleManager on initialisation.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 (too many arguments)
         self,
         app: AppMetadata,
         project: Project,
         *,
         work_dir: Path | str,
         cache_dir: Path | str,
+        build_for: str,
         **lifecycle_kwargs: Any,  # noqa: ANN401 - eventually used in an Any
     ) -> None:
         super().__init__(app, project)
         self._work_dir = work_dir
         self._cache_dir = cache_dir
+        self._build_for = build_for
         self._manager_kwargs = lifecycle_kwargs
         self._lcm = self._init_lifecycle_manager()
 
@@ -133,6 +136,7 @@ class LifecycleService(base.BaseService):
             return LifecycleManager(
                 {"parts": self._project.parts},
                 application_name=self._app.name,
+                arch=convert_architecture_deb_to_platform(self._build_for),
                 cache_dir=self._cache_dir,
                 work_dir=self._work_dir,
                 ignore_local_sources=self._app.source_ignore_patterns,
@@ -183,7 +187,8 @@ class LifecycleService(base.BaseService):
     def __repr__(self) -> str:
         work_dir = self._work_dir
         cache_dir = self._cache_dir
+        build_for = self._build_for
         return (
             f"{self.__class__.__name__}({self._app!r}, {self._project!r}, "
-            f"{work_dir=}, {cache_dir=}, **{self._manager_kwargs!r})"
+            f"{work_dir=}, {cache_dir=}, {build_for=}, **{self._manager_kwargs!r})"
         )

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -103,6 +103,8 @@ class LifecycleService(base.BaseService):
     :param app: An AppMetadata object containing metadata about the application.
     :param project: The Project object that describes this project.
     :param work_dir: The working directory for parts processing.
+    :param cache_dir: The cache directory for parts processing.
+    :param build_for: The architecture or platform we are building for.
     :param lifecycle_kwargs: Additional keyword arguments are passed through to the
         LifecycleManager on initialisation.
     """

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -86,7 +86,7 @@ class ProviderService(base.BaseService):
         """
         work_dir_inode = work_dir.stat().st_ino
         instance_name = (
-	    f"{self._app.name}-{self._project.name}-on-{build_info.build_on}-"
+            f"{self._app.name}-{self._project.name}-on-{build_info.build_on}-"
             f"for-{build_info.build_for}-{work_dir_inode}"
         )
         emit.debug("Preparing managed instance {instance_name!r}")

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -71,7 +71,7 @@ class ProviderService(base.BaseService):
     @contextlib.contextmanager
     def instance(
         self,
-        base_name: bases.BaseName | tuple[str, str],
+        build_info: models.BuildInfo,
         *,
         work_dir: pathlib.Path,
         allow_unstable: bool = True,
@@ -87,6 +87,7 @@ class ProviderService(base.BaseService):
         emit.debug("Preparing managed instance")
         work_dir_inode = work_dir.stat().st_ino
         instance_name = f"{self._app.name}-{self._project.name}-{work_dir_inode}"
+        base_name = build_info.base
         base = self.get_base(base_name, instance_name=instance_name, **kwargs)
         provider = self.get_provider()
 

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -84,9 +84,12 @@ class ProviderService(base.BaseService):
         :param allow_unstable: Whether to allow the use of unstable images.
         :returns: a context manager of the provider instance.
         """
-        emit.debug("Preparing managed instance")
         work_dir_inode = work_dir.stat().st_ino
-        instance_name = f"{self._app.name}-{self._project.name}-{work_dir_inode}"
+        instance_name = (
+	    f"{self._app.name}-{self._project.name}-on-{build_info.build_on}-"
+            f"for-{build_info.build_for}-{work_dir_inode}"
+        )
+        emit.debug("Preparing managed instance {instance_name!r}")
         base_name = build_info.base
         base = self.get_base(base_name, instance_name=instance_name, **kwargs)
         provider = self.get_provider()

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -16,7 +16,13 @@
 """Utilities for craft-application."""
 
 from craft_application.util.yaml import safe_yaml_load
+from craft_application.util.platforms import (
+    get_host_architecture,
+    convert_architecture_deb_to_platform,
+)
 
 __all__ = [
     "safe_yaml_load",
+    "get_host_architecture",
+    "convert_architecture_deb_to_platform",
 ]

--- a/craft_application/util/platforms.py
+++ b/craft_application/util/platforms.py
@@ -62,4 +62,3 @@ _ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
     "s390x": "s390x",
     "riscv64": "riscv64",
 }
-

--- a/craft_application/util/platforms.py
+++ b/craft_application/util/platforms.py
@@ -1,0 +1,65 @@
+# This file is part of craft_application.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""OS and architecture helpers for craft applications."""
+from __future__ import annotations
+
+import functools
+import platform
+
+
+@functools.lru_cache(maxsize=1)
+def get_host_architecture() -> str:
+    """Get host architecture in deb format."""
+    machine = platform.machine()
+    return _ARCH_TRANSLATIONS_PLATFORM_TO_DEB.get(machine, machine)
+
+
+def convert_architecture_deb_to_platform(arch: str) -> str:
+    """Convert an architecture from deb/snap syntax to platform syntax.
+
+    :param architecture: architecture string in debian/snap syntax
+    :return: architecture in platform syntax
+    """
+    return _ARCH_TRANSLATIONS_DEB_TO_PLATFORM.get(arch, arch)
+
+
+# architecture translations from the platform syntax to the deb/snap syntax
+# These two architecture mappings are almost inverses of each other, except one map is
+# not reversible (same value for different keys)
+_ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
+    "aarch64": "arm64",
+    "armv7l": "armhf",
+    "i686": "i386",
+    "ppc": "powerpc",
+    "ppc64le": "ppc64el",
+    "x86_64": "amd64",
+    "AMD64": "amd64",  # Windows support
+    "s390x": "s390x",
+    "riscv64": "riscv64",
+}
+
+# architecture translations from the deb/snap syntax to the platform syntax
+_ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
+    "arm64": "aarch64",
+    "armhf": "armv7l",
+    "i386": "i686",
+    "powerpc": "ppc",
+    "ppc64el": "ppc64le",
+    "amd64": "x86_64",
+    "s390x": "s390x",
+    "riscv64": "riscv64",
+}
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
 
 
-class MyProject(craft_application.models.Project):
+class MyProject(models.Project):
     def get_build_plan(self) -> list[models.BuildInfo]:
-        arch = craft_application.util.get_host_architecture()
+        arch = util.get_host_architecture()
         return [models.BuildInfo(arch, arch, bases.BaseName("ubuntu", "22.04"))]
 
 
@@ -50,7 +50,7 @@ def app_metadata() -> craft_application.AppMetadata:
 
 
 @pytest.fixture()
-def fake_project() -> MyProject:
+def fake_project() -> models.Project:
     return MyProject(
         name="full-project",  # pyright: ignore[reportGeneralTypeIssues]
         title="A fully-defined project",  # pyright: ignore[reportGeneralTypeIssues]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class MyProject(craft_application.models.Project):
-    def get_build_plan(self) -> List[models.BuildInfo]:
+    def get_build_plan(self) -> list[models.BuildInfo]:
         arch = craft_application.util.get_host_architecture()
         return [models.BuildInfo(arch, arch, bases.BaseName("ubuntu", "22.04"))]
 

--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -18,6 +18,7 @@
 import pytest
 import pytest_check
 from craft_application.services.lifecycle import LifecycleService
+from craft_application.util import get_host_architecture
 
 
 @pytest.fixture(
@@ -37,6 +38,7 @@ def parts_lifecycle(app_metadata, fake_project, tmp_path, request):
         fake_project,
         work_dir=tmp_path / "work",
         cache_dir=tmp_path / "cache",
+        build_for=get_host_architecture(),
     )
 
 

--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -19,6 +19,8 @@ import sys
 
 import craft_providers
 import pytest
+from craft_application.models import BuildInfo
+from craft_application.util import get_host_architecture
 
 
 @pytest.mark.parametrize(
@@ -54,7 +56,9 @@ def test_provider_lifecycle(
         pytest.skip("multipass only provides ubuntu images")
     provider_service.get_provider(name)
 
-    instance = provider_service.instance(base_name, work_dir=snap_safe_tmp_path)
+    arch = get_host_architecture()
+    build_info = BuildInfo(arch, arch, craft_providers.bases.BaseName(*base_name))
+    instance = provider_service.instance(build_info, work_dir=snap_safe_tmp_path)
     executor = None
     try:
         with instance as executor:

--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -21,6 +21,7 @@ import craft_providers
 import pytest
 from craft_application.models import BuildInfo
 from craft_application.util import get_host_architecture
+from craft_providers import bases
 
 
 @pytest.mark.parametrize(
@@ -57,7 +58,7 @@ def test_provider_lifecycle(
     provider_service.get_provider(name)
 
     arch = get_host_architecture()
-    build_info = BuildInfo(arch, arch, craft_providers.bases.BaseName(*base_name))
+    build_info = BuildInfo(arch, arch, bases.BaseName(*base_name))
     instance = provider_service.instance(build_info, work_dir=snap_safe_tmp_path)
     executor = None
     try:

--- a/tests/integration/services/test_service_factory.py
+++ b/tests/integration/services/test_service_factory.py
@@ -47,6 +47,6 @@ def test_real_service_error(app_metadata, fake_project):
     with pytest.raises(
         TypeError,
         # Python 3.8 doesn't specify the LifecycleService, 3.10 does.
-        match=r"(LifecycleService.)?__init__\(\) missing 2 required keyword-only arguments: 'work_dir' and 'cache_dir'",
+        match=r"(LifecycleService.)?__init__\(\) missing 3 required keyword-only arguments: 'work_dir', 'cache_dir', and 'build_for'",
     ):
         _ = factory.lifecycle

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -139,10 +139,13 @@ def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):
     app.run()
 
 
-def test_run_always_load_project(monkeypatch, app):
-    """Run a command without having a project instance shall not fail."""
+@pytest.mark.parametrize(
+    "cmd", ["clean", "pull", "build", "stage", "prime", "pack"]
+)
+def test_run_always_load_project(monkeypatch, app, cmd):
+    """Run a lifecycle command without having a project shall fail."""
     monkeypatch.setenv("CRAFT_DEBUG", "1")
-    monkeypatch.setattr("sys.argv", ["testcraft", "clean"])
+    monkeypatch.setattr("sys.argv", ["testcraft", cmd])
 
     with pytest.raises(FileNotFoundError) as raised:
         app.run()

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -137,3 +137,14 @@ def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):
 
     app.add_command_group("Nothing", [NothingCommand])
     app.run()
+
+
+def test_run_always_load_project(monkeypatch, app):
+    """Run a command without having a project instance shall not fail."""
+    monkeypatch.setenv("CRAFT_DEBUG", "1")
+    monkeypatch.setattr("sys.argv", ["testcraft", "clean"])
+
+    with pytest.raises(FileNotFoundError) as raised:
+        app.run()
+
+    assert str(raised.value).endswith("/testcraft.yaml'") is True

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -139,9 +139,7 @@ def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):
     app.run()
 
 
-@pytest.mark.parametrize(
-    "cmd", ["clean", "pull", "build", "stage", "prime", "pack"]
-)
+@pytest.mark.parametrize("cmd", ["clean", "pull", "build", "stage", "prime", "pack"])
 def test_run_always_load_project(monkeypatch, app, cmd):
     """Run a lifecycle command without having a project shall fail."""
     monkeypatch.setenv("CRAFT_DEBUG", "1")

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -132,7 +132,7 @@ def test_step_command_fill_parser(
 ):
     cls = get_fake_command_class(_LifecycleStepCommand, managed=True)
     parser = argparse.ArgumentParser("step_command")
-    expected = {"parts": parts_args, **shell_dict}
+    expected = {"parts": parts_args, "build_for": None, **shell_dict}
     command = cls({"app": app_metadata, "services": fake_services})
 
     command.fill_parser(parser)
@@ -238,7 +238,12 @@ def test_pack_fill_parser(
     app_metadata, mock_services, parts_args, shell_args, shell_dict, output_arg
 ):
     parser = argparse.ArgumentParser("step_command")
-    expected = {"parts": parts_args, "output": pathlib.Path(output_arg), **shell_dict}
+    expected = {
+        "parts": parts_args,
+        "build_for": None,
+        "output": pathlib.Path(output_arg),
+        **shell_dict,
+    }
     command = PackCommand({"app": app_metadata, "services": mock_services})
 
     command.fill_parser(parser)

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -27,6 +27,7 @@ class MyProject(Project):
     def get_build_plan(self) -> List[BuildInfo]:
         return []
 
+
 PROJECTS_DIR = pathlib.Path(__file__).parent / "project_models"
 PARTS_DICT = {"my-part": {"plugin": "nil"}}
 # pyright doesn't like these types and doesn't have a pydantic plugin like mypy.

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -101,6 +101,12 @@ def test_unmarshal_then_marshal(project_dict):
     assert Project.unmarshal(project_dict).marshal() == project_dict
 
 
+@pytest.mark.parametrize("project", [BASIC_PROJECT, FULL_PROJECT])
+def test_build_plan_not_implemented(project):
+    with pytest.raises(NotImplementedError):
+        project.get_build_plan()
+
+
 @pytest.mark.parametrize(
     ("project_file", "expected"),
     [

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -16,23 +16,17 @@
 """Tests for BaseProject"""
 import pathlib
 from textwrap import dedent
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 from craft_application.errors import CraftValidationError
-from craft_application.models import BuildInfo, Project
-
-
-class MyProject(Project):
-    def get_build_plan(self) -> List[BuildInfo]:
-        return []
-
+from craft_application.models import Project
 
 PROJECTS_DIR = pathlib.Path(__file__).parent / "project_models"
 PARTS_DICT = {"my-part": {"plugin": "nil"}}
 # pyright doesn't like these types and doesn't have a pydantic plugin like mypy.
 # Because of this, we need to silence several errors in these constants.
-BASIC_PROJECT = MyProject(
+BASIC_PROJECT = Project(
     name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
     version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
     parts=PARTS_DICT,
@@ -42,7 +36,7 @@ BASIC_PROJECT_DICT = {
     "version": "1.0",
     "parts": PARTS_DICT,
 }
-FULL_PROJECT = MyProject(
+FULL_PROJECT = Project(
     name="full-project",  # pyright: ignore[reportGeneralTypeIssues]
     title="A fully-defined project",  # pyright: ignore[reportGeneralTypeIssues]
     base="core24",
@@ -88,23 +82,23 @@ def test_marshal(project, project_dict):
     [(BASIC_PROJECT, BASIC_PROJECT_DICT), (FULL_PROJECT, FULL_PROJECT_DICT)],
 )
 def test_unmarshal_success(project, project_dict):
-    assert MyProject.unmarshal(project_dict) == project
+    assert Project.unmarshal(project_dict) == project
 
 
 @pytest.mark.parametrize("data", [None, [], (), 0, ""])
 def test_unmarshal_error(data):
     with pytest.raises(TypeError):
-        MyProject.unmarshal(data)
+        Project.unmarshal(data)
 
 
 @pytest.mark.parametrize("project", [BASIC_PROJECT, FULL_PROJECT])
 def test_marshal_then_unmarshal(project):
-    assert MyProject.unmarshal(project.marshal()) == project
+    assert Project.unmarshal(project.marshal()) == project
 
 
 @pytest.mark.parametrize("project_dict", [BASIC_PROJECT_DICT, FULL_PROJECT_DICT])
 def test_unmarshal_then_marshal(project_dict):
-    assert MyProject.unmarshal(project_dict).marshal() == project_dict
+    assert Project.unmarshal(project_dict).marshal() == project_dict
 
 
 @pytest.mark.parametrize(
@@ -116,7 +110,7 @@ def test_unmarshal_then_marshal(project_dict):
 )
 def test_from_yaml_file_success(project_file, expected):
     with project_file.open():
-        actual = MyProject.from_yaml_file(project_file)
+        actual = Project.from_yaml_file(project_file)
 
     assert expected == actual
 
@@ -130,7 +124,7 @@ def test_from_yaml_file_success(project_file, expected):
 )
 def test_from_yaml_file_failure(project_file, error_class):
     with pytest.raises(error_class):
-        MyProject.from_yaml_file(project_file)
+        Project.from_yaml_file(project_file)
 
 
 @pytest.mark.parametrize(
@@ -153,7 +147,7 @@ def test_effective_base_is_base(project):
     assert project.effective_base == project.base
 
 
-class FakeBuildBaseProject(MyProject):
+class FakeBuildBaseProject(Project):
     build_base: Optional[str]
 
 

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -315,7 +315,6 @@ def test_repr(fake_parts_lifecycle, app_metadata, fake_project):
     start = f"FakePartsLifecycle({app_metadata!r}, {fake_project!r}, "
 
     actual = repr(fake_parts_lifecycle)
-    print("=====", actual)
 
     pytest_check.is_true(actual.startswith(start))
     pytest_check.is_true(

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -18,7 +18,7 @@ from unittest import mock
 
 import craft_providers
 import pytest
-from craft_application import errors
+from craft_application import errors, models, util
 from craft_application.services import provider
 from craft_providers import bases, lxd, multipass
 from craft_providers.actions.snap_installer import Snap
@@ -163,9 +163,11 @@ def test_instance(
     mock_provider = mock.MagicMock(spec=craft_providers.Provider)
     monkeypatch.setattr(provider_service, "get_provider", lambda: mock_provider)
     spy_pause = mocker.spy(provider.emit, "pause")
+    arch = util.get_host_architecture()
+    build_info = models.BuildInfo(arch, arch, base_name)
 
     with provider_service.instance(
-        base_name, work_dir=tmp_path, allow_unstable=allow_unstable
+        build_info, work_dir=tmp_path, allow_unstable=allow_unstable
     ) as instance:
         pass
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -28,6 +28,9 @@ import pytest
 import pytest_check
 from craft_application import application, commands, services
 from craft_application.models import BuildInfo
+from craft_application.util import (
+    get_host_architecture,  # pyright: ignore[reportGeneralTypeIssues]
+)
 from craft_providers import bases
 
 EMPTY_COMMAND_GROUP = craft_cli.CommandGroup("FakeCommands", [])
@@ -48,7 +51,7 @@ def app(app_metadata, fake_services):
 
 @pytest.fixture()
 def mock_dispatcher(monkeypatch):
-    dispatcher = mock.Mock(spec_set=craft_application.application._Dispatcher)
+    dispatcher = mock.Mock(spec_set=application._Dispatcher)
     monkeypatch.setattr(
         "craft_application.application._Dispatcher", mock.Mock(return_value=dispatcher)
     )
@@ -101,7 +104,7 @@ def test_run_managed_success(app, fake_project, emitter):
     app.services.provider = mock_provider
     app.project = fake_project
 
-    arch = craft_application.util.get_host_architecture()
+    arch = get_host_architecture()
     app.run_managed(arch)
 
     emitter.assert_debug(f"Running testcraft in {arch} instance...")
@@ -115,7 +118,7 @@ def test_run_managed_failure(app, fake_project):
     app.project = fake_project
 
     with pytest.raises(craft_providers.ProviderError) as exc_info:
-        app.run_managed(craft_application.util.get_host_architecture())
+        app.run_managed(get_host_architecture())
 
     assert exc_info.value.brief == "Failed to execute testcraft in instance."
 
@@ -125,7 +128,7 @@ def test_run_managed_multiple(app, fake_project, emitter, monkeypatch):
     app.services.provider = mock_provider
     app.project = fake_project
 
-    arch = craft_application.util.get_host_architecture()
+    arch = get_host_architecture()
     monkeypatch.setattr(
         app.project.__class__,
         "get_build_plan",
@@ -145,7 +148,7 @@ def test_run_managed_specified(app, fake_project, emitter, monkeypatch):
     app.services.provider = mock_provider
     app.project = fake_project
 
-    arch = craft_application.util.get_host_architecture()
+    arch = get_host_architecture()
     monkeypatch.setattr(
         app.project.__class__,
         "get_build_plan",
@@ -242,7 +245,7 @@ def test_run_success_managed(monkeypatch, app, fake_project):
 def test_run_success_managed_with_arch(monkeypatch, app, fake_project):
     app.project = fake_project
     app.run_managed = mock.Mock()
-    arch = craft_application.util.get_host_architecture()
+    arch = get_host_architecture()
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull", f"--build-for={arch}"])
 
     pytest_check.equal(app.run(), 0)

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -27,6 +27,8 @@ import craft_providers
 import pytest
 import pytest_check
 from craft_application import application, commands, services
+from craft_application.models import BuildInfo
+from craft_providers import bases
 
 EMPTY_COMMAND_GROUP = craft_cli.CommandGroup("FakeCommands", [])
 
@@ -46,8 +48,10 @@ def app(app_metadata, fake_services):
 
 @pytest.fixture()
 def mock_dispatcher(monkeypatch):
-    dispatcher = mock.Mock(spec_set=craft_cli.Dispatcher)
-    monkeypatch.setattr("craft_cli.Dispatcher", mock.Mock(return_value=dispatcher))
+    dispatcher = mock.Mock(spec_set=craft_application.application._Dispatcher)
+    monkeypatch.setattr(
+        "craft_application.application._Dispatcher", mock.Mock(return_value=dispatcher)
+    )
     return dispatcher
 
 
@@ -97,9 +101,10 @@ def test_run_managed_success(app, fake_project, emitter):
     app.services.provider = mock_provider
     app.project = fake_project
 
-    app.run_managed()
+    arch = craft_application.util.get_host_architecture()
+    app.run_managed(arch)
 
-    emitter.assert_debug("Running testcraft in a managed instance...")
+    emitter.assert_debug(f"Running testcraft in {arch} instance...")
 
 
 def test_run_managed_failure(app, fake_project):
@@ -110,9 +115,52 @@ def test_run_managed_failure(app, fake_project):
     app.project = fake_project
 
     with pytest.raises(craft_providers.ProviderError) as exc_info:
-        app.run_managed()
+        app.run_managed(craft_application.util.get_host_architecture())
 
     assert exc_info.value.brief == "Failed to execute testcraft in instance."
+
+
+def test_run_managed_multiple(app, fake_project, emitter, monkeypatch):
+    mock_provider = mock.MagicMock(spec_set=services.ProviderService)
+    app.services.provider = mock_provider
+    app.project = fake_project
+
+    arch = craft_application.util.get_host_architecture()
+    monkeypatch.setattr(
+        app.project.__class__,
+        "get_build_plan",
+        lambda _: [
+            BuildInfo(arch, "arch1", bases.BaseName("base", "1")),
+            BuildInfo(arch, "arch2", bases.BaseName("base", "2")),
+        ],
+    )
+    app.run_managed(None)
+
+    emitter.assert_debug("Running testcraft in arch1 instance...")
+    emitter.assert_debug("Running testcraft in arch2 instance...")
+
+
+def test_run_managed_specified(app, fake_project, emitter, monkeypatch):
+    mock_provider = mock.MagicMock(spec_set=services.ProviderService)
+    app.services.provider = mock_provider
+    app.project = fake_project
+
+    arch = craft_application.util.get_host_architecture()
+    monkeypatch.setattr(
+        app.project.__class__,
+        "get_build_plan",
+        lambda _: [
+            BuildInfo(arch, "arch1", bases.BaseName("base", "1")),
+            BuildInfo(arch, "arch2", bases.BaseName("base", "2")),
+        ],
+    )
+    app.run_managed("arch2")
+
+    emitter.assert_debug("Running testcraft in arch2 instance...")
+    assert (
+        mock.call("debug", "Running testcraft in arch1 instance...")
+        not in emitter.interactions
+    )
 
 
 @pytest.mark.parametrize(
@@ -188,7 +236,18 @@ def test_run_success_managed(monkeypatch, app, fake_project):
 
     pytest_check.equal(app.run(), 0)
 
-    app.run_managed.assert_called_once_with()
+    app.run_managed.assert_called_once_with(None)  # --build-for not used
+
+
+def test_run_success_managed_with_arch(monkeypatch, app, fake_project):
+    app.project = fake_project
+    app.run_managed = mock.Mock()
+    arch = craft_application.util.get_host_architecture()
+    monkeypatch.setattr(sys, "argv", ["testcraft", "pull", f"--build-for={arch}"])
+
+    pytest_check.equal(app.run(), 0)
+
+    app.run_managed.assert_called_once_with(arch)
 
 
 @pytest.mark.parametrize("return_code", [None, 0, 1])

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -309,3 +309,26 @@ def test_run_error_debug(monkeypatch, mock_dispatcher, app, fake_project, error)
 
     with pytest.raises(error.__class__):
         app.run()
+
+
+_base = bases.BaseName("", "")
+_on_a_for_a = BuildInfo("a", "a", _base)
+_on_a_for_b = BuildInfo("a", "b", _base)
+
+
+@pytest.mark.parametrize(
+    ("plan", "build_for", "host_arch", "result"),
+    [
+        ([_on_a_for_a], None, "a", [_on_a_for_a]),
+        ([_on_a_for_a], "a", "a", [_on_a_for_a]),
+        ([_on_a_for_a], "b", "a", []),
+        ([_on_a_for_a], "a", "b", []),
+        ([_on_a_for_a, _on_a_for_b], "b", "a", [_on_a_for_b]),
+        ([_on_a_for_a, _on_a_for_b], "b", "b", []),
+        ([_on_a_for_a, _on_a_for_b], None, "b", []),
+        ([_on_a_for_a, _on_a_for_b], None, "a", [_on_a_for_a, _on_a_for_b]),
+    ],
+)
+def test_filter_plan(mocker, plan, build_for, host_arch, result):
+    mocker.patch("craft_application.util.get_host_architecture", return_value=host_arch)
+    assert application._filter_plan(plan, build_for) == result


### PR DESCRIPTION
Enable multi-artefact builds by using the application-defined build plan
resolver to create multiple provider instances. Further refactoring may
be necessary if applications such as Rockcraft and Charmcraft require
additional features.

Fixes #60

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

-----

Note
* Passing the target architecture in service creation because instantiating the lifecycle manager in the `run` method proved to be problematic in certain situations, this can be refactored later if needed.
    


- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?


