### PR TITLE
fix(ProviderService): set base compatibilty tag

### DIFF
--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -138,6 +138,7 @@ class ProviderService(base.ProjectService):
         base_class = bases.get_base_from_alias(alias)
         return base_class(
             alias=alias,
+            compatibility_tag=f"{self._app.name}-{base_class.compatibility_tag}",
             hostname=instance_name,
             snaps=self.snaps,
             environment=self.environment,

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -141,6 +141,7 @@ def test_get_base(check, provider_service, base_name, base_class, alias, environ
 
     check.is_instance(base, base_class)
     check.equal(base.alias, alias)
+    check.equal(base.compatibility_tag, f"testcraft-{base_class.compatibility_tag}")
     check.equal(base._environment, environment)
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Set the base compatibility tag so that is it unique per each application.

This works around a bug in craft-providers where LXD instances will fail to launch.  It is described in detail here: https://github.com/canonical/craft-providers/issues/454

Fixes #139 
(CRAFT-2230)