### PR TITLE
fix: use platformdirs replace pyxdg for cache path

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any, Iterable, cast, final
 import craft_cli
 import craft_parts
 import craft_providers
-from xdg.BaseDirectory import save_cache_path  # type: ignore[import]
+from platformdirs import user_cache_path
 
 from craft_application import commands, models, secrets, util
 from craft_application.models import BuildInfo
@@ -177,12 +177,9 @@ class Application:
         self._command_groups.append(craft_cli.CommandGroup(name, commands))
 
     @property
-    def cache_dir(self) -> str:
+    def cache_dir(self) -> pathlib.Path:
         """Get the directory for caching any data."""
-        # Mypy doesn't know what type save_cache_path returns, but pyright figures
-        # it out correctly. We can remove this ignore comment once the typeshed has
-        # xdg types: https://github.com/python/typeshed/pull/10163
-        return save_cache_path(self.app.name)  # type: ignore[no-any-return]
+        return user_cache_path(self.app.name, ensure_exists=True)
 
     def _configure_services(
         self,

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -35,6 +35,10 @@ class ProjectFileMissingError(CraftError, FileNotFoundError):
     """Error finding project file."""
 
 
+class PathInvalidError(CraftError, OSError):
+    """Error that the given path is not usable."""
+
+
 class CraftValidationError(CraftError):
     """Error validating project yaml."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ dependencies = [
     "craft-cli>=2.4.0",
     "craft-parts>=1.21.1",
     "craft-providers>=1.20.0,<2.0",
+    "platformdirs",
     "pydantic>=1.10,<2.0",
     "pydantic-yaml<1.0",
-    "pyxdg",
     "PyYaml>=6.0",
     "typing_extensions>=4.4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "craft-cli>=2.4.0",
     "craft-parts>=1.21.1",
     "craft-providers>=1.20.0,<2.0",
-    "platformdirs",
+    "platformdirs>=3.10",
     "pydantic>=1.10,<2.0",
     "pydantic-yaml<1.0",
     "PyYaml>=6.0",

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -627,16 +627,14 @@ def test_get_project_other_dir(monkeypatch, tmp_path, app, fake_project_file):
 
 def test_get_cache_dir(tmp_path, app):
     """Test that the cache dir is created and returned."""
-    with mock.patch("xdg.BaseDirectory.xdg_cache_home", str(tmp_path / "cache")):
-        assert app.cache_dir == str(tmp_path / "cache" / "testcraft")
+    with mock.patch.dict("os.environ", {"XDG_CACHE_HOME": str(tmp_path / "cache")}):
+        assert app.cache_dir == tmp_path / "cache" / "testcraft"
+        assert app.cache_dir.is_dir()
 
 
 def test_get_cache_dir_exists(tmp_path, app):
     """Test that the cache dir is returned when already exists."""
-    # This currently fails with pyxdg, [Errno 17] File exists
     (tmp_path / "cache" / "testcraft").mkdir(parents=True, exist_ok=True)
-    with mock.patch("xdg.BaseDirectory.xdg_cache_home", str(tmp_path / "cache")):
-        # Race condition here, that is in shared environment
-        with mock.patch("os.path.isdir") as isdir:
-            isdir.return_value = False
-            assert app.cache_dir == str(tmp_path / "cache" / "testcraft")
+    with mock.patch.dict("os.environ", {"XDG_CACHE_HOME": str(tmp_path / "cache")}):
+        assert app.cache_dir == tmp_path / "cache" / "testcraft"
+        assert app.cache_dir.is_dir()

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -638,3 +638,24 @@ def test_get_cache_dir_exists(tmp_path, app):
     with mock.patch.dict("os.environ", {"XDG_CACHE_HOME": str(tmp_path / "cache")}):
         assert app.cache_dir == tmp_path / "cache" / "testcraft"
         assert app.cache_dir.is_dir()
+
+
+def test_get_cache_dir_is_file(tmp_path, app):
+    """Test that the cache dir path is not valid when it is a file."""
+    (tmp_path / "cache").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "cache" / "testcraft").write_text("test")
+    with mock.patch.dict("os.environ", {"XDG_CACHE_HOME": str(tmp_path / "cache")}):
+        with pytest.raises(application.PathInvalidError, match="is not a directory"):
+            assert app.cache_dir == tmp_path / "cache" / "testcraft"
+
+
+def test_get_cache_dir_parent_read_only(tmp_path, app):
+    """Test that the cache dir path is not valid when its parent is read-only."""
+    (tmp_path / "cache").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "cache").chmod(0o400)
+    with mock.patch.dict("os.environ", {"XDG_CACHE_HOME": str(tmp_path / "cache")}):
+        with pytest.raises(
+            application.PathInvalidError,
+            match="Unable to create/access cache directory: Permission denied",
+        ):
+            assert app.cache_dir == tmp_path / "cache" / "testcraft"

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -623,3 +623,20 @@ def test_get_project_other_dir(monkeypatch, tmp_path, app, fake_project_file):
 
     assert app.get_project(fake_project_file.parent) is project
     assert app.get_project() is project
+
+
+def test_get_cache_dir(tmp_path, app):
+    """Test that the cache dir is created and returned."""
+    with mock.patch("xdg.BaseDirectory.xdg_cache_home", str(tmp_path / "cache")):
+        assert app.cache_dir == str(tmp_path / "cache" / "testcraft")
+
+
+def test_get_cache_dir_exists(tmp_path, app):
+    """Test that the cache dir is returned when already exists."""
+    # This currently fails with pyxdg, [Errno 17] File exists
+    (tmp_path / "cache" / "testcraft").mkdir(parents=True, exist_ok=True)
+    with mock.patch("xdg.BaseDirectory.xdg_cache_home", str(tmp_path / "cache")):
+        # Race condition here, that is in shared environment
+        with mock.patch("os.path.isdir") as isdir:
+            isdir.return_value = False
+            assert app.cache_dir == str(tmp_path / "cache" / "testcraft")


### PR DESCRIPTION
Solve a race condition issue when creating dir under pyxdg.

Notice that `cache_dir` is now return `Path` not `str`.

Fixes: #167 