### PR TITLE
feat(application)!: make configure_services not take parameters

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -207,11 +207,7 @@ class Application:
                 f"Unable to create/access cache directory: {err.strerror}"
             ) from err
 
-    def _configure_services(
-        self,
-        platform: str | None,  # noqa: ARG002 (Unused method argument)
-        build_for: str | None,  # noqa: ARG002 (Unused method argument)
-    ) -> None:
+    def _configure_services(self) -> None:
         """Configure additional keyword arguments for any service classes.
 
         Any child classes that override this must either call this directly or must
@@ -470,7 +466,7 @@ class Application:
                     platform=platform, build_for=build_for
                 )
 
-            self._configure_services(platform, build_for)
+            self._configure_services()
 
             if not managed_mode:
                 # command runs in the outer instance


### PR DESCRIPTION
Removes `build_for` and `platform` from `Application._configure_services()`

This will break any application that implements _configure_services and any service that expects these.

The new methodology is to pass the build plan to a service and use that.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
