### PR TITLE
feat: fetch logs from inside the build instance

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -106,15 +106,8 @@ class Application:
     def log_path(self) -> pathlib.Path | None:
         """Get the path to this process's log file, if any."""
         if self.services.ProviderClass.is_managed():
-            return self._managed_log_path
+            return util.get_managed_logpath(self.app)
         return None
-
-    @property
-    def _managed_log_path(self) -> pathlib.Path:
-        """Get the location of the managed instance's log file."""
-        return pathlib.Path(
-            f"/tmp/{self.app.name}.log"  # noqa: S108 - only applies inside managed instance.
-        )
 
     def add_global_argument(self, argument: craft_cli.GlobalArgument) -> None:
         """Add a global argument to the Application."""

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -28,6 +28,7 @@ from craft_providers.actions.snap_installer import Snap
 from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
+from craft_application import util
 from craft_application.services import base
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -193,7 +194,7 @@ class ProviderService(base.BaseService):
 
     def _capture_logs_from_instance(self, instance: craft_providers.Executor) -> None:
         """Fetch the logfile from inside `instance` and emit its contents."""
-        source_log_path = pathlib.PosixPath(f"/root/{self._app.name}.log")
+        source_log_path = util.get_managed_logpath(self._app)
         with instance.temporarily_pull_file(
             source=source_log_path, missing_ok=True
         ) as log_path:

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import pathlib
 import sys
 from typing import TYPE_CHECKING
 
@@ -30,7 +31,6 @@ from craft_providers.multipass import MultipassProvider
 from craft_application.services import base
 
 if TYPE_CHECKING:  # pragma: no cover
-    import pathlib
     from collections.abc import Generator
 
     import craft_providers
@@ -112,8 +112,11 @@ class ProviderService(base.BaseService):
                 target=self._app.managed_instance_project_path,  # type: ignore[arg-type]
             )
             emit.debug("Instance launched and working directory mounted")
