### PR TITLE
fix: quote field names in error messages

### DIFF
--- a/craft_application/util/error_formatting.py
+++ b/craft_application/util/error_formatting.py
@@ -54,15 +54,15 @@ def format_pydantic_error(loc: Iterable[Union[str, int]], message: str) -> str:
     field_path = _format_pydantic_error_location(loc)
     message = _format_pydantic_error_message(message)
     field_name, location = FieldLocationTuple.from_str(field_path)
+    if location != "top-level":
+        location = repr(location)
 
     if message == "field required":
-        return f"- field {field_name} required in {location} configuration"
+        return f"- field {field_name!r} required in {location} configuration"
     if message == "extra fields not permitted":
-        return f"- extra field {field_name} not permitted in {location} configuration"
+        return f"- extra field {field_name!r} not permitted in {location} configuration"
     if message == "the list has duplicated items":
-        return (
-            f"- duplicate {field_name} entry not permitted in {location} configuration"
-        )
+        return f"- duplicate {field_name!r} entry not permitted in {location} configuration"
     if field_path == "__root__":
         return f"- {message}"
     return f"- {message} (in field {field_path!r})"

--- a/tests/unit/util/test_error_formatting.py
+++ b/tests/unit/util/test_error_formatting.py
@@ -42,31 +42,35 @@ def test_field_location_tuple_from_str(loc_str, location, field):
 @pytest.mark.parametrize(
     ("field_path", "message", "expected"),
     [
-        (["foo"], "field required", "- field foo required in top-level configuration"),
+        (
+            ["foo"],
+            "field required",
+            "- field 'foo' required in top-level configuration",
+        ),
         (
             ["foo", 0, "bar"],
             "field required",
-            "- field bar required in foo[0] configuration",
+            "- field 'bar' required in 'foo[0]' configuration",
         ),
         (
             ["foo"],
             "extra fields not permitted",
-            "- extra field foo not permitted in top-level configuration",
+            "- extra field 'foo' not permitted in top-level configuration",
         ),
         (
             ["foo", 2, "bar"],
             "extra fields not permitted",
-            "- extra field bar not permitted in foo[2] configuration",
+            "- extra field 'bar' not permitted in 'foo[2]' configuration",
         ),
         (
             ["foo"],
             "the list has duplicated items",
-            "- duplicate foo entry not permitted in top-level configuration",
+            "- duplicate 'foo' entry not permitted in top-level configuration",
         ),
         (
             ["foo", 1, "bar"],
             "the list has duplicated items",
-            "- duplicate bar entry not permitted in foo[1] configuration",
+            "- duplicate 'bar' entry not permitted in 'foo[1]' configuration",
         ),
         (["__root__"], "generic error message", "- generic error message"),
         (


### PR DESCRIPTION
I'm unclear whether this would be considered a 'breaking change' since we do have several app-level tests that would need changing. I'm guessing not?

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This makes tracking the field names easier.

See: https://github.com/canonical/rockcraft/pull/440/files#r1417818696