### PR TITLE
chore: drop pdf/epub readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,11 +9,6 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF
-formats:
-  - pdf
-  - epub
-
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
I think these came from a template, but the readthedocs build is currently failing from lack of latex and I can't imagine someone would want a pdf/ebook of these docs.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
