### PR TITLE
feat(snap_config): add snap_config model and utilities

### DIFF
--- a/craft_application/util/snap_config.py
+++ b/craft_application/util/snap_config.py
@@ -1,0 +1,97 @@
+# This file is part of craft-application.
+#
+# Copyright 2022,2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Snap config file definitions and helpers."""
+from typing import Any, Dict, Literal, Optional
+
+import os
+import pydantic
+from craft_cli import emit
+from snaphelpers import SnapConfigOptions, SnapCtlError
+
+
+def is_snapcraft_running_from_snap() -> bool:
+    """Check if snapcraft is running from the snap."""
+    return os.getenv("SNAP_NAME") == "snapcraft" and os.getenv("SNAP") is not None
+
+
+class SnapConfig(pydantic.BaseModel, extra=pydantic.Extra.forbid):
+    """Data stored in a snap config.
+
+    :param provider: provider to use. Valid values are 'lxd' and 'multipass'.
+    """
+
+    provider: Optional[Literal["lxd", "multipass"]] = None
+
+    @pydantic.validator("provider", pre=True)
+    @classmethod
+    def convert_to_lower(cls, provider):
+        """Convert provider value to lowercase."""
+        return provider.lower()
+
+    @classmethod
+    def unmarshal(cls, data: Dict[str, Any]) -> "SnapConfig":
+        """Create and populate a new ``SnapConfig`` object from dictionary data.
+
+        The unmarshal method validates entries in the input dictionary, populating
+        the corresponding fields in the data object.
+
+        :param data: The dictionary data to unmarshal.
+
+        :return: The newly created object.
+
+        :raise TypeError: If data is not a dictionary.
+        :raise ValueError: If data is invalid.
+        """
+        if not isinstance(data, dict):
+            raise TypeError("snap config data is not a dictionary")
+
+        try:
+            snap_config = cls(**data)
+        except pydantic.ValidationError as error:
+            # TODO: use `_format_pydantic_errors()` from project.py
+            raise ValueError(f"error parsing snap config: {error}") from error
+
+        return snap_config
+
+
+def get_snap_config() -> Optional[SnapConfig]:
+    """Get validated snap configuration.
+
+    :return: SnapConfig. If not running as a snap, return None.
+    """
+    if not is_snapcraft_running_from_snap():
+        emit.debug(
+            "Not loading snap config because snapcraft is not running as a snap."
+        )
+        return None
+
+    try:
+        snap_config = SnapConfigOptions(keys=["provider"])
+        # even if the initialization of SnapConfigOptions succeeds, `fetch()` may
+        # raise the same errors since it makes calls to snapd
+        snap_config.fetch()
+    except (AttributeError, SnapCtlError) as error:
+        # snaphelpers raises an error (either AttributeError or SnapCtlError) when
+        # it fails to get the snap config. this can occur when running inside a
+        # docker or podman container where snapd is not available
+        emit.debug("Could not retrieve the snap config. Is snapd running?")
+        emit.trace(f"snaphelpers error: {error!r}")
+        return None
+
+    emit.debug(f"Retrieved snap config: {snap_config.as_dict()}")
+
+    return SnapConfig.unmarshal(snap_config.as_dict())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "craft-grammar>=1.1.1",
     "craft-parts>=1.21.1",
     "craft-providers>=1.20.0,<2.0",
+    "snap-helpers>=0.4.2",
     "platformdirs>=3.10",
     "pydantic>=1.10,<2.0",
     "pydantic-yaml<1.0",

