### PR TITLE
fix: allow project names to start with multiple digits

### DIFF
--- a/craft_application/models/constraints.py
+++ b/craft_application/models/constraints.py
@@ -33,7 +33,7 @@ class ProjectName(ConstrainedStr):
     max_length = 40
     strict = True
     strip_whitespace = True
-    regex = re.compile(r"^([a-z0-9][a-z0-9-]?)?[a-z]+([a-z0-9-]?[a-z0-9])*$")
+    regex = re.compile(r"^([a-z0-9][a-z0-9-]?)*[a-z]+([a-z0-9-]?[a-z0-9])*$")
 
 
 MESSAGE_INVALID_NAME = (

--- a/tests/unit/models/test_constraints.py
+++ b/tests/unit/models/test_constraints.py
@@ -88,6 +88,8 @@ def test_valid_project_name_hypothesis(name):
     [
         "purealpha",
         "0start-and-end-numeric9",
+        "0123start-with-multiple-digits",
+        "end-with-multiple-digits6789",
         *(
             pytest.param(letter, id=f"single-letter-{letter}")
             for letter in ascii_lowercase


### PR DESCRIPTION
This was always supposed to be allowed. Found while updating snapcraft.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
