### PR TITLE
feat: extensible commands

### DIFF
--- a/craft_application/commands/__init__.py
+++ b/craft_application/commands/__init__.py
@@ -15,13 +15,14 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Command classes for a craft application."""
 
-from craft_application.commands.base import AppCommand
+from craft_application.commands.base import AppCommand, ExtensibleCommand
 from craft_application.commands import lifecycle
 from craft_application.commands.lifecycle import get_lifecycle_command_group
 from craft_application.commands.other import get_other_command_group
 
 __all__ = [
     "AppCommand",
+    "ExtensibleCommand",
     "lifecycle",
     "get_lifecycle_command_group",
     "get_other_command_group",

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -103,6 +103,11 @@ class ExtensibleCommand(AppCommand):
     _prologue: RunCallback | None
     _epilogue: RunCallback | None
 
+    @property
+    def services(self) -> service_factory.ServiceFactory:
+        """Services available to this command."""
+        return self._services
+
     @classmethod
     def register_parser_filler(cls, callback: ParserCallback) -> None:
         """Register a function that modifies the argument parser.

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -166,14 +166,11 @@ class ExtensibleCommand(AppCommand):
     ) -> Optional[int]:  # noqa: UP007
         """Run any prologue callbacks, the main command, and any epilogue callbacks."""
         result = None
-        for cls in reversed(self.__class__.mro()):
-            if callback := getattr(cls, "_prologue", None):
-                result = callback(self, parsed_args, **kwargs) or result
+        for prologue in util.get_unique_callbacks(self.__class__, "_prologue"):
+            result = prologue(self, parsed_args, **kwargs) or result
         result = self._run(parsed_args, **kwargs) or result
-        for cls in reversed(self.__class__.mro()):
-            if callback := getattr(cls, "_epilogue", None):
-                result = (
-                    callback(self, parsed_args, current_result=result, **kwargs)
-                    or result
-                )
+        for epilogue in util.get_unique_callbacks(self.__class__, "_epilogue"):
+            result = (
+                epilogue(self, parsed_args, current_result=result, **kwargs) or result
+            )
         return result

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -106,7 +106,7 @@ class ExtensibleCommand(AppCommand):
     @property
     def services(self) -> service_factory.ServiceFactory:
         """Services available to this command."""
