### PR TITLE
feat(lifecycle): get pull assets and primed stage packages

### DIFF
--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -205,6 +205,22 @@ class LifecycleService(base.ProjectService):
         """The lifecycle's ProjectInfo."""
         return self._lcm.project_info
 
+    def get_pull_assets(self, *, part_name: str) -> dict[str, Any] | None:
+        """Obtain the part's pull state assets.
+
+        :param part_name: The name of the part to get assets from.
+        :return: The dictionary of the part's pull assets, or None if no state found.
+        """
+        return self._lcm.get_pull_assets(part_name=part_name)
+
+    def get_primed_stage_packages(self, *, part_name: str) -> list[str] | None:
+        """Obtain the list of primed stage packages.
+
+        :param part_name: The name of the part to get primed stage packages from.
+        :return: The sorted list of primed stage packages, or None if no state found.
+        """
+        return self._lcm.get_primed_stage_packages(part_name=part_name)
+
     def run(self, step_name: str | None, part_names: list[str] | None = None) -> None:
         """Run the lifecycle manager for the parts."""
         target_step = _get_step(step_name) if step_name else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,7 @@ def enable_overlay() -> Iterator[craft_parts.Features]:
 
 @pytest.fixture()
 def lifecycle_service(
-    app_metadata, fake_project, fake_services, tmp_path, fake_build_plan
+    app_metadata, fake_project, fake_services, fake_build_plan, mocker, tmp_path
 ) -> services.LifecycleService:
     work_dir = tmp_path / "work"
     cache_dir = tmp_path / "cache"
@@ -159,6 +159,16 @@ def lifecycle_service(
         build_plan=fake_build_plan,
     )
     service.setup()
+    mocker.patch.object(
+        service._lcm,
+        "get_pull_assets",
+        new=lambda **p: {"foo": "bar"} if p["part_name"] == "my-part" else {},
+    )
+    mocker.patch.object(
+        service._lcm,
+        "get_primed_stage_packages",
+        new=lambda **p: ["pkg1", "pkg2"] if p["part_name"] == "my-part" else {},
+    )
     return service
 
 

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -319,6 +319,18 @@ def test_project_info(lifecycle_service):
     assert info.application_name == "testcraft"
 
 
+def test_get_pull_assets(lifecycle_service):
+    assets = lifecycle_service.get_pull_assets(part_name="my-part")
+
+    assert assets == {"foo": "bar"}
+
+
+def test_get_primed_stage_packages(lifecycle_service):
+    pkgs = lifecycle_service.get_primed_stage_packages(part_name="my-part")
+
+    assert pkgs == ["pkg1", "pkg2"]
+
+
 @pytest.mark.parametrize(
     "actions",
     [


### PR DESCRIPTION
Add methods to the lifecycle service to retrieve the list of pull
assets and primed stage packages from a given part. These can be
used to generate manifests of processed content.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
