### PR TITLE
feat(package): add method to update project

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -269,6 +269,7 @@ class PrimeCommand(LifecycleStepCommand):
         """Run the prime command."""
         super()._run(parsed_args, step_name=step_name)
 
+        self._services.package.update_project()
         self._services.package.write_metadata(self._services.lifecycle.prime_dir)
 
 

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -264,9 +264,6 @@ class LifecycleService(base.ProjectService):
         except Exception as err:  # noqa: BLE001 - Converting general error.
             raise errors.PartsLifecycleError(f"Unknown error: {str(err)}") from err
 
-        emit.progress("Updating project metadata")
-        self._update_project_metadata()
-
         for field in self._app.mandatory_adoptable_fields:
             if not getattr(self._project, field):
                 raise errors.PartsLifecycleError(
@@ -318,19 +315,6 @@ class LifecycleService(base.ProjectService):
             f"{self.__class__.__name__}({self._app!r}, {self._project!r}, "
             f"{work_dir=}, {cache_dir=}, {plan=}, **{self._manager_kwargs!r})"
         )
-
-    def _update_project_metadata(self) -> None:
-        """Replace project fields with values adopted during the lifecycle."""
-        self._update_project_variables()
-
-    def _update_project_variables(self) -> None:
-        """Replace project fields with values set using craftctl."""
-        update_vars: dict[str, str] = {}
-        for var in self._app.project_variables:
-            update_vars[var] = self.project_info.get_project_var(var)
-
-        emit.debug(f"Update project variables: {update_vars}")
-        self._project.__dict__.update(update_vars)
 
     def _verify_parallel_build_count(
         self, env_name: str, parallel_build_count: int | str

--- a/craft_application/services/package.py
+++ b/craft_application/services/package.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 import abc
 from typing import TYPE_CHECKING
 
+from craft_cli import emit
+
+from craft_application import errors
 from craft_application.services import base
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -43,6 +46,22 @@ class PackageService(base.ProjectService):
     @abc.abstractmethod
     def metadata(self) -> models.BaseMetadata:
         """The metadata model for this project."""
+
+    def update_project(self) -> None:
+        """Update project fields with dynamic values set during the lifecycle."""
+        update_vars: dict[str, str] = {}
+        project_info = self._services.lifecycle.project_info
+        for var in self._app.project_variables:
+            update_vars[var] = project_info.get_project_var(var)
+
+        emit.debug(f"Update project variables: {update_vars}")
+        self._project.__dict__.update(update_vars)
+
+        for field in self._app.mandatory_adoptable_fields:
+            if not getattr(self._project, field):
+                raise errors.PartsLifecycleError(
+                    f"Project field '{field}' was not set."
+                )
 
     def write_metadata(self, path: pathlib.Path) -> None:
         """Write the project metadata to metadata.yaml in the given directory.

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -459,6 +459,9 @@ def test_shell(
 ):
     parsed_args = argparse.Namespace(parts=None, shell=True)
     mock_lifecycle_run = mocker.patch.object(fake_services.lifecycle, "run")
+    mocker.patch.object(
+        fake_services.lifecycle.project_info, "execution_finished", return_value=True
+    )
     command = command_cls(
         {
             "app": app_metadata,
@@ -477,6 +480,9 @@ def test_shell_after(
 ):
     parsed_args = argparse.Namespace(parts=None, shell_after=True)
     mock_lifecycle_run = mocker.patch.object(fake_services.lifecycle, "run")
+    mocker.patch.object(
+        fake_services.lifecycle.project_info, "execution_finished", return_value=True
+    )
     command = command_cls(
         {
             "app": app_metadata,

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import dataclasses
 import re
 from pathlib import Path
-from typing import cast
 from unittest import mock
 
 import craft_parts
@@ -634,6 +633,7 @@ def test_get_parallel_build_count_error(
 
 
 # endregion
+
 # region project variables
 
 
@@ -674,75 +674,8 @@ def test_lifecycle_project_variables(
 
     service.run("prime")
 
-    assert service._project.version == "foo"
-    assert cast(LocalProject, service._project).color == "foo"
-
-
-def test_lifecycle_project_variables_unset(
-    app_metadata, fake_project, fake_services, tmp_path, fake_build_plan
-):
-    """Test that project variables must be set after the lifecycle runs."""
-    work_dir = tmp_path / "work"
-    app_metadata = dataclasses.replace(
-        app_metadata,
-        project_variables=["version", "color"],
-        mandatory_adoptable_fields=["version", "color"],
-    )
-
-    service = lifecycle.LifecycleService(
-        app_metadata,
-        fake_services,
-        project=fake_project,
-        work_dir=work_dir,
-        cache_dir=tmp_path / "cache",
-        platform=None,
-        build_plan=fake_build_plan,
-    )
-    service._lcm = mock.MagicMock(spec=LifecycleManager)
-    service._lcm.project_info = mock.MagicMock(spec=ProjectInfo)
-    service._lcm.project_info.get_project_var = lambda x: (
-        "foo" if x == "version" else None
-    )
-
-    with pytest.raises(PartsLifecycleError) as exc_info:
-        service.run("prime")
-
-    assert str(exc_info.value) == "Project field 'color' was not set."
-
-
-def test_lifecycle_project_variables_optional(
-    app_metadata,
-    fake_project,
-    fake_services,
-    tmp_path,
-    fake_build_plan,
-):
-    """Test that project variables must be set after the lifecycle runs."""
-    work_dir = tmp_path / "work"
-    app_metadata = dataclasses.replace(
-        app_metadata,
-        project_variables=["version", "color"],
-        mandatory_adoptable_fields=["version"],
-    )
-
-    service = lifecycle.LifecycleService(
-        app_metadata,
-        fake_services,
-        project=fake_project,
-        work_dir=work_dir,
-        cache_dir=tmp_path / "cache",
-        platform=None,
-        build_plan=fake_build_plan,
-    )
-    service._lcm = mock.MagicMock(spec=LifecycleManager)
-    service._lcm.project_info = mock.MagicMock(spec=ProjectInfo)
-    service._lcm.project_info.get_project_var = lambda x: (
-        "foo" if x == "version" else None
-    )
-
-    service.run("prime")
-
-    assert service._project.version == "foo"
+    assert service.project_info.get_project_var("version") == "foo"
+    assert service.project_info.get_project_var("color") == "foo"
 
 
 # endregion


### PR DESCRIPTION
Update the project with values adopted during the lifecycle and
make them available for metadata files. These variables were
previously updated at the end of the lifecycle service, but
doing so in the package service guarantees that this will happen
after prime.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
