### PR TITLE
feat: request service

### DIFF
--- a/craft_application/services/__init__.py
+++ b/craft_application/services/__init__.py
@@ -19,6 +19,7 @@ from craft_application.services.base import AppService, ProjectService
 from craft_application.services.lifecycle import LifecycleService
 from craft_application.services.package import PackageService
 from craft_application.services.provider import ProviderService
+from craft_application.services.request import RequestService
 from craft_application.services.service_factory import ServiceFactory
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "LifecycleService",
     "PackageService",
     "ProviderService",
+    "RequestService",
     "ServiceFactory",
 ]

--- a/craft_application/services/request.py
+++ b/craft_application/services/request.py
@@ -1,0 +1,113 @@
+#  This file is part of craft-application.
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Service class for network requests."""
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING
+
+import craft_cli
+import requests
+
+from craft_application import util
+from craft_application.services import base, service_factory
+
+if TYPE_CHECKING:
+    from craft_application.application import AppMetadata
+
+
+class RequestService(base.AppService):
+    """A service for handling network requests."""
+
+    def __init__(
+        self, app: AppMetadata, services: service_factory.ServiceFactory
+    ) -> None:
+        super().__init__(app, services)
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = f"{self._app.name}/{self._app.version}"
+
+        # Passthroughs for requests methods so other services can use the session.
+        self.request = self._session.request
+        self.delete = self._session.delete
+        self.get = self._session.get
+        self.head = self._session.head
+        self.options = self._session.options
+        self.patch = self._session.patch
+        self.post = self._session.post
+        self.put = self._session.put
+
+    def download_chunks(self, url: str, dest: pathlib.Path) -> Iterator[int]:
+        """Download a file.
+
+        :param url: The source URL of the file.
+        :param dest: The destination. Either a directory or a file.
+        :yields: First the length in bytes of the file (or -1 if unknown), then the
+            size of each downloaded chunk.
+        """
+        if dest.is_dir():
+            filename = util.get_filename_from_url_path(url)
+            dest = dest / filename
+
+        with self.get(url, stream=True) as download:
+            with dest.open("wb") as file:
+                yield int(download.headers.get("Content-Length", -1))
+                for chunk in download.iter_content(None):
+                    file.write(chunk)
+                    yield len(chunk)
+
+    def download_with_progress(self, url: str, dest: pathlib.Path) -> pathlib.Path:
+        """Download a single file with a progress bar."""
+        return self.download_files_with_progress({url: dest})[url]
+
+    def download_files_with_progress(
+        self, files: Mapping[str, pathlib.Path]
+    ) -> Mapping[str, pathlib.Path]:
+        """Download a set of files to `dest_dir` from various URLs, with a progress bar.
+
+        :param files: A mapping of urls to their destination files or directories
+        :returns: The files mapping, updated with the actual file paths.
+        """
+        if not files:
+            return {}
+        files = dict(files)
+        downloads: set[Iterator[int]] = set()
+
+        for url, path in files.items():
+            filename = util.get_filename_from_url_path(url)
+            if path.is_dir():
+                path = files[url] = path / filename  # noqa: PLW2901
+            downloads.add(self.download_chunks(url, path))
+
+        if len(files) == 1:
+            title = f"Downloading {next(iter(files))}"
+        else:
+            title = f"Downloading {len(files)} files"
+
+        sizes = [next(dl) for dl in downloads]
+        total_size = sum(size for size in sizes if size > 0)
+
+        with craft_cli.emit.progress_bar(title, total_size) as progress:
+            while downloads:
+                for dl in downloads.copy():
+                    try:
+                        chunk_size = next(dl)
+                    except StopIteration:
+                        downloads.remove(dl)
+                    else:
+                        progress.advance(chunk_size)
+
+        return files

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -17,7 +17,7 @@
 
 from craft_application.util.callbacks import get_unique_callbacks
 from craft_application.util.logging import setup_loggers
-from craft_application.util.paths import get_managed_logpath
+from craft_application.util.paths import get_filename_from_url_path, get_managed_logpath
 from craft_application.util.platforms import (
     get_host_architecture,
     convert_architecture_deb_to_platform,
@@ -27,6 +27,7 @@ from craft_application.util.yaml import dump_yaml, safe_yaml_load
 __all__ = [
     "get_unique_callbacks",
     "setup_loggers",
+    "get_filename_from_url_path",
     "get_managed_logpath",
     "get_host_architecture",
     "convert_architecture_deb_to_platform",

--- a/craft_application/util/paths.py
+++ b/craft_application/util/paths.py
@@ -1,6 +1,6 @@
 # This file is part of craft_application.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import pathlib
+import urllib.parse
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -32,3 +33,8 @@ def get_managed_logpath(app: AppMetadata) -> pathlib.PosixPath:
     return pathlib.PosixPath(
         f"/tmp/{app.name}.log"  # noqa: S108 - only applies inside managed instance.
     )
+
+
+def get_filename_from_url_path(url: str) -> str:
+    """Get just the filename of a URL path."""
+    return pathlib.PurePosixPath(urllib.parse.urlparse(url).path).name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "pytest-cov==4.1.0",
     "pytest-mock==3.12.0",
     "pytest-rerunfailures==13.0",
+    "responses~=0.24.1",
 ]
 lint = [
     "black~=24.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,12 @@ def lifecycle_service(
     return service
 
 
+@pytest.fixture()
+def request_service(app_metadata, fake_services) -> services.RequestService:
+    """A working version of the requests service."""
+    return services.RequestService(app=app_metadata, services=fake_services)
+
+
 @pytest.fixture(params=list(EmitterMode))
 def emitter_verbosity(request):
     reset_verbosity = emit.get_mode()

--- a/tests/integration/services/test_request.py
+++ b/tests/integration/services/test_request.py
@@ -1,0 +1,45 @@
+#  This file is part of craft-application.
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for the Request service."""
+import hashlib
+from unittest.mock import call
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("url", "checksum", "size"),
+    [
+        pytest.param(
+            # A real build log.
+            "https://launchpad.net/~charmcraft-team/charmcraft/+snap/charmcraft-edge/+build/2377699/+files/buildlog_snap_ubuntu_jammy_armhf_charmcraft-edge_BUILDING.txt.gz",
+            # The hash of the plain text file (uncompressed)
+            "1f3b5ac763cf6885c26965f8d559bca6e8a6b2d2b2ce1f8935628647f57a0c0a",
+            29595,  # Size of the compressed file.
+            id="real-logfile",
+        )
+    ],
+)
+def test_get_real_file(tmp_path, emitter, request_service, url, checksum, size):
+    result = request_service.download_with_progress(url, tmp_path)
+    actual_hash = hashlib.sha256(result.read_bytes()).hexdigest()
+
+    assert actual_hash == checksum
+    emitter.assert_interactions(
+        [
+            call("progress_bar", f"Downloading {url}", size),
+        ]
+    )