-        return self._services
+        return self._services  # pragma: no cover
 
     @classmethod
     def register_parser_filler(cls, callback: ParserCallback) -> None:

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -16,15 +16,37 @@
 """Base command for craft-application commands."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import abc
+from typing import TYPE_CHECKING, Any, Optional, Protocol, final
 
 from craft_cli import BaseCommand, emit
+from typing_extensions import Self
 
 if TYPE_CHECKING:  # pragma: no cover
     import argparse
 
     from craft_application import application
     from craft_application.services import service_factory
+
+
+class ParserCallback(Protocol):
+    """A protocol that expresses the type for a parser callback."""
+
+    @staticmethod
+    def __call__(cmd: ExtensibleCommand, parser: argparse.ArgumentParser) -> None:
+        """Call the parser callback function. Works the same as fill_parser."""
+
+
+class RunCallback(Protocol):
+    """A protocol that expresses the type for pre-run and post-run callbacks."""
+
+    @staticmethod
+    def __call__(
+        cmd: ExtensibleCommand,
+        parsed_args: argparse.Namespace,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> int | None:
+        """Call the prologue or epilogue. Takes the same parameters as run."""
 
 
 class AppCommand(BaseCommand):
@@ -74,3 +96,82 @@ class AppCommand(BaseCommand):
         cmd_name = self._app.name
         verbosity = emit.get_mode().name.lower()
         return [cmd_name, f"--verbosity={verbosity}", self.name]
+
+
+class ExtensibleCommand(AppCommand):
+    """A command that allows applications to register modifications."""
+
+    _parse_callback: ParserCallback | None
+    _prologue: RunCallback | None
+    _epilogue: RunCallback | None
+
+    @classmethod
+    def register_parser_filler(cls, callback: ParserCallback) -> None:
+        """Register a function that modifies the argument parser.
+
+        Only one parser filler callback can be registered to a particular command class.
+        However, fillers registered to parent classes will still be run, from the
+        top class in the inheritance tree on down.
+        """
+        cls._parse_callback = callback
+
+    @classmethod
+    def register_prologue(cls, callback: RunCallback) -> None:
+        """Register a function that runs before the main run.
+
+        Each command class may only have a single prologue. Prologues on the inheritance
+        tree are run in reverse method resolution order. (That is, a child command's
+        prologue is run after the parent command's.)
+        """
+        cls._prologue = callback
+
+    @classmethod
+    def register_epilogue(cls, callback: RunCallback) -> None:
+        """Register a function that runs after the main run.
+
+        Each command class may only have a single epilogue. Epilogues on the inheritance
+        tree are run in reverse method resolution order. (That is, a child command's
+        epilogue is run after the parent command's.)
+        """
+        cls._epilogue = callback
+
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        """Real parser filler for an ExtensibleCommand."""
+        super().fill_parser(parser)  # type: ignore[arg-type]
+
+    @final
+    def fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        """Set the arguments for the parser.
+
+        First, the real filler in ``_fill_parser`` is run, filling the base parser.
+        After that, the parse callbacks are run in reverse method resolution order.
+        (That is, starting with the top ancestor.)
+        """
+        self._fill_parser(parser)
+        for cls in reversed(self.__class__.mro()):
+            if callback := getattr(cls, "_parse_callback", None):
+                callback(self, parser)
+
+    @abc.abstractmethod
+    def _run(
+        self: Self, parsed_args: argparse.Namespace, **kwargs: Any  # noqa: ANN401
+    ) -> int | None:
+        """Run the real run method for an ExtensibleCommand."""
+
+    @final
+    def run(
+        self: Self, parsed_args: argparse.Namespace, **kwargs: Any  # noqa: ANN401
+    ) -> Optional[int]:  # noqa: UP007
+        """Run any prologue callbacks, the main command, and any epilogue callbacks."""
+        result = None
+        for cls in reversed(self.__class__.mro()):
+            if callback := getattr(cls, "_prologue", None):
+                result = callback(self, parsed_args, **kwargs) or result
+        result = self._run(parsed_args, **kwargs) or result
+        for cls in reversed(self.__class__.mro()):
+            if callback := getattr(cls, "_epilogue", None):
+                result = (
+                    callback(self, parsed_args, current_result=result, **kwargs)
+                    or result
+                )
+        return result

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -59,6 +59,8 @@ class _LifecycleCommand(base.ExtensibleCommand):
 
 
 class LifecyclePartsCommand(_LifecycleCommand):
+    """A lifecycle command that uses parts."""
+
     # All lifecycle-related commands need a project to work
     always_load_project = True
 
@@ -88,6 +90,8 @@ class LifecyclePartsCommand(_LifecycleCommand):
 
 
 class LifecycleStepCommand(LifecyclePartsCommand):
+    """An actual lifecycle step."""
+
     @override
     def run_managed(self, parsed_args: argparse.Namespace) -> bool:
         return not parsed_args.destructive_mode

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -18,7 +18,7 @@ import os
 import pathlib
 import subprocess
 import textwrap
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from craft_cli import CommandGroup, emit
 from craft_parts.features import Features
@@ -50,11 +50,11 @@ def get_lifecycle_command_group() -> CommandGroup:
     )
 
 
-class _LifecycleCommand(base.AppCommand):
+class _LifecycleCommand(base.ExtensibleCommand):
     """Lifecycle-related commands."""
 
     @override
-    def run(self, parsed_args: argparse.Namespace) -> None:
+    def _run(self, parsed_args: argparse.Namespace, **kwargs: Any) -> None:
         emit.trace(f"lifecycle command: {self.name!r}, arguments: {parsed_args!r}")
 
 
@@ -63,8 +63,8 @@ class _LifecyclePartsCommand(_LifecycleCommand):
     always_load_project = True
 
     @override
-    def fill_parser(self, parser: argparse.ArgumentParser) -> None:
-        super().fill_parser(parser)  # type: ignore[arg-type]
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)  # type: ignore[arg-type]
         parser.add_argument(
             "parts",
             metavar="part-name",
@@ -93,8 +93,8 @@ class _LifecycleStepCommand(_LifecyclePartsCommand):
         return not parsed_args.destructive_mode
 
     @override
-    def fill_parser(self, parser: argparse.ArgumentParser) -> None:
-        super().fill_parser(parser)
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)
 
         if self._should_add_shell_args():
             group = parser.add_mutually_exclusive_group()
@@ -149,11 +149,14 @@ class _LifecycleStepCommand(_LifecyclePartsCommand):
         return cmd
 
     @override
-    def run(
-        self, parsed_args: argparse.Namespace, step_name: str | None = None
+    def _run(
+        self,
+        parsed_args: argparse.Namespace,
+        step_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Run a lifecycle step command."""
-        super().run(parsed_args)
+        super()._run(parsed_args)
 
         shell = getattr(parsed_args, "shell", False)
         shell_after = getattr(parsed_args, "shell_after", False)
@@ -253,11 +256,14 @@ class PrimeCommand(_LifecycleStepCommand):
     )
 
     @override
-    def run(
-        self, parsed_args: argparse.Namespace, step_name: str | None = None
+    def _run(
+        self,
+        parsed_args: argparse.Namespace,
+        step_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Run the prime command."""
-        super().run(parsed_args, step_name=step_name)
+        super()._run(parsed_args, step_name=step_name)
 
         self._services.package.write_metadata(self._services.lifecycle.prime_dir)
 
@@ -274,8 +280,8 @@ class PackCommand(PrimeCommand):
     )
 
     @override
-    def fill_parser(self, parser: argparse.ArgumentParser) -> None:
-        super().fill_parser(parser)
+    def _fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        super()._fill_parser(parser)
 
         parser.add_argument(
             "--output",
@@ -286,13 +292,16 @@ class PackCommand(PrimeCommand):
         )
 
     @override
-    def run(
-        self, parsed_args: argparse.Namespace, step_name: str | None = None
+    def _run(
+        self,
+        parsed_args: argparse.Namespace,
+        step_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Run the pack command."""
         if step_name not in ("pack", None):
             raise RuntimeError(f"Step name {step_name} passed to pack command.")
-        super().run(parsed_args, step_name="prime")
+        super()._run(parsed_args, step_name="prime")
 
         emit.progress("Packing...")
         packages = self._services.package.pack(
@@ -326,9 +335,9 @@ class CleanCommand(_LifecyclePartsCommand):
     )
 
     @override
-    def run(self, parsed_args: argparse.Namespace) -> None:
+    def _run(self, parsed_args: argparse.Namespace, **kwargs: Any) -> None:
         """Run the clean command."""
-        super().run(parsed_args)
+        super()._run(parsed_args)
 
         if parsed_args.destructive_mode or not self._should_clean_instances(
             parsed_args

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -58,7 +58,7 @@ class _LifecycleCommand(base.ExtensibleCommand):
         emit.trace(f"lifecycle command: {self.name!r}, arguments: {parsed_args!r}")
 
 
-class _LifecyclePartsCommand(_LifecycleCommand):
+class LifecyclePartsCommand(_LifecycleCommand):
     # All lifecycle-related commands need a project to work
     always_load_project = True
 
@@ -87,7 +87,7 @@ class _LifecyclePartsCommand(_LifecycleCommand):
         return cmd
 
 
-class _LifecycleStepCommand(_LifecyclePartsCommand):
+class LifecycleStepCommand(LifecyclePartsCommand):
     @override
     def run_managed(self, parsed_args: argparse.Namespace) -> bool:
         return not parsed_args.destructive_mode
@@ -188,7 +188,7 @@ class _LifecycleStepCommand(_LifecyclePartsCommand):
         return True
 
 
-class PullCommand(_LifecycleStepCommand):
+class PullCommand(LifecycleStepCommand):
     """Command to pull parts."""
 
     name = "pull"
@@ -202,7 +202,7 @@ class PullCommand(_LifecycleStepCommand):
     )
 
 
-class OverlayCommand(_LifecycleStepCommand):
+class OverlayCommand(LifecycleStepCommand):
     """Command to overlay parts."""
 
     name = "overlay"
@@ -215,7 +215,7 @@ class OverlayCommand(_LifecycleStepCommand):
     )
 
 
-class BuildCommand(_LifecycleStepCommand):
+class BuildCommand(LifecycleStepCommand):
     """Command to build parts."""
 
     name = "build"
@@ -228,7 +228,7 @@ class BuildCommand(_LifecycleStepCommand):
     )
 
 
-class StageCommand(_LifecycleStepCommand):
+class StageCommand(LifecycleStepCommand):
     """Command to stage parts."""
 
     name = "stage"
@@ -242,7 +242,7 @@ class StageCommand(_LifecycleStepCommand):
     )
 
 
