### PR TITLE
build(deps): bump craft-providers to 1.19.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "craft-cli>=2.4.0",
     "craft-parts>=1.21.1",
-    "craft-providers>=1.14.0,<2.0",
+    "craft-providers>=1.19.2,<2.0",
     "pydantic>=1.10,<2.0",
     "pydantic-yaml<1.0",
     "pyxdg",


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

### Changelog

#### 1.19.2 (2023-11-02)
- Update base compatibility tag from ``base-v2`` to ``base-v3``
  This fixes an issue where LXD instances created with
  ``craft-providers==1.16.0`` may fail to start with
  ``craft-providers>=1.17.0``.

####  1.19.1 (2023-10-26)
- Require a disk device in the default LXD profile

#### 1.19.0 (2023-10-23)
- Add Ubuntu 23.10 (Mantic) support

#### 1.18.0 (2023-09-28)
- Check if base instance status before copying
- Fail quickly when LXD errors do not involve instance creation
- Add ``check`` parameter to ``execute_run``

#### 1.17.0 (2023-09-22)
- Use a shared pip cache across instances
- Remove Ubuntu 22.10 (Kinetic) support
- Capture details for snap errors

#### 1.16.0 (2023-08-25)
- Improve LXD instance creation process to avoid race conditions. The base
  instance is now created first and copied to an instance. Retry, timeout,
  and locking mechanisms prevent multiple processes from creating the
  same base instance.
- Add LXD functions ``check_instance_status()``, ``config_set()``,
  ``config_get()``, and ``restart()``

#### 1.15.0 (2023-08-21)
- Update base compatibility tag from ``base-v1`` to ``base-v2``
- Use ``snap refresh --hold`` inside instances
- Re-level log messages
- Add more info-level log messages
- Update links from linuxcontainers.org to ubuntu.com
- Set timezone of LXD instances to match host's timezone
- Add name and install recommendations to Providers

#### 1.14.1 (2023-07-24)
- Prevent race when two processes try to create the same project
  at the same time
