### PR TITLE
refactor: delay creation of LifecycleManager

### DIFF
--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from craft_cli import emit
 from craft_parts import Action, ActionType, Features, LifecycleManager, PartsError, Step
+from typing_extensions import override
 
 from craft_application import errors
 from craft_application.services import base
@@ -126,6 +127,11 @@ class LifecycleService(base.BaseService):
         self._cache_dir = cache_dir
         self._build_for = build_for
         self._manager_kwargs = lifecycle_kwargs
+        self._lcm: LifecycleManager = None  # type: ignore[assignment]
+
+    @override
+    def setup(self) -> None:
+        """Initialize the LifecycleManager with previously-set arguments."""
         self._lcm = self._init_lifecycle_manager()
 
     def _init_lifecycle_manager(self) -> LifecycleManager:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def lifecycle_service(
     cache_dir = tmp_path / "cache"
     build_for = util.get_host_architecture()
 
-    return services.LifecycleService(
+    service = services.LifecycleService(
         app_metadata,
         fake_project,
         fake_services,
@@ -90,6 +90,8 @@ def lifecycle_service(
         cache_dir=cache_dir,
         build_for=build_for,
     )
+    service.setup()
+    return service
 
 
 @pytest.fixture(params=list(EmitterMode))

--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -33,7 +33,7 @@ from craft_application.util import get_host_architecture
 def parts_lifecycle(app_metadata, fake_project, fake_services, tmp_path, request):
     fake_project.parts = request.param
 
-    return LifecycleService(
+    service = LifecycleService(
         app_metadata,
         fake_project,
         fake_services,
@@ -41,6 +41,8 @@ def parts_lifecycle(app_metadata, fake_project, fake_services, tmp_path, request
         cache_dir=tmp_path / "cache",
         build_for=get_host_architecture(),
     )
+    service.setup()
+    return service
 
 
 def test_run_and_clean_all_parts(parts_lifecycle, emitter, check, tmp_path):


### PR DESCRIPTION
The previous version of the LifecycleService was initializing the craft-parts lifecycle manager during its __init__(). This is possibly an expensive operation that is better suited for the setup() method.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
