### PR TITLE
feat: pass environment variables to the instance.

### DIFF
--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -45,6 +45,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from craft_application.services import ServiceFactory
 
 
+DEFAULT_FORWARD_ENVIRONMENT_VARIABLES = ("http_proxy", "https_proxy", "no_proxy")
+
+
 class ProviderService(base.ProjectService):
     """Manager for craft_providers in an application.
 
@@ -79,6 +82,13 @@ class ProviderService(base.ProjectService):
     def is_managed(cls) -> bool:
         """Determine whether we're running in managed mode."""
         return os.getenv(cls.managed_mode_env_var) == "1"
+
+    def setup(self) -> None:
+        """Application-specific service setup."""
+        super().setup()
+        for name in DEFAULT_FORWARD_ENVIRONMENT_VARIABLES:
+            if name in os.environ:
+                self.environment[name] = os.getenv(name)
 
     @contextlib.contextmanager
     def instance(

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -16,6 +16,7 @@
 """Unit tests for provider service"""
 import pathlib
 import pkgutil
+import uuid
 from unittest import mock
 
 import craft_providers
@@ -60,6 +61,22 @@ def test_is_managed(managed_value, expected, monkeypatch):
     )
 
     assert provider.ProviderService.is_managed() == expected
+
+
+def test_forward_environment_variables(monkeypatch, provider_service):
+    var_contents = uuid.uuid4().hex
+    for var in provider.DEFAULT_FORWARD_ENVIRONMENT_VARIABLES:
+        monkeypatch.setenv(var, f"{var}__{var_contents}")
+
+    provider_service.setup()
+
+    assert provider_service.environment == {
+        provider_service.managed_mode_env_var: "1",
+        **{
+            var: f"{var}__{var_contents}"
+            for var in provider.DEFAULT_FORWARD_ENVIRONMENT_VARIABLES
+        },
+    }
 
 
 @pytest.mark.parametrize("lxd_remote", ["local", "something-else"])


### PR DESCRIPTION
This provides two things:
1. Forwards proxy variables to the provider.
2. Provides an example for how an application can forward additional variables.

Fixes #258 (CRAFT-2579)

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
