### PR TITLE
feat: support build-secrets in managed-mode

### DIFF
--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -109,8 +109,8 @@ class PartsLifecycleError(CraftError):
 class SecretsCommandError(CraftError):
     """Error when rendering a build-secret."""
 
-    def __init__(self, host_secret: str, error_message: str) -> None:
-        message = f'Error when processing secret "{host_secret}"'
+    def __init__(self, host_directive: str, error_message: str) -> None:
+        message = f'Error when processing secret "{host_directive}"'
         details = f"Command output: {error_message}"
         super().__init__(message=message, details=details)
 
@@ -118,6 +118,18 @@ class SecretsCommandError(CraftError):
 class SecretsFieldError(CraftError):
     """Error when using a build-secret in a disallowed field."""
 
-    def __init__(self, host_secret: str, field_name: str) -> None:
-        message = f'Build secret "{host_secret}" is not allowed on field "{field_name}"'
+    def __init__(self, host_directive: str, field_name: str) -> None:
+        message = (
+            f'Build secret "{host_directive}" is not allowed on field "{field_name}"'
+        )
+        super().__init__(message=message)
+
+
+class SecretsManagedError(CraftError):
+    """A secret value was not found while in managed mode."""
+
+    def __init__(self, host_directive: str) -> None:
+        message = (
+            f'Build secret "{host_directive}" was not found in the managed environment.'
+        )
         super().__init__(message=message)