-class PrimeCommand(_LifecycleStepCommand):
+class PrimeCommand(LifecycleStepCommand):
     """Command to prime parts."""
 
     name = "prime"
@@ -322,7 +322,7 @@ class PackCommand(PrimeCommand):
         return False
 
 
-class CleanCommand(_LifecyclePartsCommand):
+class CleanCommand(LifecyclePartsCommand):
     """Command to remove part assets."""
 
     name = "clean"

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -15,17 +15,19 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Utilities for craft-application."""
 
-from craft_application.util.yaml import safe_yaml_load, dump_yaml
+from craft_application.util.callbacks import get_unique_callbacks
 from craft_application.util.paths import get_managed_logpath
 from craft_application.util.platforms import (
     get_host_architecture,
     convert_architecture_deb_to_platform,
 )
+from craft_application.util.yaml import dump_yaml, safe_yaml_load
 
 __all__ = [
-    "safe_yaml_load",
-    "dump_yaml",
+    "get_unique_callbacks",
+    "get_managed_logpath",
     "get_host_architecture",
     "convert_architecture_deb_to_platform",
-    "get_managed_logpath",
+    "dump_yaml",
+    "safe_yaml_load",
 ]

--- a/craft_application/util/callbacks.py
+++ b/craft_application/util/callbacks.py
@@ -16,20 +16,44 @@
 """Utilities related to callbacks."""
 from __future__ import annotations
 
-from typing import Callable, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable, Literal, overload
+
+if TYPE_CHECKING:  # pragma: no-cover
+    # Caution: Removing these from type checking will result in circular imports.
+    from craft_application.commands.base import ParserCallback, RunCallback
 
 
-def get_unique_callbacks(cls: type, callback_name: str) -> Iterable[Callable]:
+@overload
+def get_unique_callbacks(
+    cls: type, callback_name: Literal["_parse_callback"]
+) -> Iterable[ParserCallback]:
+    ...
+
+
+@overload
+def get_unique_callbacks(
+    cls: type, callback_name: Literal["_prologue", "_epilogue"]
+) -> Iterable[RunCallback]:
+    ...
+
+
+def get_unique_callbacks(  # pyright: ignore[reportUnknownParameterType]
+    cls: type, callback_name: str
+) -> Iterable[Callable]:  # type: ignore[type-arg]
     """Get all unique callbacks in a class's inheritance tree.
 
     Guarantees order to be the reverse of the method resolution order (that is,
     starting with ``object`` and working its way down the resolution tree to the
     class itself). This means that the callbacks for child classes may depend on
     or modify the results of the callbacks for the parent class.
