### PR TITLE
build(deps): bump craft-providers to 1.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "craft-cli>=2.4.0",
     "craft-parts>=1.21.1",
-    "craft-providers>=1.19.2,<2.0",
+    "craft-providers>=1.20.0,<2.0",
     "pydantic>=1.10,<2.0",
     "pydantic-yaml<1.0",
     "pyxdg",


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

### Changelog

#### 1.20.0 (2023-11-10)

Snaps injected from the host will have their base snap injected into the instance.