### PR TITLE
fix: clean build provider when no parts are given

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -143,6 +143,10 @@ class Application:
             work_dir=self._work_dir,
             build_for=build_for,
         )
+        self.services.set_kwargs(
+            "provider",
+            work_dir=self._work_dir,
+        )
 
     @functools.cached_property
     def project(self) -> models.Project:

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -274,7 +274,7 @@ class Application:
             build_for = getattr(dispatcher.parsed_args, "build_for", None)
             self._configure_services(platform, build_for)
 
-            if not command.run_managed:
+            if not command.run_managed(dispatcher.parsed_args):
                 # command runs in the outer instance
                 craft_cli.emit.debug(f"Running {self.app.name} {command.name} on host")
                 if command.always_load_project:

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -30,9 +30,6 @@ if TYPE_CHECKING:  # pragma: no cover
 class AppCommand(BaseCommand):
     """Command for use with craft-application."""
 
-    run_managed: bool = False
-    """Whether this command should run in managed mode."""
-
     always_load_project: bool = False
     """The project is also loaded in non-managed mode."""
 
@@ -48,9 +45,20 @@ class AppCommand(BaseCommand):
         self._app: application.AppMetadata = config["app"]
         self._services: service_factory.ServiceFactory = config["services"]
 
+    def run_managed(
+        self,
+        parsed_args: argparse.Namespace,  # noqa: ARG002 (the unused argument is for subclasses)
+    ) -> bool:
+        """Whether this command should run in managed mode.
+
+        By default returns `False`. Subclasses can override this method to change this,
+        including by inspecting the arguments in `parsed_args`.
+        """
+        return False
+
     def get_managed_cmd(
         self,
-        parsed_args: argparse.Namespace,  # noqa: ARG002 - Used by subclasses
+        parsed_args: argparse.Namespace,  # - Used by subclasses
     ) -> list[str]:
         """Get the command to run in managed mode.
 
@@ -61,7 +69,7 @@ class AppCommand(BaseCommand):
         Commands that have additional parameters to pass in managed mode should
         override this method to include those parameters.
         """
-        if not self.run_managed:
+        if not self.run_managed(parsed_args):
             raise RuntimeError("Unmanaged commands should not be run in managed mode.")
         cmd_name = self._app.name
         verbosity = emit.get_mode().name.lower()

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -323,7 +323,21 @@ class CleanCommand(_LifecyclePartsCommand):
         """Run the clean command."""
         super().run(parsed_args)
 
-        self._services.lifecycle.clean(parsed_args.parts)
+        if self._should_clean_instances(parsed_args):
+            self._services.provider.clean_instances()
+        else:
+            self._services.lifecycle.clean(parsed_args.parts)
+
+    @override
+    def run_managed(self, parsed_args: argparse.Namespace) -> bool:
+        # "clean" should run managed if cleaning specific parts.
+        # otherwise, should run on the host to clean the build provider.
+        return not self._should_clean_instances(parsed_args)
+
+    @staticmethod
+    def _should_clean_instances(parsed_args: argparse.Namespace) -> bool:
+        # Note: in the future this will also take into account destructive mode.
+        return not bool(parsed_args.parts)
 
 
 def _launch_shell() -> None:

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -80,7 +80,9 @@ class _LifecyclePartsCommand(_LifecycleCommand):
 
 
 class _LifecycleStepCommand(_LifecyclePartsCommand):
-    run_managed = True
+    @override
+    def run_managed(self, parsed_args: argparse.Namespace) -> bool:
+        return True
 
     @override
     def fill_parser(self, parser: argparse.ArgumentParser) -> None:

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -30,6 +30,7 @@ from craft_providers.multipass import MultipassProvider
 
 from craft_application import util
 from craft_application.services import base
+from craft_application.util import platforms
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Generator
@@ -51,16 +52,18 @@ class ProviderService(base.BaseService):
 
     managed_mode_env_var = "CRAFT_MANAGED_MODE"
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 (too many arguments)
         self,
         app: AppMetadata,
         project: models.Project,
         services: ServiceFactory,
         *,
+        work_dir: pathlib.Path,
         install_snap: bool = True,
     ) -> None:
         super().__init__(app, project, services)
         self._provider: craft_providers.Provider | None = None
+        self._work_dir = work_dir
         self.snaps: list[Snap] = []
         if install_snap:
             self.snaps.append(Snap(name=app.name, channel=None, classic=True))
