### PR TITLE
some minor lifecycle papercuts

### DIFF
--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -171,6 +171,7 @@ class LifecycleService(base.BaseService):
             else:
                 actions = []
 
+            emit.progress("Initialising lifecycle")
             with self._lcm.action_executor() as aex:
                 for action in actions:
                     message = _get_parts_action_message(action)

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -30,6 +30,8 @@ from craft_application.util import convert_architecture_deb_to_platform
 if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
 
+    import craft_parts
+
     from craft_application.application import AppMetadata
     from craft_application.models import Project
     from craft_application.services import ServiceFactory
@@ -159,6 +161,11 @@ class LifecycleService(base.BaseService):
     def prime_dir(self) -> Path:
         """The path to the prime directory."""
         return self._lcm.project_info.dirs.prime_dir
+
+    @property
+    def project_info(self) -> craft_parts.ProjectInfo:
+        """The lifecycle's ProjectInfo."""
+        return self._lcm.project_info
 
     def run(self, step_name: str | None, part_names: list[str] | None = None) -> None:
         """Run the lifecycle manager for the parts."""

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -267,6 +267,12 @@ def test_prime_dir(lifecycle_service, tmp_path):
     pytest_check.equal(prime_dir, tmp_path / "work/prime")
 
 
+def test_project_info(lifecycle_service):
+    info = lifecycle_service.project_info
+
+    assert info.application_name == "testcraft"
+
+
 @pytest.mark.parametrize(
     "actions",
     [


### PR DESCRIPTION
* Add a progress message for the step where the lifecycle is initialised (build-packages, snaps, etc)
* Expose the lifecycle's ProjectInfo, mostly for the sake of tests.