### PR TITLE
feat: support control parallel build count from env

### DIFF
--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -117,3 +117,12 @@ class InvalidPlatformError(CraftError):
         details = f"Valid platforms are: {', '.join(all_platforms)}."
 
         super().__init__(message=message, details=details)
+
+
+class InvalidParameterError(CraftError):
+    """Invalid parameter or environment variable."""
+
+    def __init__(self, parameter: str, value: str) -> None:
+        message = f"Value '{value}' is invalid for parameter {parameter!r}."
+
+        super().__init__(message=message)

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -268,10 +268,46 @@ class LifecycleService(base.ProjectService):
             f"{work_dir=}, {cache_dir=}, {build_for=}, **{self._manager_kwargs!r})"
         )
 
-    def _get_parallel_build_count(self) -> int:  # noqa: PLR0912
-        """Get the number of parallel builds to run."""
+    def _verify_parallel_build_count(
+        self, env_name: str, parallel_build_count: int | str
+    ) -> int:
+        """Verify the parallel build count is valid.
+
+        :param env_name: The name of the environment variable being checked.
+        :param parallel_build_count: The value of the variable.
+        :return: The parallel build count as an integer.
+        """
+        try:
+            parallel_build_count = int(parallel_build_count)
+        except ValueError as err:
+            raise errors.InvalidParameterError(
+                env_name, str(os.environ[env_name])
+            ) from err
+
+        # Ensure the value is valid positive integer
+        if parallel_build_count < 1:
+            raise errors.InvalidParameterError(env_name, str(parallel_build_count))
+
+        return parallel_build_count
+
+    def _get_parallel_build_count(self) -> int:
+        """Get the number of parallel builds to run.
+
+        The parallel build count is determined by the first available of the
+        following environment variables in the order:
+
+        - <APP_NAME>_PARALLEL_BUILD_COUNT
+        - CRAFT_PARALLEL_BUILD_COUNT
+        - <APP_NAME>_MAX_PARALLEL_BUILD_COUNT
+        - CRAFT_MAX_PARALLEL_BUILD_COUNT
+
+        where the MAX_PARALLEL_BUILD_COUNT variables are dynamically compared to
+        the number of CPUs, and the smaller of the two is used.
+
+        If no environment variable is set, the CPU count is used.
+        If the CPU count is not available for some reason, 1 is used as a fallback.
+        """
         parallel_build_count = None
-        effect_env_name = "PARALLEL BUILD COUNT"
 
         # fixed parallel build count environment variable
         for env_name in [
@@ -279,49 +315,41 @@ class LifecycleService(base.ProjectService):
             "CRAFT_PARALLEL_BUILD_COUNT",
         ]:
             if os.environ.get(env_name):
-                try:
-                    parallel_build_count = int(os.environ[env_name])
-                except ValueError as err:
-                    raise errors.InvalidParameterError(
-                        env_name, str(os.environ[env_name])
-                    ) from err
-
-                effect_env_name = env_name
+                parallel_build_count = self._verify_parallel_build_count(
+                    env_name, os.environ[env_name]
+                )
+                emit.debug(
+                    f"Using parallel build count of {parallel_build_count} "
+                    f"from environment variable {env_name!r}"
+                )
                 break
 
         # CPU count related max parallel build count environment variable
         if parallel_build_count is None:
-            cpu_count = os.cpu_count()
-            if cpu_count:
-                for env_name in [
-                    (self._app.name + "_MAX_PARALLEL_BUILD_COUNT").upper(),
-                    "CRAFT_MAX_PARALLEL_BUILD_COUNT",
-                ]:
-                    if os.environ.get(env_name):
-                        try:
-                            parallel_build_count = min(
-                                int(os.environ[env_name]), cpu_count
-                            )
-                        except ValueError as err:
-                            raise errors.InvalidParameterError(
-                                env_name, str(os.environ[env_name])
-                            ) from err
+            cpu_count = os.cpu_count() or 1
+            for env_name in [
+                (self._app.name + "_MAX_PARALLEL_BUILD_COUNT").upper(),
+                "CRAFT_MAX_PARALLEL_BUILD_COUNT",
+            ]:
+                if os.environ.get(env_name):
+                    parallel_build_count = min(
+                        cpu_count,
+                        self._verify_parallel_build_count(
+                            env_name, os.environ[env_name]
+                        ),
+                    )
+                    emit.debug(
+                        f"Using parallel build count of {parallel_build_count} "
+                        f"from environment variable {env_name!r}"
+                    )
+                    break
 