+
+    :param cls:  The class to search for callbacks
+    :param callback_name:  The name of the function
+    :return: Ordered callbacks starting at the top of the class tree.
     """
-    callbacks = []
+    callbacks = []  # pyright: ignore[reportUnknownVariableType]
     for class_ in reversed(cls.mro()):
         callback = getattr(class_, callback_name, None)
         if callback is not None and callback not in callbacks:
-            callbacks.append(callback)
-    return callbacks
+            callbacks.append(callback)  # pyright: ignore[reportUnknownMemberType]
+    return callbacks  # pyright: ignore[reportUnknownVariableType]

--- a/craft_application/util/callbacks.py
+++ b/craft_application/util/callbacks.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, overload
 
-if TYPE_CHECKING:  # pragma: no-cover
+if TYPE_CHECKING:  # pragma: no cover
     # Caution: Removing these from type checking will result in circular imports.
     from craft_application.commands.base import ParserCallback, RunCallback
 
@@ -27,14 +27,14 @@ if TYPE_CHECKING:  # pragma: no-cover
 def get_unique_callbacks(
     cls: type, callback_name: Literal["_parse_callback"]
 ) -> Iterable[ParserCallback]:
-    ...
+    ...  # pragma: no cover
 
 
 @overload
 def get_unique_callbacks(
     cls: type, callback_name: Literal["_prologue", "_epilogue"]
 ) -> Iterable[RunCallback]:
-    ...
+    ...  # pragma: no cover
 
 
 def get_unique_callbacks(  # pyright: ignore[reportUnknownParameterType]

--- a/craft_application/util/callbacks.py
+++ b/craft_application/util/callbacks.py
@@ -1,4 +1,21 @@
+#  This file is part of craft-application.
+#
+#  Copyright 2023 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utilities related to callbacks."""
 from __future__ import annotations