--- a/tests/unit/util/test_snap_config.py
+++ b/tests/unit/util/test_snap_config.py
@@ -1,0 +1,153 @@
+# This file is part of craft-application.
+#
+# Copyright 2022,2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for SnapConfig class."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from snaphelpers import SnapCtlError
+
+from snapcraft.snap_config import SnapConfig, get_snap_config, is_snapcraft_running_from_snap
+
+
+@pytest.fixture
+def mock_config():
+    with patch(
+        "snapcraft.snap_config.SnapConfigOptions", autospec=True
+    ) as mock_snap_config:
+        yield mock_snap_config
+
+
+@pytest.fixture()
+def mock_is_running_from_snap(mocker):
+    yield mocker.patch(
+        "snapcraft.snap_config.is_snapcraft_running_from_snap", return_value=True
+    )
+
+
+@pytest.mark.parametrize(
+    "snap_name,snap,result",
+    [
+        (None, None, False),
+        (None, "/snap/snapcraft/x1", False),
+        ("snapcraft", None, False),
+        ("snapcraft", "/snap/snapcraft/x1", True),
+    ],
+)
+def test_is_snapcraft_running_from_snap(monkeypatch, snap_name, snap, result):
+    if snap_name is None:
+        monkeypatch.delenv("SNAP_NAME", raising=False)
+    else:
+        monkeypatch.setenv("SNAP_NAME", snap_name)
+
+    if snap is None:
+        monkeypatch.delenv("SNAP", raising=False)
+    else:
+        monkeypatch.setenv("SNAP", snap)
+
+    assert is_snapcraft_running_from_snap() == result
+
+
+def test_unmarshal():
+    """Verify unmarshalling works as expected."""
+    config = SnapConfig.unmarshal({"provider": "lxd"})
+
+    assert config.provider == "lxd"
+
+
+def test_unmarshal_not_a_dictionary():
+    """Verify unmarshalling with data that is not a dictionary raises an error."""
+    with pytest.raises(TypeError) as raised:
+        SnapConfig.unmarshal("provider=lxd")  # type: ignore
+
+    assert str(raised.value) == "snap config data is not a dictionary"
+
+
+def test_unmarshal_invalid_provider_error():
+    """Verify unmarshalling with an invalid provider raises an error."""
+    with pytest.raises(ValueError) as raised:
+        SnapConfig.unmarshal({"provider": "invalid-value"})
+
+    assert str(raised.value) == (
+        "error parsing snap config: 1 validation error for SnapConfig\n"
+        "provider\n"
+        "  unexpected value; permitted: 'lxd', 'multipass' "
+        "(type=value_error.const; given=invalid-value; permitted=('lxd', 'multipass'))"
+    )
+
+
+def test_unmarshal_extra_data_error():
+    """Verify unmarshalling with extra data raises an error."""
+    with pytest.raises(ValueError) as raised:
+        SnapConfig.unmarshal({"provider": "lxd", "test": "test"})
+
+    assert str(raised.value) == (
+        "error parsing snap config: 1 validation error for SnapConfig\n"
+        "test\n"
+        "  extra fields not permitted (type=value_error.extra)"
+    )
+
+
+@pytest.mark.parametrize("provider", ["lxd", "multipass"])
+def test_get_snap_config(mock_config, mock_is_running_from_snap, provider):
+    """Verify getting a valid snap config."""
+
+    def fake_as_dict():
+        return {"provider": provider}
+
+    mock_config.return_value.as_dict.side_effect = fake_as_dict
+    config = get_snap_config()
+
+    assert config == SnapConfig(provider=provider)
+
+
+def test_get_snap_config_empty(mock_config, mock_is_running_from_snap):
+    """Verify getting an empty config returns a default SnapConfig."""
+
+    def fake_as_dict():
+        return {}
+
+    mock_config.return_value.as_dict.side_effect = fake_as_dict
+    config = get_snap_config()
+
+    assert config == SnapConfig()
+
+
+def test_get_snap_config_not_from_snap(mock_is_running_from_snap):
+    """Verify None is returned when snapcraft is not running from a snap."""
+    mock_is_running_from_snap.return_value = False
+
+    assert get_snap_config() is None
+
+
+@pytest.mark.parametrize("error", [AttributeError, SnapCtlError(process=MagicMock())])
+def test_get_snap_config_handle_init_error(
+    error, mock_config, mock_is_running_from_snap
+):
+    """An error when initializing the snap config object should return None."""
+    mock_config.side_effect = error
+
+    assert get_snap_config() is None
+
+
+@pytest.mark.parametrize("error", [AttributeError, SnapCtlError(process=MagicMock())])
+def test_get_snap_config_handle_fetch_error(
+    error, mock_config, mock_is_running_from_snap
+):
+    """An error when fetching the snap config should return None."""
+    mock_config.return_value.fetch.side_effect = error
+
+    assert get_snap_config() is None


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This is the first of 3 commits for setting the build mode:
 - a PR to import `snap_config` (this PR)
 - a PR to determine which provider to use
 - a PR to determine whether to run on the host or in a provider)

The first commit imports the `snap_config` model and utilities from snapcraft unmodified.

The second commit updates them to `craft-application` coding standards and makes the code generic.

The `snap-helpers` package is a required library but applications are not required to run as a snap or have a snap config.  I will ensure this behavior in the next PR where I will use the model.

(CRAFT-2477)