### PR TITLE
feat!: remove optional project commands

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -430,20 +430,6 @@ class Application:
                     resolution="Ensure the path entered is correct.",
                 )
 
-    def _try_load_project(
-        self, command: commands.AppCommand, platform: str | None, build_for: str | None
-    ) -> None:
-        """Try to load the project and fail as needed."""
-        try:
-            self.services.project = self.get_project(
-                platform=platform, build_for=build_for
-            )
-        except Exception:  # noqa: BLE001
-            if command.always_load_project == "try":
-                craft_cli.emit.debug("Project not found. Continuing without.")
-            else:
-                raise
-
     def run(self) -> int:  # noqa: PLR0912 (too many branches)
         """Bootstrap and run the application."""
         self._setup_logging()
@@ -467,7 +453,9 @@ class Application:
 
             managed_mode = command.run_managed(dispatcher.parsed_args())
             if managed_mode or command.always_load_project:
-                self._try_load_project(command, platform, build_for)
+                self.services.project = self.get_project(
+                    platform=platform, build_for=build_for
+                )
 
             self._configure_services(platform, build_for)
 

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import abc
 import argparse
-from typing import Any, Literal, Optional, Protocol, final
+from typing import Any, Optional, Protocol, final
 
 from craft_cli import BaseCommand, emit
 from typing_extensions import Self
@@ -50,12 +50,8 @@ class RunCallback(Protocol):
 class AppCommand(BaseCommand):
     """Command for use with craft-application."""
 
-    always_load_project: bool | Literal["try"] = False
-    """The project is also loaded in non-managed mode.
-
-    If the value is "try", the app will attempt to load the project but not error on
-    failure.
-    """
+    always_load_project: bool = False
+    """The project is also loaded in non-managed mode."""
 
     def __init__(self, config: dict[str, Any] | None) -> None:
         if config is None:

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -390,33 +390,6 @@ def test_gets_project(monkeypatch, tmp_path, app_metadata, fake_services):
     assert app.project is not None
 
 
-def test_succeeds_without_project(
-    monkeypatch, emitter, tmp_path, app_metadata, fake_services
-):
-    monkeypatch.setattr(sys, "argv", ["testcraft", "try-load-project"])
-
-    app = FakeApplication(app_metadata, fake_services)
-    app.project_dir = tmp_path
-    fake_services.project = None
-
-    class TryLoadProject(commands.AppCommand):
-        """A command that tries to load the project but continues without it."""
-
-        name = "try-load-project"
-        help_msg = overview = "unimportant"
-        always_load_project = "try"
-
-        def run(self, parsed_args: argparse.Namespace) -> None:
-            _ = parsed_args
-
-    app.add_command_group("test", [TryLoadProject])
-
-    assert app.run() == 0
-
-    assert fake_services.project is None
-    emitter.assert_debug("Project not found. Continuing without.")
-
-
 def test_fails_without_project(
     monkeypatch, capsys, tmp_path, app_metadata, fake_services
 ):


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Design discussion on this said it was better to remove the options in commands that needed this and enforce a command either needing or not needing a project.

This essentially reverts #213 , but leaves the extra tests that are still relevant.