### PR TITLE
fix: catch PartsError and ProviderError from dispatch run

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -28,6 +28,7 @@ from importlib import metadata
 from typing import TYPE_CHECKING, Any, cast, final
 
 import craft_cli
+import craft_parts
 import craft_providers
 from xdg.BaseDirectory import save_cache_path  # type: ignore[import]
 
@@ -294,6 +295,20 @@ class Application:
             return_code = 128 + signal.SIGINT
         except craft_cli.CraftError as err:
             self._emit_error(err)
+        except craft_parts.PartsError as err:
+            self._emit_error(
+                craft_cli.CraftError(
+                    err.brief, details=err.details, resolution=err.resolution
+                )
+            )
+            return_code = 1
+        except craft_providers.ProviderError as err:
+            self._emit_error(
+                craft_cli.CraftError(
+                    err.brief, details=err.details, resolution=err.resolution
+                )
+            )
+            return_code = 1
         except Exception as err:  # noqa: BLE001 pylint: disable=broad-except
             self._emit_error(
                 craft_cli.CraftError(f"{self.app.name} internal error: {err!r}")

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 import craft_application
 import craft_cli
+import craft_parts
 import craft_providers
 import pytest
 import pytest_check
@@ -310,6 +311,8 @@ def test_run_success_managed_inside_managed(
     [
         (KeyboardInterrupt(), 130, "Interrupted.\n"),
         (craft_cli.CraftError("msg"), 1, "msg\n"),
+        (craft_parts.PartsError("unable to pull"), 1, "unable to pull\n"),
+        (craft_providers.ProviderError("fail to launch"), 1, "fail to launch\n"),
         (Exception(), 70, "testcraft internal error: Exception()\n"),
     ],
 )


### PR DESCRIPTION
Capture these errors so they are not treated as internal errors with no details about the error.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
Fixes #55 