--- a/craft_application/secrets.py
+++ b/craft_application/secrets.py
@@ -98,11 +98,11 @@ def _render_part_secrets(
 
 
 def _render_secret(
-    text: str,
+    yaml_string: str,
     command_cache: dict[str, str],
     managed_mode: bool,  # noqa: FBT001 (boolean positional arg)
 ) -> str | None:
-    if match := SECRET_REGEX.search(text):
+    if match := SECRET_REGEX.search(yaml_string):
         command = match.group("command")
         host_directive = match.group(0)
 
@@ -121,7 +121,7 @@ def _render_secret(
                 ) from err
             command_cache[command] = output
 
-        return text.replace(host_directive, output)
+        return yaml_string.replace(host_directive, output)
     return None
 
 

--- a/craft_application/secrets.py
+++ b/craft_application/secrets.py
@@ -16,48 +16,75 @@
 """Handling of build-time secrets."""
 from __future__ import annotations
 
+import base64
+import dataclasses
+import json
+import os
 import re
 import subprocess
-from typing import Any
+from typing import Any, Mapping, cast
 
 from craft_application import errors
 
 SECRET_REGEX = re.compile(r"\$\(HOST_SECRET:(?P<command>.*)\)")
 
 
-def render_secrets(yaml_data: dict[str, Any]) -> set[str]:
+@dataclasses.dataclass(frozen=True)
+class BuildSecrets:
+    """The data needed to correctly handle build-time secrets in the application."""
+
+    environment: dict[str, str]
+    """The encoded information that can be passed to a managed instance's environment."""
+
+    secret_strings: set[str]
+    """The actual secret text strings, to be passed to craft_cli."""
+
+
+def render_secrets(yaml_data: dict[str, Any], *, managed_mode: bool) -> BuildSecrets:
     """Render/expand the build secrets in a project's yaml data (in-place).
 
     This function will process directives of the form $(HOST_SECRET:<cmd>) in string
     values in ``yaml_data``. For each such directive, the <cmd> part is executed (with
-    bash) and the resulting output replaces the whole directive. The returned set
-    contains the outputs of all HOST_SECRET processing (for masking with craft-cli).
+    bash) and the resulting output replaces the whole directive. The returned object
+    contains the result of HOST_SECRET processing (for masking with craft-cli and
+    forwarding to managed instances).
 
     Note that only a few fields are currently supported:
 
     - "source" and "build-environment" for parts.
 
     Using HOST_SECRET directives in any other field is an error.
+
+    :param yaml_data: The project's loaded data
+    :param managed_mode: Whether the current application is running in managed mode.
     """
     command_cache: dict[str, str] = {}
+
+    if managed_mode:
+        command_cache = _decode_commands(os.environ)
 
     # Process the fields where we allow build secrets
     parts = yaml_data.get("parts", {})
     for part in parts.values():
-        _render_part_secrets(part, command_cache)
+        _render_part_secrets(part, command_cache, managed_mode)
 
     # Now loop over all the data to check for build secrets in disallowed fields
     _check_for_secrets(yaml_data)
 
-    return set(command_cache.values())
+    return BuildSecrets(
+        environment=_encode_commands(command_cache),
+        secret_strings=set(command_cache.values()),
+    )
 
 
 def _render_part_secrets(
-    part_data: dict[str, Any], command_cache: dict[str, Any]
+    part_data: dict[str, Any],
+    command_cache: dict[str, Any],
+    managed_mode: bool,  # noqa: FBT001 (boolean positional arg)
 ) -> None:
     # Render "source"
     source = part_data.get("source", "")
-    if (rendered := _render_secret(source, command_cache)) is not None:
+    if (rendered := _render_secret(source, command_cache, managed_mode)) is not None:
         part_data["source"] = rendered
 
     # Render "build-environment"
@@ -65,11 +92,16 @@ def _render_part_secrets(
     # "build-environment" is a list of dicts with a single item each
     for single_entry_dict in build_env:
         for var_name, var_value in single_entry_dict.items():
-            if (rendered := _render_secret(var_value, command_cache)) is not None:
+            rendered = _render_secret(var_value, command_cache, managed_mode)
+            if rendered is not None:
                 single_entry_dict[var_name] = rendered
 
 
-def _render_secret(text: str, command_cache: dict[str, str]) -> str | None:
+def _render_secret(
+    text: str,
+    command_cache: dict[str, str],
+    managed_mode: bool,  # noqa: FBT001 (boolean positional arg)
+) -> str | None:
     if match := SECRET_REGEX.search(text):
         command = match.group("command")
         host_directive = match.group(0)
@@ -77,6 +109,10 @@ def _render_secret(text: str, command_cache: dict[str, str]) -> str | None:
         if command in command_cache:
             output = command_cache[command]
         else:
+            if managed_mode:
+                # In managed mode the command *must* be in the cache; this is an error.
+                raise errors.SecretsManagedError(host_directive)
+
             try:
                 output = _run_command(command)
             except subprocess.CalledProcessError as err:
@@ -115,4 +151,40 @@ def _check_str(
     value: Any, field_name: str  # noqa: ANN401 (using Any on purpose)
 ) -> None:
     if isinstance(value, str) and (match := SECRET_REGEX.search(value)):
-        raise errors.SecretsFieldError(host_secret=match.group(), field_name=field_name)
+        raise errors.SecretsFieldError(
+            host_directive=match.group(), field_name=field_name
+        )
+
+
+def _encode_commands(commands: dict[str, str]) -> dict[str, str]:
+    """Encode a dict of (command, command-output) pairs for env serialization.
+
+    The resulting dict can be passed to the environment of managed instances (via
+    subprocess.run() or equivalents).
+    """
+    if not commands:
+        # Empty dict: don't spend time encoding anything.
+        return {}
+
+    # The current encoding scheme is to dump the entire dict to base64-encoded json
+    # string, then put this resulting string in a dict under the "CRAFT_SECRETS" key.
+    as_json = json.dumps(commands)
+    as_bytes = as_json.encode("utf-8")
+    as_b64 = base64.b64encode(as_bytes)
+    as_str = as_b64.decode("ascii")
+
+    return {"CRAFT_SECRETS": as_str}
+
+
+def _decode_commands(environment: Mapping[str, Any]) -> dict[str, str]:
+    as_str = environment.get("CRAFT_SECRETS")
+
+    if as_str is None:
+        # Not necessarily an error: it means the project has no secrets.
+        return {}
+
+    as_b64 = as_str.encode("ascii")
+    as_bytes = base64.b64decode(as_b64)
+    as_json = as_bytes.decode("utf-8")
+
+    return cast("dict[str, str]", json.loads(as_json))

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -19,7 +19,8 @@ import pytest
 from craft_application import errors, secrets
 
 
-def test_secrets_parts(monkeypatch):
+@pytest.fixture()
+def good_yaml_data():
     p1_data = {
         "source": "the source secret is $(HOST_SECRET:echo ${SECRET_1})",
         "build-environment": [
@@ -28,14 +29,35 @@ def test_secrets_parts(monkeypatch):
         ],
     }
 
-    monkeypatch.setenv("SECRET_1", "source-secret")
-    monkeypatch.setenv("SECRET_2", "env-secret")
+    return {"parts": {"p1": p1_data}}
 
-    yaml_data = {"parts": {"p1": p1_data}}
-    secret_values = secrets.render_secrets(yaml_data)
 
-    assert secret_values == {"source-secret", "env-secret"}
+@pytest.mark.parametrize("managed_mode", [True, False])
+def test_secrets_parts(monkeypatch, good_yaml_data, managed_mode):
+    commands = {
+        "echo ${SECRET_1}": "source-secret",
+        "echo ${SECRET_2}": "env-secret",
+    }
+    encoded = secrets._encode_commands(commands)
 
+    if not managed_mode:
+        # Running on the "host"; the secrets will be obtained by running commands,
+        # so we set some environment variables that those commands will use.
+        monkeypatch.setenv("SECRET_1", "source-secret")
+        monkeypatch.setenv("SECRET_2", "env-secret")
+    else:
+        # Managed mode; the secrets must necessarily come from the environment already.
+        # Here we fake the work that the host application would have done: get the
+        # secrets by running the commands, and then encode them into the environment
+        # of the launched (managed) application.
+        monkeypatch.setenv("CRAFT_SECRETS", encoded["CRAFT_SECRETS"])
+
+    secret_values = secrets.render_secrets(good_yaml_data, managed_mode=managed_mode)
+
+    assert secret_values.environment == encoded
+    assert secret_values.secret_strings == {"source-secret", "env-secret"}
+
+    p1_data = good_yaml_data["parts"]["p1"]
     assert p1_data["source"] == "the source secret is source-secret"
     assert p1_data["build-environment"][0]["VAR1"] == "the env secret is env-secret"
 
@@ -47,7 +69,7 @@ def test_secrets_command_error():
     yaml_data = {"parts": {"p1": {"source": "$(HOST_SECRET:echo ${I_DONT_EXIST})"}}}
 
     with pytest.raises(errors.SecretsCommandError) as exc:
-        secrets.render_secrets(yaml_data)
+        secrets.render_secrets(yaml_data, managed_mode=False)
 
     expected_message = (
         'Error when processing secret "$(HOST_SECRET:echo ${I_DONT_EXIST})"'
@@ -71,7 +93,7 @@ def test_secrets_cache(mocker, monkeypatch):
     yaml_data = {"parts": {"p1": p1_data}}
 
     spied_run = mocker.spy(secrets, "_run_command")
-    secrets.render_secrets(yaml_data)
+    secrets.render_secrets(yaml_data, managed_mode=False)
 
     # Even though the HOST_SECRET is used twice, only a single bash call is done because
     # the command is the same.
@@ -96,8 +118,37 @@ def test_secrets_bad_field(monkeypatch, yaml_data, field_name):
     monkeypatch.setenv("GIT_VERSION", "1.0")
 
     with pytest.raises(errors.SecretsFieldError) as exc:
-        secrets.render_secrets(yaml_data)
+        secrets.render_secrets(yaml_data, managed_mode=False)
 
     expected_error = f'Build secret "{_SECRET}" is not allowed on field "{field_name}"'
     err = exc.value
     assert str(err) == expected_error
+
+
+def test_secrets_encode_decode():
+    commands = {
+        "echo $VAR1": "var1-value",
+        "echo $VAR2": "var2-value",
+    }
+
+    encoded = secrets._encode_commands(commands)
+    decoded = secrets._decode_commands(encoded)
+
+    assert decoded == commands
+
+
+def test_secrets_encode_decode_empty():
+    commands = {}
+
+    encoded = secrets._encode_commands(commands)
+    decoded = secrets._decode_commands(encoded)
+
+    assert decoded == encoded == commands
+
+
+def test_secrets_managed_missing_key(good_yaml_data):
+    with pytest.raises(errors.SecretsManagedError) as exc:
+        secrets.render_secrets(good_yaml_data, managed_mode=True)
+
+    expected_message = 'Build secret "$(HOST_SECRET:echo ${SECRET_1})" was not found in the managed environment.'
+    assert str(exc.value) == expected_message


### PR DESCRIPTION
This is done by encoding the secrets, in the host-application, into the environment of the managed instance. The managed instance then decodes this environment and uses it to re-render the project secrets.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