-                        effect_env_name = env_name
-                        break
-
-                # Default to CPU count if no max environment variable is set
-                if parallel_build_count is None:
-                    parallel_build_count = cpu_count
-
-        # Default to 1 if no environment variable is set and CPU count is not available
-        if parallel_build_count is None:
-            return 1
-
-        # Ensure the value is valid positive integer
-        if parallel_build_count < 1:
-            raise errors.InvalidParameterError(
-                effect_env_name, str(parallel_build_count)
-            )
+            # Default to CPU count if no max environment variable is set
+            if parallel_build_count is None:
+                parallel_build_count = cpu_count
+                emit.debug(
+                    f"Using parallel build count of {parallel_build_count} "
+                    "from CPU count"
+                )
 
         return parallel_build_count

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import types
 from typing import TYPE_CHECKING, Any
 
@@ -169,6 +170,7 @@ class LifecycleService(base.ProjectService):
                 cache_dir=self._cache_dir,
                 work_dir=self._work_dir,
                 ignore_local_sources=self._app.source_ignore_patterns,
+                parallel_build_count=self._get_parallel_build_count(),
                 **self._manager_kwargs,
             )
         except PartsError as err:
@@ -265,3 +267,61 @@ class LifecycleService(base.ProjectService):
             f"{self.__class__.__name__}({self._app!r}, {self._project!r}, "
             f"{work_dir=}, {cache_dir=}, {build_for=}, **{self._manager_kwargs!r})"
         )
+
+    def _get_parallel_build_count(self) -> int:  # noqa: PLR0912
+        """Get the number of parallel builds to run."""
+        parallel_build_count = None
+        effect_env_name = "PARALLEL BUILD COUNT"
+
+        # fixed parallel build count environment variable
+        for env_name in [
+            (self._app.name + "_PARALLEL_BUILD_COUNT").upper(),
+            "CRAFT_PARALLEL_BUILD_COUNT",
+        ]:
+            if os.environ.get(env_name):
+                try:
+                    parallel_build_count = int(os.environ[env_name])
+                except ValueError as err:
+                    raise errors.InvalidParameterError(
+                        env_name, str(os.environ[env_name])
+                    ) from err
+
+                effect_env_name = env_name
+                break
+
+        # CPU count related max parallel build count environment variable
+        if parallel_build_count is None:
+            cpu_count = os.cpu_count()
+            if cpu_count:
+                for env_name in [
+                    (self._app.name + "_MAX_PARALLEL_BUILD_COUNT").upper(),
+                    "CRAFT_MAX_PARALLEL_BUILD_COUNT",
+                ]:
+                    if os.environ.get(env_name):
+                        try:
+                            parallel_build_count = min(
+                                int(os.environ[env_name]), cpu_count
+                            )
+                        except ValueError as err:
+                            raise errors.InvalidParameterError(
+                                env_name, str(os.environ[env_name])
+                            ) from err
+
+                        effect_env_name = env_name
+                        break
+
+                # Default to CPU count if no max environment variable is set
+                if parallel_build_count is None:
+                    parallel_build_count = cpu_count
+
+        # Default to 1 if no environment variable is set and CPU count is not available
+        if parallel_build_count is None:
+            return 1
+
+        # Ensure the value is valid positive integer
+        if parallel_build_count < 1:
+            raise errors.InvalidParameterError(
+                effect_env_name, str(parallel_build_count)
+            )
+
+        return parallel_build_count

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -25,7 +25,7 @@ import craft_parts.callbacks
 import pytest
 import pytest_check
 from craft_application import util
