### PR TITLE
fix(launchpad): use timezone-aware expiry time

### DIFF
--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -232,7 +232,8 @@ class RemoteBuildService(base.AppService):
 
         token = lp_repository.get_access_token(
             f"{self._app.name} {self._app.version} remote build",
-            expiry=datetime.datetime.now() + datetime.timedelta(seconds=60),
+            expiry=datetime.datetime.now(tz=datetime.timezone.utc)
+            + datetime.timedelta(seconds=300),
         )
         repo_url = parse.urlparse(str(lp_repository.git_https_url))
         push_url = repo_url._replace(


### PR DESCRIPTION
Launchpad doesn't error out if you try to create a token that expired in the past. Using non-timezone-aware datetime object in a timezone behind UTC can cause this.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
