### PR TITLE
fix: use progress for the packing messages

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -300,12 +300,12 @@ class PackCommand(PrimeCommand):
         )
 
         if not packages:
-            emit.message("No packages created.")
+            emit.progress("No packages created.", permanent=True)
         elif len(packages) == 1:
-            emit.message(f"Packed {packages[0].name}")
+            emit.progress(f"Packed {packages[0].name}", permanent=True)
         else:
             package_names = ", ".join(pkg.name for pkg in packages)
-            emit.message(f"Packed: {package_names}")
+            emit.progress(f"Packed: {package_names}", permanent=True)
 
     @staticmethod
     @override

--- a/tests/integration/data/valid_projects/basic/stderr
+++ b/tests/integration/data/valid_projects/basic/stderr
@@ -1,0 +1,1 @@
+Packed package.tar.zst

--- a/tests/integration/data/valid_projects/basic/stdout
+++ b/tests/integration/data/valid_projects/basic/stdout
@@ -1,1 +1,0 @@
-Packed package.tar.zst

--- a/tests/integration/data/valid_projects/environment/stderr
+++ b/tests/integration/data/valid_projects/environment/stderr
@@ -1,0 +1,1 @@
+Packed package.tar.zst

--- a/tests/integration/data/valid_projects/environment/stdout
+++ b/tests/integration/data/valid_projects/environment/stdout
@@ -1,1 +1,0 @@
-Packed package.tar.zst

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -124,7 +124,10 @@ def test_project_managed(capsys, monkeypatch, tmp_path, project, create_app):
 
     assert (tmp_path / "package.tar.zst").exists()
     captured = capsys.readouterr()
-    assert captured.out == (VALID_PROJECTS_DIR / project / "stdout").read_text()
+    assert (
+        captured.err.splitlines()[-1]
+        == (VALID_PROJECTS_DIR / project / "stderr").read_text()
+    )
 
 
 @pytest.mark.parametrize("project", (d.name for d in VALID_PROJECTS_DIR.iterdir()))
@@ -139,7 +142,10 @@ def test_project_destructive(capsys, monkeypatch, tmp_path, project, create_app)
 
     assert (tmp_path / "package.tar.zst").exists()
     captured = capsys.readouterr()
-    assert captured.out == (VALID_PROJECTS_DIR / project / "stdout").read_text()
+    assert (
+        captured.err.splitlines()[-1]
+        == (VALID_PROJECTS_DIR / project / "stderr").read_text()
+    )
 
     for dirname in ("parts", "stage", "prime"):
         assert (tmp_path / dirname).is_dir()

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -417,7 +417,7 @@ def test_pack_run(
         tmp_path,
     )
     emitter.assert_progress("Packing...")
-    emitter.assert_message(message)
+    emitter.assert_progress(message, permanent=True)
 
 
 def test_pack_run_wrong_step(app_metadata, fake_services):


### PR DESCRIPTION
Replace the previous "Packing..." message instead of appending to it.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
