### PR TITLE
fix: make GrammarAwareProject accept no parts

### DIFF
--- a/craft_application/models/grammar.py
+++ b/craft_application/models/grammar.py
@@ -52,6 +52,19 @@ class GrammarAwareProject(_GrammarAwareModel):
 
     parts: "dict[str, _GrammarAwarePart]"
 
+    @pydantic.root_validator(  # pyright: ignore[reportUntypedFunctionDecorator,reportUnknownMemberType]
+        pre=True
+    )
+    def _ensure_parts(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Ensure that the "parts" dictionary exists.
+
+        Some models (e.g. charmcraft) have this as optional. If there is no `parts`
+        item defined, set it to an empty dictionary. This is distinct from having
+        `parts` be invalid, which is not coerced here.
+        """
+        data.setdefault("parts", {})
+        return data
+
     @classmethod
     def validate_grammar(cls, data: dict[str, Any]) -> None:
         """Ensure grammar-enabled entries are syntactically valid."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,6 +287,7 @@ lint.ignore = [
 
 [tool.ruff.lint.pep8-naming]
 classmethod-decorators = [
+    "pydantic.root_validator",
     "pydantic.validator",
 ]
 

--- a/tests/unit/test_grammar.py
+++ b/tests/unit/test_grammar.py
@@ -188,6 +188,23 @@ def test_grammar_aware_part_error(part):
                 },
             }
         ),
+        (
+            {  # No "parts" defined - gets coerced to an empty dict of parts.
+                "name": "empty",
+                "title": "A most basic project",
+                "version": "git",
+                "base": ["ubuntu", "22.04"],
+            }
+        ),
+        (
+            {  # Same as above, but without coercion.
+                "name": "empty",
+                "title": "A most basic project",
+                "version": "git",
+                "base": ["ubuntu", "22.04"],
+                "parts": {},
+            }
+        ),
     ],
 )
 def test_grammar_aware_project(project):
@@ -198,14 +215,6 @@ def test_grammar_aware_project(project):
 @pytest.mark.parametrize(
     ("project"),
     [
-        (
-            {
-                "name": "empty",
-                "title": "A most basic project",
-                "version": "git",
-                "base": ["ubuntu", "22.04"],
-            }
-        ),
         (
             {
                 "name": "empty",


### PR DESCRIPTION
Parts are optional in charmcraft.yaml.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