@@ -88,11 +91,7 @@ class ProviderService(base.BaseService):
         :param allow_unstable: Whether to allow the use of unstable images.
         :returns: a context manager of the provider instance.
         """
-        work_dir_inode = work_dir.stat().st_ino
-        instance_name = (
-            f"{self._app.name}-{self._project.name}-on-{build_info.build_on}-"
-            f"for-{build_info.build_for}-{work_dir_inode}"
-        )
+        instance_name = self._get_instance_name(work_dir, build_info)
         emit.debug(f"Preparing managed instance {instance_name!r}")
         base_name = build_info.base
         base = self.get_base(base_name, instance_name=instance_name, **kwargs)
@@ -163,6 +162,32 @@ class ProviderService(base.BaseService):
         emit.debug(f"Using provider {name!r}")
         self._provider = self._get_provider_by_name(name)
         return self._provider
+
+    def clean_instances(self) -> None:
+        """Clean all existing managed instances related to the project."""
+        provider = self.get_provider()
+
+        current_arch = platforms.get_host_architecture()
+        build_plan = self._project.get_build_plan()
+        build_plan = [info for info in build_plan if info.build_on == current_arch]
+
+        if build_plan:
+            target = "providers" if len(build_plan) > 1 else "provider"
+            emit.progress(f"Cleaning build {target}")
+
+        for info in build_plan:
+            instance_name = self._get_instance_name(self._work_dir, info)
+            emit.debug(f"Cleaning instance {instance_name}")
+            provider.clean_project_environments(instance_name=instance_name)
+
+    def _get_instance_name(
+        self, work_dir: pathlib.Path, build_info: models.BuildInfo
+    ) -> str:
+        work_dir_inode = work_dir.stat().st_ino
+        return (
+            f"{self._app.name}-{self._project.name}-on-{build_info.build_on}-"
+            f"for-{build_info.build_for}-{work_dir_inode}"
+        )
 
     def _get_default_provider(self) -> craft_providers.Provider:
         """Get the default provider class to use for this application.

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -172,7 +172,7 @@ class ProviderService(base.BaseService):
         build_plan = [info for info in build_plan if info.build_on == current_arch]
 
         if build_plan:
-            target = "providers" if len(build_plan) > 1 else "provider"
+            target = "environments" if len(build_plan) > 1 else "environment"
             emit.progress(f"Cleaning build {target}")
 
         for info in build_plan:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,20 @@ def emitter_verbosity(request):
 
 
 @pytest.fixture()