--- a/tests/unit/services/test_request.py
+++ b/tests/unit/services/test_request.py
@@ -1,0 +1,109 @@
+#  This file is part of craft-application.
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the Request service."""
+from unittest.mock import call
+
+import craft_cli.pytest_plugin
+import pytest
+import pytest_check
+import responses
+from hypothesis import HealthCheck, given, settings, strategies
+
+
+@responses.activate
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(data=strategies.binary())
+def test_download_chunks(tmp_path, request_service, data):
+    responses.add(
+        responses.GET,
+        "http://example/file",
+        body=data,
+        headers={"Content-Length": str(len(data))},
+    )
+    output_file = tmp_path / "file"
+
+    downloader = request_service.download_chunks("http://example/file", output_file)
+    size = next(downloader)
+    dl_size = sum(downloader)
+
+    pytest_check.equal(int(size), len(data), "Downloaded size is incorrect")
+    pytest_check.equal(dl_size, len(data), "Downloaded size is incorrect")
+    pytest_check.equal(output_file.read_bytes(), data, "Download data is incorrect")
+
+    downloader = request_service.download_chunks("http://example/file", tmp_path)
+    size = next(downloader)
+    dl_size = sum(downloader)
+
+    pytest_check.equal(int(size), len(data), "Downloaded size is incorrect")
+    pytest_check.equal(dl_size, len(data), "Downloaded size is incorrect")
+    pytest_check.equal(output_file.read_bytes(), data, "Download data is incorrect")
+
+
+@responses.activate
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(data=strategies.binary(min_size=1))
+def test_download_with_progress(
+    tmp_path, emitter: craft_cli.pytest_plugin.RecordingEmitter, request_service, data
+):
+    emitter.interactions = []  # Reset the emitter so we can re-run with hypothesis.
+    responses.add(
+        responses.GET,
+        "http://example/file",
+        body=data,
+        headers={"Content-Length": str(len(data))},
+    )
+    output_file = tmp_path / "file"
+
+    request_service.download_with_progress("http://example/file", tmp_path)
+
+    pytest_check.equal(output_file.read_bytes(), data, "Download data is incorrect")
+    emitter.assert_interactions(
+        [
+            call("progress_bar", "Downloading http://example/file", len(data)),
+            call("advance", len(data)),
+        ]
+    )
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    "downloads",
+    [
+        {
+            "http://example/file": b"abc",
+            "https://localhost/file.py": b"#!/usr/bin/env python3\nprint('hi')",
+        },
+    ],
+)
+def test_download_files_with_progress(tmp_path, emitter, request_service, downloads):
+    files = {url: tmp_path for url in downloads}
+    for url, data in downloads.items():
+        responses.add(
+            responses.GET, url, body=data, headers={"Content-Length": str(len(data))}
+        )
+
+    results = request_service.download_files_with_progress(files)
+
+    assert emitter.interactions[0] == call(
+        "progress_bar",
+        f"Downloading {len(downloads)} files",
+        sum(len(dl) for dl in downloads.values()),
+    )
+    for file in downloads.values():
+        assert call("advance", len(file)) in emitter.interactions
+
+    for url, path in results.items():
+        assert path.read_bytes() == downloads[url]

--- a/tests/unit/services/test_request.py
+++ b/tests/unit/services/test_request.py
@@ -83,6 +83,7 @@ def test_download_with_progress(
     "downloads",
     [
         {
+            "http://example/empty.txt": b"",
             "http://example/file": b"abc",
             "https://localhost/file.py": b"#!/usr/bin/env python3\nprint('hi')",
         },
@@ -103,7 +104,8 @@ def test_download_files_with_progress(tmp_path, emitter, request_service, downlo
         sum(len(dl) for dl in downloads.values()),
     )
     for file in downloads.values():
-        assert call("advance", len(file)) in emitter.interactions
+        if len(file) > 0:  # Advance doesn't get called on empty files
+            assert call("advance", len(file)) in emitter.interactions
 
     for url, path in results.items():
         assert path.read_bytes() == downloads[url]

--- a/tests/unit/util/test_paths.py
+++ b/tests/unit/util/test_paths.py
@@ -16,7 +16,10 @@
 """Tests for internal path utilities."""
 import pathlib
 
+import pytest
 from craft_application import util
+from craft_application.util.paths import get_filename_from_url_path
+from hypothesis import given, provisional
 
 
 def test_get_managed_logpath(app_metadata):
@@ -24,3 +27,20 @@ def test_get_managed_logpath(app_metadata):
 
     assert isinstance(logpath, pathlib.PosixPath)
     assert str(logpath) == "/tmp/testcraft.log"
+
+
+@given(url=provisional.urls())
+def test_get_filename_from_url_path(url):
+    """Test that it works with hypothesis-generated URLs"""
+    get_filename_from_url_path(url)
+
+
+@pytest.mark.parametrize(
+    ("url", "filename"),
+    [
+        ("http://localhost/some/file.html?thing=stuff#anchor", "file.html"),
+        ("http://localhost", ""),
+    ],
+)
+def test_get_filename_from_url_path_correct(url, filename):
+    assert get_filename_from_url_path(url) == filename


### PR DESCRIPTION
This service wraps Requests and adds some convenience functions methods. It's used by the remote build service, but can be used any time one might need requests.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
