### PR TITLE
fix(cli): enable per-command help queries

### DIFF
--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -36,8 +36,15 @@ class AppCommand(BaseCommand):
     always_load_project: bool = False
     """The project is also loaded in non-managed mode."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any] | None) -> None:
+        if config is None:
+            # This should only be the case when the command is not going to be run.
+            # For example, when requesting help on the command.
+            emit.trace("Not completing command configuration")
+            return
+
         super().__init__(config)
+
         self._app: application.AppMetadata = config["app"]
         self._services: service_factory.ServiceFactory = config["services"]
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -149,3 +149,23 @@ def test_run_always_load_project(monkeypatch, app, cmd):
         app.run()
 
     assert str(raised.value).endswith("/testcraft.yaml'") is True
+
+
+@pytest.mark.parametrize("help_param", ["-h", "--help"])
+@pytest.mark.parametrize(
+    "cmd", ["clean", "pull", "build", "stage", "prime", "pack", "version"]
+)
+def test_get_command_help(monkeypatch, emitter, capsys, app, cmd, help_param):
+    monkeypatch.setattr("sys.argv", ["testcraft", cmd, help_param])
+
+    with pytest.raises(SystemExit) as exit_info:
+        app.run()
+
+    assert exit_info.value.code == 0
+
+    # Ensure the command got help set to true.
+    emitter.assert_trace(".+'help': True.+", regex=True)
+
+    stdout, stderr = capsys.readouterr()
+
+    assert f"testcraft {cmd} [options]" in stderr

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -55,3 +55,16 @@ def test_get_managed_cmd(fake_command, verbosity, app_metadata):
         f"--verbosity={verbosity.name.lower()}",
         "fake",
     ]
+
+
+def test_without_config(emitter):
+    """Test that a command can be initialised without a config.
+
+    This is necessary for providing per-command help.
+    """
+
+    command = base.AppCommand(None)
+
+    emitter.assert_trace("Not completing command configuration")
+    assert not hasattr(command, "_app")
+    assert not hasattr(command, "_services")


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Fixes #76 

This is further tested in Charmcraft's craft-application pack testing.