+def fake_provider_service_class():
+    class FakeProviderService(services.ProviderService):
+        def __init__(
+            self,
+            app: application.AppMetadata,
+            project: models.Project,
+            services: services.ServiceFactory,
+        ):
+            super().__init__(app, project, services, work_dir=pathlib.Path())
+
+    return FakeProviderService
+
+
+@pytest.fixture()
 def fake_package_service_class():
     class FakePackageService(services.PackageService):
         def pack(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,7 +44,11 @@ def pytest_runtest_setup(item: pytest.Item):
 def provider_service(app_metadata, fake_project, fake_services):
     """Provider service with install snap disabled for integration tests"""
     return provider.ProviderService(
-        app_metadata, fake_project, fake_services, install_snap=False
+        app_metadata,
+        fake_project,
+        fake_services,
+        work_dir=pathlib.Path(),
+        install_snap=False,
     )
 
 

--- a/tests/integration/services/test_service_factory.py
+++ b/tests/integration/services/test_service_factory.py
@@ -24,12 +24,14 @@ def test_gets_real_services(
     fake_project,
     fake_package_service_class,
     fake_lifecycle_service_class,
+    fake_provider_service_class,
 ):
     factory = services.ServiceFactory(
         app_metadata,
         project=fake_project,
         PackageClass=fake_package_service_class,
         LifecycleClass=fake_lifecycle_service_class,
+        ProviderClass=fake_provider_service_class,
     )
 
     check.is_instance(factory.package, services.PackageService)

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -19,15 +19,20 @@ import argparse
 import pytest
 from craft_application.commands import base
 from craft_cli import EmitterMode, emit
+from typing_extensions import override
 
 
 @pytest.fixture()
 def fake_command(app_metadata, fake_services):
     class FakeCommand(base.AppCommand):
-        run_managed = True
+        _run_managed = True
         name = "fake"
         help_msg = "Help!"
         overview = "It's an overview."
+
+        @override
+        def run_managed(self, parsed_args: argparse.Namespace) -> bool:
+            return self._run_managed
 
     return FakeCommand(
         {
@@ -38,7 +43,7 @@ def fake_command(app_metadata, fake_services):
 
 
 def test_get_managed_cmd_unmanaged(fake_command):
-    fake_command.run_managed = False
+    fake_command._run_managed = False
 
     with pytest.raises(RuntimeError):
         fake_command.get_managed_cmd(argparse.Namespace())

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -61,10 +61,13 @@ def get_fake_command_class(parent_cls, managed):
     """Create a fully described fake command based on a partial class."""
 
     class FakeCommand(parent_cls):
-        run_managed = managed
+        _run_managed = managed
         name = "fake"
         help_msg = "help"
         overview = "overview"
+
+        def run_managed(self, parsed_args: argparse.Namespace) -> bool:  # noqa: ARG002
+            return self._run_managed
 
     return FakeCommand
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -265,14 +265,43 @@ def test_managed_concrete_commands_run(app_metadata, mock_services, command_cls,
     )
 
 
-@pytest.mark.parametrize("parts", PARTS_LISTS)
-def test_clean_run(app_metadata, parts, tmp_path, mock_services):
+@pytest.mark.parametrize("parts", [("my-part",), ("my-part", "your-part")])
+def test_clean_run_with_parts(app_metadata, parts, tmp_path, mock_services):
     parsed_args = argparse.Namespace(parts=parts, output=tmp_path)
     command = CleanCommand({"app": app_metadata, "services": mock_services})
 
     command.run(parsed_args)
 
     mock_services.lifecycle.clean.assert_called_once_with(parts)
+    assert not mock_services.provider.clean_instances.called
+
+
+def test_clean_run_without_parts(app_metadata, tmp_path, mock_services):
+    parts = []
+    parsed_args = argparse.Namespace(parts=parts, output=tmp_path)
+    command = CleanCommand({"app": app_metadata, "services": mock_services})
+
+    command.run(parsed_args)
+
+    assert not mock_services.lifecycle.clean.called
+    mock_services.provider.clean_instances.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("parts", "expected_run_managed"),
+    [
+        # Clean specific parts: should run managed
+        (["part1"], True),
+        (["part1", "part2"], True),
+        # "part-less" clean: shouldn't run managed
+        ([], False),
+    ],
+)
+def test_clean_run_managed(app_metadata, mock_services, parts, expected_run_managed):
+    parsed_args = argparse.Namespace(parts=parts)
+    command = CleanCommand({"app": app_metadata, "services": mock_services})
+
+    assert command.run_managed(parsed_args) == expected_run_managed
 
 
 @pytest.mark.parametrize(("debug_dict", "debug_args"), DEBUG_PARAMS)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,8 +23,10 @@ from craft_application import services
 
 
 @pytest.fixture()
-def provider_service(app_metadata, fake_project, fake_services):
-    return services.ProviderService(app_metadata, fake_project, fake_services)
+def provider_service(app_metadata, fake_project, fake_services, tmp_path):
+    return services.ProviderService(
+        app_metadata, fake_project, fake_services, work_dir=tmp_path
+    )
 
 
 @pytest.fixture()

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -35,13 +35,18 @@ def factory(
 
 
 def test_correct_init(
-    app_metadata, fake_project, fake_package_service_class, fake_lifecycle_service_class
+    app_metadata,
+    fake_project,
+    fake_package_service_class,
+    fake_lifecycle_service_class,
+    fake_provider_service_class,
 ):
     factory = services.ServiceFactory(
         app_metadata,
         project=fake_project,
         PackageClass=fake_package_service_class,
         LifecycleClass=fake_lifecycle_service_class,
+        ProviderClass=fake_provider_service_class,
     )
 
     pytest_check.is_instance(factory.package, services.PackageService)


### PR DESCRIPTION
This pull request has 3 commits because I had to do some refactoring on `AppCommand` to get this "hybrid" command to work:

- The first commit adds `ProviderService.clean_instances()`;
- The second commit refactors `AppCommand.run_managed` from a property to a regular method that receives the parsed cli arguments;
- The third commit hooks the first two by updating the `clean` command to call either `provider.clean_instances()` or `lifecycle.clean()` depending on the command line args.

Fixes #56 