-from craft_application.errors import PartsLifecycleError
+from craft_application.errors import InvalidParameterError, PartsLifecycleError
 from craft_application.services import lifecycle
 from craft_application.util import get_host_architecture, repositories
 from craft_parts import (
@@ -447,6 +447,160 @@ def test_lifecycle_package_repositories(
 
     mock_install.assert_called_once_with(fake_repositories, service._lcm)
     mock_callback.assert_called_once_with(repositories.install_overlay_repositories)
+
+
+# endregion
+
+# region parallel build count tests
+
+
+@pytest.mark.parametrize(
+    ("env_dict", "cpu_count", "expected"),
+    [
+        (
+            {},
+            None,
+            1,
+        ),
+        (
+            {},
+            100,
+            100,
+        ),
+        (
+            {"TESTCRAFT_PARALLEL_BUILD_COUNT": "100"},
+            1,
+            100,
+        ),
+        (
+            {"CRAFT_PARALLEL_BUILD_COUNT": "200"},
+            1,
+            200,
+        ),
+        (
+            {
+                "TESTCRAFT_MAX_PARALLEL_BUILD_COUNT": "100",
+            },
+            50,
+            50,
+        ),
+        (
+            {
+                "CRAFT_MAX_PARALLEL_BUILD_COUNT": "100",
+            },
+            80,
+            80,
+        ),
+        (
+            {
+                "TESTCRAFT_PARALLEL_BUILD_COUNT": "100",
+                "CRAFT_PARALLEL_BUILD_COUNT": "200",
+            },
+            1,
+            100,
+        ),
+        (
+            {
+                "TESTCRAFT_MAX_PARALLEL_BUILD_COUNT": "100",
+                "CRAFT_MAX_PARALLEL_BUILD_COUNT": "200",
+            },
+            150,
+            100,
+        ),
+        (
+            {
+                "TESTCRAFT_MAX_PARALLEL_BUILD_COUNT": "100",
+                "CRAFT_MAX_PARALLEL_BUILD_COUNT": "200",
+            },
+            None,
+            1,
+        ),
+        (
+            {
+                "TESTCRAFT_PARALLEL_BUILD_COUNT": "100",
+                "CRAFT_PARALLEL_BUILD_COUNT": "200",
+                "TESTCRAFT_MAX_PARALLEL_BUILD_COUNT": "300",
+                "CRAFT_MAX_PARALLEL_BUILD_COUNT": "400",
+            },
+            150,
+            100,
+        ),
+    ],
+)
+def test_get_parallel_build_count(
+    monkeypatch, mocker, fake_parts_lifecycle, env_dict, cpu_count, expected
+):
+    mocker.patch("os.cpu_count", return_value=cpu_count)
+    for env_dict_key, env_dict_value in env_dict.items():
+        monkeypatch.setenv(env_dict_key, env_dict_value)
+
+    assert fake_parts_lifecycle._get_parallel_build_count() == expected
+
+
+@pytest.mark.parametrize(
+    ("env_dict", "cpu_count"),
+    [
+        (
+            {
+                "TESTCRAFT_PARALLEL_BUILD_COUNT": "abc",
+            },
+            1,
+        ),
+        (
+            {
+                "CRAFT_PARALLEL_BUILD_COUNT": "-",
+            },
+            1,
+        ),
+        (
+            {
+                "TESTCRAFT_MAX_PARALLEL_BUILD_COUNT": "*",
+            },
+            1,
+        ),
+        (
+            {
+                "CRAFT_MAX_PARALLEL_BUILD_COUNT": "$COUNT",
+            },
+            1,
+        ),
+        (
+            {
+                "TESTCRAFT_PARALLEL_BUILD_COUNT": "0",
+            },
+            1,
+        ),
+        (
+            {
+                "CRAFT_PARALLEL_BUILD_COUNT": "-1",
+            },
+            1,
+        ),
+        (
+            {
+                "TESTCRAFT_MAX_PARALLEL_BUILD_COUNT": "5.6",
+            },
+            1,
+        ),
+        (
+            {
+                "CRAFT_MAX_PARALLEL_BUILD_COUNT": "inf",
+            },
+            1,
+        ),
+    ],
+)
+def test_get_parallel_build_count_error(
+    monkeypatch, mocker, fake_parts_lifecycle, env_dict, cpu_count
+):
+    mocker.patch("os.cpu_count", return_value=cpu_count)
+    for env_dict_key, env_dict_value in env_dict.items():
+        monkeypatch.setenv(env_dict_key, env_dict_value)
+
+    with pytest.raises(
+        InvalidParameterError, match=r"^Value '.*' is invalid for parameter '.*'.$"
+    ):
+        fake_parts_lifecycle._get_parallel_build_count()
 
 
 # endregion


### PR DESCRIPTION
Support use the following environment variables to control the parrallel build count:

Use
`<appname>_PARALLEL_BUILD_COUNT`
`CRAFT_PARALLEL_BUILD_COUNT`
to set to a fixed value.

Use
`<appname>_MAX_PARALLEL_BUILD_COUNT`
`CRAFT_MAX_PARALLEL_BUILD_COUNT`
to set to a dynamic value based on cpu count and max value.

By default it will use the current CPU count value to the parrallel build count.

Fixes: https://github.com/canonical/craft-application/issues/180
