### PR TITLE
fix: more robust determination of the app version

### DIFF
--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -15,6 +15,8 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for craft-application app classes."""
 import argparse
+import importlib
+import importlib.metadata
 import pathlib
 import re
 import subprocess
@@ -44,6 +46,31 @@ def test_app_metadata_post_init_correct(summary):
 
     pytest_check.equal(app.version, craft_application.__version__)
     pytest_check.is_not_none(app.summary)
+
+
+def test_app_metadata_version_attribute(tmp_path, monkeypatch):
+    """Set the AppMetadata version from the main app package."""
+    monkeypatch.syspath_prepend(tmp_path)
+    (tmp_path / "dummycraft_version.py").write_text("__version__ = '1.2.3'")
+
+    app = application.AppMetadata(name="dummycraft_version", summary="dummy craft")
+    assert app.version == "1.2.3"
+
+
+def test_app_metadata_importlib(tmp_path, monkeypatch, mocker):
+    """Set the AppMetadata version via importlib."""
+    monkeypatch.syspath_prepend(tmp_path)
+    (tmp_path / "dummycraft_importlib.py").write_text("print('hi')")
+
+    mocker.patch.object(importlib.metadata, "version", return_value="4.5.6")
+
+    app = application.AppMetadata(name="dummycraft_importlib", summary="dummy craft")
+    assert app.version == "4.5.6"
+
+
+def test_app_metadata_dev():
+    app = application.AppMetadata(name="dummycraft_dev", summary="dummy craft")
+    assert app.version == "dev"
 
 
 @pytest.fixture()


### PR DESCRIPTION
Instead of default to the installed metadata, first try to use the app's main package (via the standard __version__ attribute), *then* fallback to importlib.metadata, *then* fallback to "dev".

Fixes #90

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