+
 from typing import Callable, Iterable
 
 

--- a/craft_application/util/callbacks.py
+++ b/craft_application/util/callbacks.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from typing import Callable, Iterable
+
+
+def get_unique_callbacks(cls: type, callback_name: str) -> Iterable[Callable]:
+    """Get all unique callbacks in a class's inheritance tree.
+
+    Guarantees order to be the reverse of the method resolution order (that is,
+    starting with ``object`` and working its way down the resolution tree to the
+    class itself). This means that the callbacks for child classes may depend on
+    or modify the results of the callbacks for the parent class.
+    """
+    callbacks = []
+    for class_ in reversed(cls.mro()):
+        callback = getattr(class_, callback_name, None)
+        if callback is not None and callback not in callbacks:
+            callbacks.append(callback)
+    return callbacks

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -14,7 +14,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for AppCommand."""
+from __future__ import annotations
+
 import argparse
+from unittest import mock
 
 import pytest
 from craft_application.commands import base
@@ -73,3 +76,159 @@ def test_without_config(emitter):
     emitter.assert_trace("Not completing command configuration")
     assert not hasattr(command, "_app")
     assert not hasattr(command, "_services")
+
+
+# region Tests for ExtensibleCommand
+@pytest.fixture()
+def fake_extensible_cls():
+    class FakeExtensibleCommand(base.ExtensibleCommand):
+        name = "fake"
+        help_msg = "A fake command"
+        overview = "A fake extensible command for testing."
+
+        def __init__(self):
+            self.__run_count = 0
+            super().__init__({"app": None, "services": None})
+
+        def get_run_count(self) -> dict[str, int]:
+            return {"fake": self.__run_count}
+
+        def _run(
+            self, parsed_args: argparse.Namespace, **kwargs  # noqa: ARG002
+        ) -> int | None:
+            self.__run_count += 1
+            return self.__run_count
+
+    return FakeExtensibleCommand
+
+
+@pytest.fixture()
+def fake_extensible_child(fake_extensible_cls):
+    class FakeChild(fake_extensible_cls):
+        name = "child"
+
+        def __init__(self):
+            self.__run_count = 0
+            super().__init__()
+
+        def get_run_count(self) -> dict[str, int]:
+            counts = super().get_run_count()
+            counts["child"] = self.__run_count
+            return counts
+
+        def _run(
+            self, parsed_args: argparse.Namespace, **kwargs  # noqa: ARG002
+        ) -> int | None:
+            self.__run_count += 1
+            return super()._run(parsed_args)
+
+    return FakeChild
+
+
+def test_extensible_command_no_callbacks(fake_extensible_cls):
+    cmd = fake_extensible_cls()
+
+    cmd.fill_parser(argparse.ArgumentParser())
+    cmd.run(argparse.Namespace())
+
+    assert cmd.get_run_count() == {"fake": 1}
+
+
+def test_extensible_command_child_no_callbacks(
+    fake_extensible_cls, fake_extensible_child
+):
+    cmd = fake_extensible_child()
+
+    cmd.fill_parser(argparse.ArgumentParser())
+
+    assert cmd.get_run_count() == {"fake": 0, "child": 0}
+
+    cmd.run(argparse.Namespace())
+
+    assert cmd.get_run_count() == {"fake": 1, "child": 1}
+    assert fake_extensible_cls.get_run_count(cmd) == {"fake": 1}
+
+
+def test_extensible_command_filler(fake_extensible_cls):
+    filler = mock.Mock(spec=base.ParserCallback)
+    parser = argparse.ArgumentParser()
+    cmd = fake_extensible_cls()
+
+    fake_extensible_cls.register_parser_filler(filler)
+
+    cmd.fill_parser(parser)
+
+    filler.assert_called_once_with(cmd, parser)
+
+
+def test_extensible_command_prologue(fake_extensible_cls):
+    prologue = mock.Mock(spec=base.RunCallback)
+    parser = argparse.ArgumentParser()
+    namespace = parser.parse_args([])
+    cmd = fake_extensible_cls()
+
+    fake_extensible_cls.register_prologue(prologue)
+
+    cmd.fill_parser(parser)
+    cmd.run(namespace)
+
+    prologue.assert_called_once_with(cmd, namespace)
+
+
+def test_extensible_command_epilogue(fake_extensible_cls):
+    epilogue = mock.Mock(spec=base.RunCallback)
+    parser = argparse.ArgumentParser()
+    namespace = parser.parse_args([])
+    cmd = fake_extensible_cls()
+
+    fake_extensible_cls.register_epilogue(epilogue)
+
+    cmd.fill_parser(parser)
+    cmd.run(namespace)
+    cmd.run(namespace)
+
+    assert epilogue.call_args_list == [
+        mock.call(cmd, namespace, current_result=1),
+        mock.call(cmd, namespace, current_result=2),
+    ]
+
+
+def test_extensible_command_parser_order(
+    capsys, fake_extensible_cls, fake_extensible_child
+):
+    fake_extensible_cls.register_parser_filler(lambda *_: print("parent", end=","))
+    fake_extensible_child.register_parser_filler(lambda *_: print("child", end=","))
+
+    fake_extensible_child().fill_parser(argparse.ArgumentParser())
+
+    stdout, stderr = capsys.readouterr()
+    assert stdout == "parent,child,"
+
+
+def test_extensible_command_prologue_order(
+    capsys, fake_extensible_cls, fake_extensible_child
+):
+    fake_extensible_cls.register_prologue(lambda *_: print("parent", end=","))
+    fake_extensible_child.register_prologue(lambda *_: print("child", end=","))
+    cmd = fake_extensible_child()
+
+    cmd.run(argparse.Namespace())
+
+    stdout, stderr = capsys.readouterr()
+    assert stdout == "parent,child,"
+
+
+def test_extensible_command_epilogue_order(
+    capsys, fake_extensible_cls, fake_extensible_child
+):
+    fake_extensible_cls.register_epilogue(lambda *_, **__: print("parent", end=","))
+    fake_extensible_child.register_epilogue(lambda *_, **__: print("child", end=","))
+    cmd = fake_extensible_child()
+
+    cmd.run(argparse.Namespace())
+
+    stdout, stderr = capsys.readouterr()
+    assert stdout == "parent,child,"
+
+
+# endregion

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -23,13 +23,13 @@ import pytest
 from craft_application.commands.lifecycle import (
     BuildCommand,
     CleanCommand,
+    LifecyclePartsCommand,
+    LifecycleStepCommand,
     OverlayCommand,
     PackCommand,
     PrimeCommand,
     PullCommand,
     StageCommand,
-    LifecyclePartsCommand,
-    LifecycleStepCommand,
     get_lifecycle_command_group,
 )
 from craft_cli import emit

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -28,8 +28,8 @@ from craft_application.commands.lifecycle import (
     PrimeCommand,
     PullCommand,
     StageCommand,
-    _LifecyclePartsCommand,
-    _LifecycleStepCommand,
+    LifecyclePartsCommand,
+    LifecycleStepCommand,
     get_lifecycle_command_group,
 )
 from craft_cli import emit
@@ -109,7 +109,7 @@ def test_get_lifecycle_command_group(enable_overlay, commands):
 def test_parts_command_fill_parser(
     app_metadata, fake_services, destructive_arg, parts_args
 ):
-    cls = get_fake_command_class(_LifecyclePartsCommand, managed=True)
+    cls = get_fake_command_class(LifecyclePartsCommand, managed=True)
     parser = argparse.ArgumentParser("parts_command")
     command = cls({"app": app_metadata, "services": fake_services})
 
@@ -130,7 +130,7 @@ def test_parts_command_fill_parser(
 def test_parts_command_get_managed_cmd(
     app_metadata, fake_services, parts, emitter_verbosity
 ):
-    cls = get_fake_command_class(_LifecyclePartsCommand, managed=True)
+    cls = get_fake_command_class(LifecyclePartsCommand, managed=True)
 
     expected = [
         app_metadata.name,
@@ -162,7 +162,7 @@ def test_step_command_fill_parser(
     shell_args,
     shell_dict,
 ):
-    cls = get_fake_command_class(_LifecycleStepCommand, managed=True)
+    cls = get_fake_command_class(LifecycleStepCommand, managed=True)
     parser = argparse.ArgumentParser("step_command")
     expected = {
         "parts": parts_args,
@@ -187,7 +187,7 @@ def test_step_command_fill_parser(
 def test_step_command_get_managed_cmd(
     app_metadata, fake_services, parts, emitter_verbosity, shell_params, shell_opts
 ):
-    cls = get_fake_command_class(_LifecycleStepCommand, managed=True)
+    cls = get_fake_command_class(LifecycleStepCommand, managed=True)
 
     expected = [
         app_metadata.name,
@@ -209,7 +209,7 @@ def test_step_command_get_managed_cmd(
 @pytest.mark.parametrize("step_name", STEP_NAMES)
 @pytest.mark.parametrize("parts", PARTS_LISTS)
 def test_step_command_run_explicit_step(app_metadata, mock_services, parts, step_name):
-    cls = get_fake_command_class(_LifecycleStepCommand, managed=True)
+    cls = get_fake_command_class(LifecycleStepCommand, managed=True)
 
     parsed_args = argparse.Namespace(parts=parts)
     command = cls({"app": app_metadata, "services": mock_services})

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -430,7 +430,7 @@ def test_pack_run_wrong_step(app_metadata, fake_services):
     )
 
     with pytest.raises(RuntimeError) as exc_info:
-        command.run(parsed_args, "wrong-command")
+        command.run(parsed_args, step_name="wrong-command")
 
     assert exc_info.value.args[0] == "Step name wrong-command passed to pack command."
 


### PR DESCRIPTION
This creates a version of commands that can be modified by the application by registering parser fillers, prologues and epilogues. Additionally, it makes the lifecycle commands versions of these.

This is needed to support charmcraft's craft-application changeover, but is kept in draft until I can test it with charmcraft.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
