### PR TITLE
refactor: pass the service factory to the services

### DIFF
--- a/craft_application/services/base.py
+++ b/craft_application/services/base.py
@@ -24,15 +24,19 @@ from craft_cli import emit
 if typing.TYPE_CHECKING:
     from craft_application import models
     from craft_application.application import AppMetadata
+    from craft_application.services import ServiceFactory
 
 
 # ignoring the fact that this abstract class has no abstract methods.
 class BaseService(metaclass=abc.ABCMeta):  # noqa: B024
     """A service containing the actual business logic of one or more commands."""
 
-    def __init__(self, app: AppMetadata, project: models.Project) -> None:
+    def __init__(
+        self, app: AppMetadata, project: models.Project, services: ServiceFactory
+    ) -> None:
         self._app = app
         self._project = project
+        self._services = services
 
     def setup(self) -> None:
         """Application-specific service preparation."""

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from craft_application.application import AppMetadata
     from craft_application.models import Project
+    from craft_application.services import ServiceFactory
 
 
 ACTION_MESSAGES = types.MappingProxyType(
@@ -106,16 +107,17 @@ class LifecycleService(base.BaseService):
         LifecycleManager on initialisation.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 (too many arguments)
         self,
         app: AppMetadata,
         project: Project,
+        services: ServiceFactory,
         *,
         work_dir: Path | str,
         cache_dir: Path | str,
         **lifecycle_kwargs: Any,  # noqa: ANN401 - eventually used in an Any
     ) -> None:
-        super().__init__(app, project)
+        super().__init__(app, project, services)
         self._work_dir = work_dir
         self._cache_dir = cache_dir
         self._manager_kwargs = lifecycle_kwargs

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from craft_application import models
     from craft_application.application import AppMetadata
+    from craft_application.services import ServiceFactory
 
 
 class ProviderService(base.BaseService):
@@ -53,10 +54,11 @@ class ProviderService(base.BaseService):
         self,
         app: AppMetadata,
         project: models.Project,
+        services: ServiceFactory,
         *,
         install_snap: bool = True,
     ) -> None:
-        super().__init__(app, project)
+        super().__init__(app, project, services)
         self._provider: craft_providers.Provider | None = None
         self.snaps: list[Snap] = []
         if install_snap:

--- a/craft_application/services/service_factory.py
+++ b/craft_application/services/service_factory.py
@@ -85,7 +85,7 @@ class ServiceFactory:
         cls = getattr(self, service_cls_name)
         if issubclass(cls, services.BaseService):
             kwargs = self._service_kwargs.get(service, {})
-            instance = cls(self.app, self.project, **kwargs)
+            instance = cls(self.app, self.project, self, **kwargs)
             instance.setup()
             setattr(self, service, instance)
             # Mypy and pyright interpret this differently.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def enable_overlay() -> Iterator[craft_parts.Features]:
 
 @pytest.fixture()
 def lifecycle_service(
-    app_metadata, fake_project, tmp_path
+    app_metadata, fake_project, fake_services, tmp_path
 ) -> services.LifecycleService:
     work_dir = tmp_path / "work"
     cache_dir = tmp_path / "cache"
@@ -76,6 +76,7 @@ def lifecycle_service(
     return services.LifecycleService(
         app_metadata,
         fake_project,
+        fake_services,
         work_dir=work_dir,
         cache_dir=cache_dir,
     )
@@ -114,11 +115,13 @@ def fake_lifecycle_service_class(tmp_path):
             self,
             app: application.AppMetadata,
             project: models.Project,
+            services: services.ServiceFactory,
             **lifecycle_kwargs: Any,
         ):
             super().__init__(
                 app,
                 project,
+                services,
                 work_dir=tmp_path / "work",
                 cache_dir=tmp_path / "cache",
                 **lifecycle_kwargs,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,9 +41,11 @@ def pytest_runtest_setup(item: pytest.Item):
 
 
 @pytest.fixture()
-def provider_service(app_metadata, fake_project):
+def provider_service(app_metadata, fake_project, fake_services):
     """Provider service with install snap disabled for integration tests"""
-    return provider.ProviderService(app_metadata, fake_project, install_snap=False)
+    return provider.ProviderService(
+        app_metadata, fake_project, fake_services, install_snap=False
+    )
 
 
 @pytest.fixture()

--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -29,12 +29,13 @@ from craft_application.services.lifecycle import LifecycleService
         ),
     ]
 )
