### PR TITLE
build(deps): bump craft-providers to 1.20.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "craft-cli>=2.4.0",
     "craft-parts>=1.21.1",
-    "craft-providers>=1.20.0,<2.0",
+    "craft-providers>=1.20.1,<2.0",
     "pydantic>=1.10,<2.0",
     "pydantic-yaml<1.0",
     "pyxdg",


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

### Changelog

- Update base compatibility tag from ``base-v3`` to ``base-v4``
- If an existing base instance is not setup, then it is auto-cleaned.
  If the process that created the not setup base instance is inactive, then
  ``craft-providers`` will immediately auto-clean the instance.
