### PR TITLE
feat(plugins): support register plugins

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -124,21 +124,6 @@ class Application:
         # ``get_project`` to access the project.
         self.__project: models.Project | None = None
 
-        # Set the logging level to DEBUG for all craft-libraries. This is OK even if
-        # the specific application doesn't use a specific library, the call does not
-        # import the package.
-        util.setup_loggers(*self._cli_loggers)
-
-        craft_cli.emit.init(
-            mode=craft_cli.EmitterMode.BRIEF,
-            appname=self.app.name,
-            greeting=f"Starting {self.app.name}, version {self.app.version}",
-            log_filepath=self.log_path,
-            streaming_brief=True,
-        )
-
-        self._register_default_plugins()
-
         if self.is_managed():
             self._work_dir = pathlib.Path("/root")
         else:
@@ -391,6 +376,8 @@ class Application:
 
     def run(self) -> int:  # noqa: PLR0912 (too many branches due to error handling)
         """Bootstrap and run the application."""
+        self._setup_logging()
+        self._register_default_plugins()
         dispatcher = self._get_dispatcher()
         craft_cli.emit.trace("Preparing application...")
 
@@ -534,6 +521,21 @@ class Application:
         Note: subclasses should return a new dict and keep the parameter unmodified.
         """
         return yaml_data
+
+    def _setup_logging(self) -> None:
+        """Initialize the logging system."""
+        # Set the logging level to DEBUG for all craft-libraries. This is OK even if
+        # the specific application doesn't use a specific library, the call does not
+        # import the package.
+        util.setup_loggers(*self._cli_loggers)
+
+        craft_cli.emit.init(
+            mode=craft_cli.EmitterMode.BRIEF,
+            appname=self.app.name,
+            greeting=f"Starting {self.app.name}, version {self.app.version}",
+            log_filepath=self.log_path,
+            streaming_brief=True,
+        )
 
 
 def _filter_plan(

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -124,6 +124,19 @@ class Application:
         # ``get_project`` to access the project.
         self.__project: models.Project | None = None
 
+        # Set the logging level to DEBUG for all craft-libraries. This is OK even if
+        # the specific application doesn't use a specific library, the call does not
+        # import the package.
+        util.setup_loggers(*self._cli_loggers)
+
+        craft_cli.emit.init(
+            mode=craft_cli.EmitterMode.BRIEF,
+            appname=self.app.name,
+            greeting=f"Starting {self.app.name}, version {self.app.version}",
+            log_filepath=self.log_path,
+            streaming_brief=True,
+        )
+
         self._register_default_plugins()
 
         if self.is_managed():
@@ -307,19 +320,6 @@ class Application:
 
         :returns: A ready-to-run Dispatcher object
         """
-        # Set the logging level to DEBUG for all craft-libraries. This is OK even if
-        # the specific application doesn't use a specific library, the call does not
-        # import the package.
-        util.setup_loggers(*self._cli_loggers)
-
-        craft_cli.emit.init(
-            mode=craft_cli.EmitterMode.BRIEF,
-            appname=self.app.name,
-            greeting=f"Starting {self.app.name}, version {self.app.version}",
-            log_filepath=self.log_path,
-            streaming_brief=True,
-        )
-
         dispatcher = craft_cli.Dispatcher(
             self.app.name,
             self.command_groups,
@@ -386,11 +386,8 @@ class Application:
         craft_parts.plugins.register(plugins)
 
     def _register_default_plugins(self) -> None:
-        """Register default + per application plugins when initializing."""
-        default_plugins: dict[str, PluginType] = {}
-        plugins = {**default_plugins, **self._get_app_plugins()}
-
-        self.register_plugins(plugins)
+        """Register per application plugins when initializing."""
+        self.register_plugins(self._get_app_plugins())
 
     def run(self) -> int:  # noqa: PLR0912 (too many branches due to error handling)
         """Bootstrap and run the application."""

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -343,7 +343,7 @@ def test_craft_lib_log_level(app_metadata, fake_services):
 
     app = FakeApplication(app_metadata, fake_services)
     with pytest.raises(SystemExit):
-        app._get_dispatcher()
+        app.run()
 
     for craft_lib in craft_libs:
         logger = logging.getLogger(craft_lib)
@@ -369,7 +369,7 @@ def test_show_app_name_and_version(monkeypatch, capsys, app):
     monkeypatch.setattr(sys, "argv", ["testcraft", "--verbosity=trace"])
 
     with pytest.raises(SystemExit):
-        app._get_dispatcher()
+        app.run()
 
     _, err = capsys.readouterr()
     assert f"Starting testcraft, version {app.app.version}" in err
@@ -707,7 +707,10 @@ def test_register_plugins(mocker, app_metadata, fake_services):
         def _get_app_plugins(self):
             return {"fake": FakePlugin}
 
-    FakeApplicationWithPlugins(app_metadata, fake_services)
+    app = FakeApplicationWithPlugins(app_metadata, fake_services)
+
+    with pytest.raises(SystemExit):
+        app.run()
 
     assert reg.call_count == 1
     assert reg.call_args[0][0] == {"fake": FakePlugin}

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -720,6 +720,8 @@ def test_register_plugins_default(mocker, app_metadata, fake_services):
     """Test that the App registers default plugins when initialing."""
     reg = mocker.patch("craft_parts.plugins.register")
 
-    FakeApplication(app_metadata, fake_services)
+    app = FakeApplication(app_metadata, fake_services)
+    with pytest.raises(SystemExit):
+        app.run()
 
     assert reg.call_count == 0

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -332,7 +332,7 @@ def test_get_dispatcher_error(
     check.is_true(re.fullmatch(message, captured.err), captured.err)
 
 
-def test_craft_lib_log_level(app):
+def test_craft_lib_log_level(app_metadata, fake_services):
     craft_libs = ["craft_archives", "craft_parts", "craft_providers", "craft_store"]
 
     # The logging module is stateful and global, so first lets clear the logging level
@@ -341,6 +341,7 @@ def test_craft_lib_log_level(app):
         logger = logging.getLogger(craft_lib)
         logger.setLevel(logging.NOTSET)
 
+    app = FakeApplication(app_metadata, fake_services)
     with pytest.raises(SystemExit):
         app._get_dispatcher()
 


### PR DESCRIPTION
This allowed applications to register their own plugins beside the default plugins when initializing the app. Defined in `_get_app_plugins()`.

This also allowed app to ondemond register plugins by call `app.register_plugins(plugins)`.
