### PR TITLE
feat!: use the build plan on LifecycleService

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -210,7 +210,7 @@ class Application:
     def _configure_services(
         self,
         platform: str | None,  # noqa: ARG002 (Unused method argument)
-        build_for: str | None,
+        build_for: str | None,  # noqa: ARG002 (Unused method argument)
     ) -> None:
         """Configure additional keyword arguments for any service classes.
 
@@ -221,7 +221,7 @@ class Application:
             "lifecycle",
             cache_dir=self.cache_dir,
             work_dir=self._work_dir,
-            build_for=build_for,
+            build_plan=self._build_plan,
         )
         self.services.set_kwargs(
             "provider",
@@ -637,7 +637,9 @@ class Application:
 
 
 def _filter_plan(
-    build_plan: list[BuildInfo], platform: str | None, build_for: str | None
+    build_plan: list[BuildInfo],
+    platform: str | None,
+    build_for: str | None,
 ) -> list[BuildInfo]:
     """Filter out builds not matching build-on and build-for."""
     host_arch = util.get_host_architecture()

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -120,6 +120,26 @@ class InvalidPlatformError(CraftError):
         super().__init__(message=message, details=details)
 
 
+class EmptyBuildPlanError(CraftError):
+    """The build plan filtered out all possible builds."""
+
+    def __init__(self) -> None:
+        message = "No build matches the current platform."
+        resolution = 'Check the "--platform" parameter.'
+
+        super().__init__(message=message, resolution=resolution)
+
+
+class MultipleBuildsError(CraftError):
+    """The build plan contains multiple possible builds."""
+
+    def __init__(self) -> None:
+        message = "Multiple builds match the current platform."
+        resolution = 'Check the "--platform" parameter.'
+
+        super().__init__(message=message, resolution=resolution)
+
+
 class InvalidParameterError(CraftError):
     """Invalid parameter or environment variable."""
 

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -21,6 +21,7 @@ from craft_application.util.paths import get_filename_from_url_path, get_managed
 from craft_application.util.platforms import (
     get_host_architecture,
     convert_architecture_deb_to_platform,
+    get_host_base,
 )
 from craft_application.util.snap_config import (
     SnapConfig,
@@ -39,6 +40,7 @@ __all__ = [
     "get_snap_config",
     "is_running_from_snap",
     "SnapConfig",
+    "get_host_base",
     "dump_yaml",
     "safe_yaml_load",
 ]

--- a/craft_application/util/platforms.py
+++ b/craft_application/util/platforms.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 import functools
 import platform
 
+from craft_parts.utils import os_utils
+from craft_providers import bases
+
 
 @functools.lru_cache(maxsize=1)
 def get_host_architecture() -> str:
@@ -34,6 +37,15 @@ def convert_architecture_deb_to_platform(arch: str) -> str:
     :return: architecture in platform syntax
     """
     return _ARCH_TRANSLATIONS_DEB_TO_PLATFORM.get(arch, arch)
+
+
+@functools.lru_cache(maxsize=1)
+def get_host_base() -> bases.BaseName:
+    """Get the craft-providers base for the running host."""
+    release = os_utils.OsRelease()
+    os_id = release.id()
+    version_id = release.version_id()
+    return bases.BaseName(os_id, version_id)
 
 
 # architecture translations from the platform syntax to the deb/snap syntax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,7 @@ lint.ignore = [
     "S103", # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
     "S108", # Allow Probable insecure usage of temporary file or directory
     "PLR0913",  # Allow many arguments for test functions
+    "PT004", # Allow fixtures that don't return anything to not start with underscores
 ]
 # isort leaves init files alone by default, this makes ruff ignore them too.
 "__init__.py" = ["I001"]

--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -23,7 +23,6 @@ import craft_parts.overlays
 import pytest
 import pytest_check
 from craft_application.services.lifecycle import LifecycleService
-from craft_application.util import get_host_architecture
 
 
 @pytest.fixture(
@@ -35,7 +34,9 @@ from craft_application.util import get_host_architecture
         ),
     ]
 )
-def parts_lifecycle(app_metadata, fake_project, fake_services, tmp_path, request):
+def parts_lifecycle(
+    app_metadata, fake_project, fake_services, tmp_path, request, fake_build_plan
+):
     fake_project.parts = request.param
 
     service = LifecycleService(
@@ -45,7 +46,7 @@ def parts_lifecycle(app_metadata, fake_project, fake_services, tmp_path, request
         work_dir=tmp_path / "work",
         cache_dir=tmp_path / "cache",
         platform=None,
-        build_for=get_host_architecture(),
+        build_plan=fake_build_plan,
     )
     service.setup()
     return service
@@ -104,7 +105,7 @@ def test_lifecycle_messages_no_duplicates(parts_lifecycle, request, capsys):
 
 @pytest.mark.usefixtures("enable_overlay")
 def test_package_repositories_in_overlay(
-    app_metadata, fake_project, fake_services, tmp_path, mocker
+    app_metadata, fake_project, fake_services, tmp_path, mocker, fake_build_plan
 ):
     # Mock overlay-related calls that need root; we won't be actually installing
     # any packages, just checking that the repositories are correctly installed
@@ -151,7 +152,7 @@ def test_package_repositories_in_overlay(
         work_dir=work_dir,
         cache_dir=tmp_path / "cache",
         platform=None,
-        build_for=get_host_architecture(),
+        build_plan=fake_build_plan,
         base_layer_dir=base_layer_dir,
         base_layer_hash=b"deadbeef",
     )

--- a/tests/integration/services/test_service_factory.py
+++ b/tests/integration/services/test_service_factory.py
@@ -49,6 +49,6 @@ def test_real_service_error(app_metadata, fake_project):
     with pytest.raises(
         TypeError,
         # Python 3.8 doesn't specify the LifecycleService, 3.10 does.
-        match=r"(LifecycleService.)?__init__\(\) missing 3 required keyword-only arguments: 'work_dir', 'cache_dir', and 'build_for'",
+        match=r"(LifecycleService.)?__init__\(\) missing 3 required keyword-only arguments: 'work_dir', 'cache_dir', and 'build_plan'",
     ):
         _ = factory.lifecycle

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -238,7 +238,7 @@ def test_run_managed_success(app, fake_project, fake_build_plan):
 
     assert (
         mock.call(
-            BuildInfo("foo", arch, arch, bases.BaseName("ubuntu", "22.04")),
+            fake_build_plan[0],
             work_dir=mock.ANY,
         )
         in mock_provider.instance.mock_calls
@@ -757,7 +757,7 @@ def test_get_project_current_dir(app):
 
 @pytest.mark.usefixtures("fake_project_file")
 def test_get_project_all_platform(app):
-    app.get_project(platform="ubuntu-22.04")
+    app.get_project(platform="foo")
 
 
 @pytest.mark.usefixtures("fake_project_file")


### PR DESCRIPTION
This commit updates the LifecycleService to make use of the project's build plan when running. This specially affects destructive mode, where:

- Trying to run a build plan with no items is a (new) error;
- Trying to run a build plan with multiple items is a (new) error;

Note that although some forms of the "clean" command are also performed destructively, in this case we don't use the build plan. The rationale for this is:

- The lifecycle's local clean is always the same, regardless of target arch;
- Trying to define a build plan item via e.g. "appname clean --build-for=x" looks non-sensical (why define a "build-for" if I want to "clean"), and from a user's perspective calling "appname clean --destructive-mode" should just cleanup whatever was built previously.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