-            with emit.pause():
-                yield instance
+            try:
+                with emit.pause():
+                    yield instance
+            finally:
+                self._capture_logs_from_instance(instance)
 
     def get_base(
         self,
@@ -187,3 +190,19 @@ class ProviderService(base.BaseService):
     def _get_multipass_provider(self) -> MultipassProvider:
         """Get the Multipass provider for this manager."""
         return MultipassProvider()
+
+    def _capture_logs_from_instance(self, instance: craft_providers.Executor) -> None:
+        """Fetch the logfile from inside `instance` and emit its contents."""
+        source_log_path = pathlib.PosixPath(f"/root/{self._app.name}.log")
+        with instance.temporarily_pull_file(
+            source=source_log_path, missing_ok=True
+        ) as log_path:
+            if log_path:
+                emit.debug("Logs retrieved from managed instance:")
+                with log_path.open() as log_file:
+                    for line in log_file:
+                        emit.debug(":: " + line.rstrip())
+            else:
+                emit.debug(
+                    f"Could not find log file {source_log_path.as_posix()} in instance."
+                )

--- a/craft_application/util/paths.py
+++ b/craft_application/util/paths.py
@@ -13,18 +13,22 @@
 #
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Utilities for craft-application."""
+"""Utility functions and helpers related to path handling."""
+from __future__ import annotations
 
-from craft_application.util.yaml import safe_yaml_load
-from craft_application.util.paths import get_managed_logpath
-from craft_application.util.platforms import (
-    get_host_architecture,
-    convert_architecture_deb_to_platform,
-)
+import pathlib
+from typing import TYPE_CHECKING
 
-__all__ = [
-    "safe_yaml_load",
-    "get_host_architecture",
-    "convert_architecture_deb_to_platform",
-    "get_managed_logpath",
-]
+if TYPE_CHECKING:
+    from craft_application import AppMetadata
+
+
+def get_managed_logpath(app: AppMetadata) -> pathlib.PosixPath:
+    """Get the path to the logfile inside a build instance.
+
+    Note that this always returns a PosixPath, as it refers to a path inside of
+    a Linux-based build instance.
+    """
+    return pathlib.PosixPath(
+        f"/tmp/{app.name}.log"  # noqa: S108 - only applies inside managed instance.
+    )

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -253,7 +253,7 @@ def test_instance_fetch_logs(
     # Now check that the logs from the build instance were collected.
     with check:
         mock_instance.temporarily_pull_file.assert_called_once_with(
-            source=pathlib.PosixPath("/root/testcraft.log"), missing_ok=True
+            source=pathlib.PosixPath("/tmp/testcraft.log"), missing_ok=True
         )
 
     expected = [
@@ -284,7 +284,7 @@ def test_instance_fetch_logs_error(
     # Now check that the logs from the build instance were collected.
     with check:
         mock_instance.temporarily_pull_file.assert_called_once_with(
-            source=pathlib.PosixPath("/root/testcraft.log"), missing_ok=True
+            source=pathlib.PosixPath("/tmp/testcraft.log"), missing_ok=True
         )
 
     expected = [
@@ -315,10 +315,10 @@ def test_instance_fetch_logs_missing_file(
     # Now check that the logs from the build instance were *attempted* to be collected.
     with check:
         mock_instance.temporarily_pull_file.assert_called_once_with(
-            source=pathlib.PosixPath("/root/testcraft.log"), missing_ok=True
+            source=pathlib.PosixPath("/tmp/testcraft.log"), missing_ok=True
         )
     expected = [
-        mock.call("debug", "Could not find log file /root/testcraft.log in instance."),
+        mock.call("debug", "Could not find log file /tmp/testcraft.log in instance."),
     ]
 
     with check:

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -236,16 +236,25 @@ def setup_fetch_logs_provider(monkeypatch, provider_service, tmp_path):
     return _setup
 
 
+def _get_build_info() -> models.BuildInfo:
+    arch = util.get_host_architecture()
+    return models.BuildInfo(
+        platform=arch,
+        build_on=arch,
+        build_for=arch,
+        base=bases.BaseName("ubuntu", "22.04"),
+    )
+
+
 def test_instance_fetch_logs(
     provider_service, setup_fetch_logs_provider, check, emitter
 ):
     """Test that logs from the build instance are fetched in case of success."""
 
     # Setup the build instance and pretend the command inside it finished successfully.
-    arch = util.get_host_architecture()
     provider_service = setup_fetch_logs_provider(should_have_logfile=True)
     with provider_service.instance(
-        build_info=models.BuildInfo(arch, arch, bases.BaseName("ubuntu", "22.04")),
+        build_info=_get_build_info(),
         work_dir=pathlib.Path(),
     ) as mock_instance:
         pass
@@ -273,10 +282,9 @@ def test_instance_fetch_logs_error(
     """Test that logs from the build instance are fetched in case of errors."""
 
     # Setup the build instance and pretend the command inside it finished with error.
-    arch = util.get_host_architecture()
     provider_service = setup_fetch_logs_provider(should_have_logfile=True)
     with pytest.raises(RuntimeError), provider_service.instance(
-        build_info=models.BuildInfo(arch, arch, bases.BaseName("ubuntu", "22.04")),
+        build_info=_get_build_info(),
         work_dir=pathlib.Path(),
     ) as mock_instance:
         raise RuntimeError("Faking an error in the build instance!")
@@ -304,10 +312,9 @@ def test_instance_fetch_logs_missing_file(
     """Test that we handle the case where the logfile is missing."""
 
     # Setup the build instance and pretend the command inside it finished successfully.
-    arch = util.get_host_architecture()
     provider_service = setup_fetch_logs_provider(should_have_logfile=False)
     with provider_service.instance(
-        build_info=models.BuildInfo(arch, arch, bases.BaseName("ubuntu", "22.04")),
+        build_info=_get_build_info(),
         work_dir=pathlib.Path(),
     ) as mock_instance:
         pass

--- a/tests/unit/util/test_paths.py
+++ b/tests/unit/util/test_paths.py
@@ -1,0 +1,26 @@
+# This file is part of craft-application.
+#
+# Copyright 2023 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for internal path utilities."""
+import pathlib
+
+from craft_application import util
+
+
+def test_get_managed_logpath(app_metadata):
+    logpath = util.get_managed_logpath(app_metadata)
+
+    assert isinstance(logpath, pathlib.PosixPath)
+    assert str(logpath) == "/tmp/testcraft.log"


### PR DESCRIPTION
One could argue that this a bugfix since this was missing behavior from the existing craft tools. Regardless, this commit updates the instance() method in the default ProviderService to fetch the logfile from inside the build instance once its done. The contents of this file are then emitted so that they can end up in the logs of the "outer" instance.

Fixes #59

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
