### PR TITLE
build: broaden pygit2 dependency to include 1.14

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:base"],
+  ignoreDeps: [
+    "pygit2",  //This needs to be done manually. See pyproject.toml for more details.
+  ],
   labels: ["dependencies"],  // For convenient searching in GitHub
   pip_requirements: {
     fileMatch: ["^tox.ini$", "(^|/)requirements([\\w-]*)\\.txt$"]

--- a/craft_application/remote/git.py
+++ b/craft_application/remote/git.py
@@ -69,7 +69,7 @@ def get_git_repo_type(path: Path) -> GitType:
     :returns: GitType
     """
     if is_repo(path):
-        repo = pygit2.Repository(path)
+        repo = pygit2.Repository(path.as_posix())
         if repo.is_shallow:
             return GitType.SHALLOW
         return GitType.NORMAL
@@ -121,7 +121,7 @@ class GitRepo:
         if not is_repo(path):
             self._init_repo()
 
-        self._repo = pygit2.Repository(path)
+        self._repo = pygit2.Repository(path.as_posix())
 
     def add_all(self) -> None:
         """Add all changes from the working tree to the index.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,12 @@ remote = [
     # Support for remote-build is optional.
     # Pygit2 and libgit2 need to match versions.
     # Further info: https://www.pygit2.org/install.html#version-numbers
-    # TODO: loosen this restriction and make apps responsible for more specific restrictions
-    "pygit2~=1.13.0",
+    # Minor versions of pygit2 can include breaking changes, so we need to check
+    # that they work with craft_application before we update to them. If we bump
+    # the minimum minor version here, that absolutely needs to go in the release
+    # notes.
+    # Pygit2 changelog: https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md
+    "pygit2>=1.13.0,<1.15.0",
     "launchpadlib>=1.10.16",
 ]
 dev = [

--- a/tests/unit/remote/test_git.py
+++ b/tests/unit/remote/test_git.py
@@ -184,10 +184,18 @@ def test_add_all(new_dir):
 
     status = pygit2.Repository(new_dir).status()
 
-    assert status == {
-        "foo": pygit2.enums.FileStatus.INDEX_NEW,
-        "bar": pygit2.enums.FileStatus.INDEX_NEW,
-    }
+    if pygit2.__version__.startswith("1.13."):
+        expected = {
+            "foo": pygit2.GIT_STATUS_INDEX_NEW,  # pyright: ignore[reportAttributeAccessIssue]
+            "bar": pygit2.GIT_STATUS_INDEX_NEW,  # pyright: ignore[reportAttributeAccessIssue]
+        }
+    else:
+        expected = {
+            "foo": pygit2.enums.FileStatus.INDEX_NEW,
+            "bar": pygit2.enums.FileStatus.INDEX_NEW,
+        }
+
+    assert status == expected
 
 
 def test_add_all_no_files_to_add(new_dir):

--- a/tests/unit/remote/test_git.py
+++ b/tests/unit/remote/test_git.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from unittest.mock import ANY
 
 import pygit2
+import pygit2.enums
 import pytest
 from craft_application.remote import (
     GitError,
@@ -184,8 +185,8 @@ def test_add_all(new_dir):
     status = pygit2.Repository(new_dir).status()
 
     assert status == {
-        "foo": pygit2.GIT_STATUS_INDEX_NEW,
-        "bar": pygit2.GIT_STATUS_INDEX_NEW,
+        "foo": pygit2.enums.FileStatus.INDEX_NEW,
+        "bar": pygit2.enums.FileStatus.INDEX_NEW,
     }
 
 


### PR DESCRIPTION
Drive-by: stop renovate from trying to update pygit2

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
