### PR TITLE
fix(models): address adopt-info validation by name

### DIFF
--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -102,13 +102,15 @@ class Project(CraftBaseModel):
     )
     @classmethod
     def _validate_adopt_info(cls, values: dict[str, Any]) -> dict[str, Any]:
-        if values.get("version") is None and values.get("adopt-info") is None:
+        # pydantic 1.x seems to inconsistently validate fields by alias or name?
+        adopting_part = values.get("adopt-info") or values.get("adopt_info")
+
+        if not values.get("version") and not adopting_part:
             raise ValueError(
                 "Required field 'version' is not set and 'adopt-info' not used."
             )
 
-        adopted_part = values.get("adopt-info")
-        if adopted_part is not None and adopted_part not in values.get("parts", {}):
+        if adopting_part and adopting_part not in values.get("parts", {}):
             raise ValueError("'adopt-info' does not reference a valid part.")
 
         return values

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -255,7 +255,7 @@ def test_adoptable_version(unmarshal, version, adopter_part, error):
                 }
             )
 
-        return Project(
+        return Project(  # pyright: ignore[reportCallIssue]
             name="project-name",
             version=version,
             adopt_info=adopter_part,

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -234,6 +234,10 @@ def test_effective_base_unknown():
         (None, None, "Required field 'version' is not set and 'adopt-info' not used."),
         (None, "bar", "'adopt-info' does not reference a valid part."),
         (None, "foo", None),
+        ("", None, "Required field 'version' is not set and 'adopt-info' not used."),
+        ("", "bar", "'adopt-info' does not reference a valid part."),
+        ("", "foo", "string does not match regex"),
+        (None, "", "Required field 'version' is not set and 'adopt-info' not used."),
     ],
 )
 def test_adoptable_version(version, adopter_part, error):

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -225,6 +225,7 @@ def test_effective_base_unknown():
     assert exc_info.match("Could not determine effective base")
 
 
+@pytest.mark.parametrize(("unmarshal"), [True, False])
 @pytest.mark.parametrize(
     ("version", "adopter_part", "error"),
     [
@@ -240,15 +241,25 @@ def test_effective_base_unknown():
         (None, "", "Required field 'version' is not set and 'adopt-info' not used."),
     ],
 )
-def test_adoptable_version(version, adopter_part, error):
+def test_adoptable_version(unmarshal, version, adopter_part, error):
     def _project(version, adopter_part) -> Project:
-        return Project(  # pyright: ignore[reportCallIssue]
-            **{
-                "name": "project-name",  # pyright: ignore[reportGeneralTypeIssues]
-                "version": version,
-                "adopt-info": adopter_part,
-                "parts": {"foo": {"plugin": "nil"}},
-            }
+        # pydantic 1.x validates differently according to the way the model
+        # is created, so we create it both ways.
+        if unmarshal:
+            return Project.unmarshal(
+                {
+                    "name": "project-name",  # pyright: ignore[reportGeneralTypeIssues]
+                    "version": version,
+                    "adopt-info": adopter_part,
+                    "parts": {"foo": {"plugin": "nil"}},
+                }
+            )
+
+        return Project(
+            name="project-name",
+            version=version,
+            adopt_info=adopter_part,
+            parts={"foo": {"plugin": "nil"}},
         )
 
     if error:


### PR DESCRIPTION
Pydantic 1.x seemingly root-validates using both file alias and name,
leading to inconsistent behavior. This should address the issue for
now, but the issue warrants further investigation.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