-def parts_lifecycle(app_metadata, fake_project, tmp_path, request):
+def parts_lifecycle(app_metadata, fake_project, fake_services, tmp_path, request):
     fake_project.parts = request.param
 
     return LifecycleService(
         app_metadata,
         fake_project,
+        fake_services,
         work_dir=tmp_path / "work",
         cache_dir=tmp_path / "cache",
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,8 +23,8 @@ from craft_application import services
 
 
 @pytest.fixture()
-def provider_service(app_metadata, fake_project):
-    return services.ProviderService(app_metadata, fake_project)
+def provider_service(app_metadata, fake_project, fake_services):
+    return services.ProviderService(app_metadata, fake_project, fake_services)
 
 
 @pytest.fixture()

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -41,11 +41,15 @@ class FakePartsLifecycle(lifecycle.LifecycleService):
 
 
 @pytest.fixture()
-def fake_parts_lifecycle(app_metadata, fake_project, tmp_path):
+def fake_parts_lifecycle(app_metadata, fake_project, fake_services, tmp_path):
     work_dir = tmp_path / "work"
     cache_dir = tmp_path / "cache"
     return FakePartsLifecycle(
-        app_metadata, fake_project, work_dir=work_dir, cache_dir=cache_dir
+        app_metadata,
+        fake_project,
+        fake_services,
+        work_dir=work_dir,
+        cache_dir=cache_dir,
     )
 
 
@@ -201,9 +205,9 @@ def test_get_step_failure(step_name):
 
 # endregion
 # region PartsLifecycle tests
-def test_init_success(app_metadata, fake_project, tmp_path):
+def test_init_success(app_metadata, fake_project, fake_services, tmp_path):
     lifecycle.LifecycleService(
-        app_metadata, fake_project, work_dir=tmp_path, cache_dir=tmp_path
+        app_metadata, fake_project, fake_services, work_dir=tmp_path, cache_dir=tmp_path
     )
 
 
@@ -221,14 +225,18 @@ def test_init_success(app_metadata, fake_project, tmp_path):
     ],
 )
 def test_init_parts_error(
-    monkeypatch, app_metadata, fake_project, tmp_path, error, expected
+    monkeypatch, app_metadata, fake_project, fake_services, tmp_path, error, expected
 ):
     mock_lifecycle = mock.Mock(side_effect=error)
     monkeypatch.setattr(lifecycle, "LifecycleManager", mock_lifecycle)
 
     with pytest.raises(type(expected)) as exc_info:
         lifecycle.LifecycleService(
-            app_metadata, fake_project, work_dir=tmp_path, cache_dir=tmp_path
+            app_metadata,
+            fake_project,
+            fake_services,
+            work_dir=tmp_path,
+            cache_dir=tmp_path,
         )
 
     assert exc_info.value.args == expected.args

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class FakePackageService(package.PackageService):
-    def pack(self, dest: pathlib.Path) -> list[pathlib.Path]:
+    def pack(self, prime_dir: pathlib.Path, dest: pathlib.Path) -> list[pathlib.Path]:
         """Create a fake package."""
         raise NotImplementedError
 
@@ -35,8 +35,8 @@ class FakePackageService(package.PackageService):
         return models.BaseMetadata()
 
 
-def test_write_metadata(tmp_path, app_metadata, fake_project):
-    service = FakePackageService(app_metadata, fake_project)
+def test_write_metadata(tmp_path, app_metadata, fake_project, fake_services):
+    service = FakePackageService(app_metadata, fake_project, fake_services)
     metadata_file = tmp_path / "metadata.yaml"
     assert not metadata_file.exists()
 

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -28,9 +28,9 @@ from craft_providers.actions.snap_installer import Snap
     ("install_snap", "snaps"),
     [(True, [Snap(name="testcraft", channel=None, classic=True)]), (False, [])],
 )
-def test_install_snap(app_metadata, fake_project, install_snap, snaps):
+def test_install_snap(app_metadata, fake_project, fake_services, install_snap, snaps):
     service = provider.ProviderService(
-        app_metadata, fake_project, install_snap=install_snap
+        app_metadata, fake_project, fake_services, install_snap=install_snap
     )
 
     assert service.snaps == snaps

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -74,7 +74,7 @@ def test_set_kwargs(
     check.equal(factory.package, MockPackageService.mock_class.return_value)
     with check:
         MockPackageService.mock_class.assert_called_once_with(
-            app_metadata, fake_project, **kwargs
+            app_metadata, fake_project, factory, **kwargs
         )
 
 


### PR DESCRIPTION
In order to allow services knowing each other, pass the ServiceFactory instance to the individual Services on initialization.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
