### PR TITLE
feat(lifecycle)!: don't build on incompatible bases

### DIFF
--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -23,6 +23,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from craft_cli import CraftError
+from craft_providers import bases
 
 from craft_application.util.error_formatting import format_pydantic_errors
 
@@ -138,6 +139,18 @@ class MultipleBuildsError(CraftError):
         resolution = 'Check the "--platform" parameter.'
 
         super().__init__(message=message, resolution=resolution)
+
+
+class IncompatibleBaseError(CraftError):
+    """The build plan's base is incompatible with the host environment."""
+
+    def __init__(self, host_base: bases.BaseName, build_base: bases.BaseName) -> None:
+        host_pretty = f"{host_base.name.title()} {host_base.version}"
+        build_pretty = f"{build_base.name.title()} {build_base.version}"
+
+        message = f'"{build_pretty}" builds cannot be performed on this "{host_pretty}" system.'
+
+        super().__init__(message=message)
 
 
 class InvalidParameterError(CraftError):

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -148,9 +148,20 @@ class IncompatibleBaseError(CraftError):
         host_pretty = f"{host_base.name.title()} {host_base.version}"
         build_pretty = f"{build_base.name.title()} {build_base.version}"
 
-        message = f'"{build_pretty}" builds cannot be performed on this "{host_pretty}" system.'
+        message = (
+            f"{build_pretty} builds cannot be performed on this {host_pretty} system."
+        )
+        details = (
+            "Builds must be performed on a specific system to ensure that the "
+            "final artefact's binaries are compatible with the intended execution "
+            "environment."
+        )
+        resolution = "Run a managed build, or run on a compatible host."
+        retcode = 78  # "configuration error" from sysexits.h
 
-        super().__init__(message=message)
+        super().__init__(
+            message=message, details=details, resolution=resolution, retcode=retcode
+        )
 
 
 class InvalidParameterError(CraftError):

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -723,7 +723,7 @@ def test_invalid_base_error(
     fake_build_plan[0].base = bases.BaseName(name=system_name, version=system_version)
 
     expected = (
-        f'"{expected_pretty}" builds cannot be performed on this "Ubuntu 24.04" system.'
+        f"{expected_pretty} builds cannot be performed on this Ubuntu 24.04 system."
     )
 
     with pytest.raises(errors.IncompatibleBaseError, match=expected):


### PR DESCRIPTION
The Lifecycle service will now check whether the build's base (as stored in the BuildInfo) matches the running environment. This doesn't affect managed runs (barring bugs), but is a change in behavior as we will no longer build, say, Ubuntu 22.04 artifacts on Fedora hosts in destructive mode.

We define "matches" here as this:

- If the build base is "devel", then only the systems have to match. For instance, you can build a "devel" Ubuntu-based artefact on any Ubuntu system, but not on a Fedora system.
- Otherwise, both the base's system and version must match, such that it is no longer possible to build ubuntu@22.04 on (say) ubuntu@20.04 systems.

Fixes #154

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
