### PR TITLE
feat(package): add a point to do tool-specific updates

### DIFF
--- a/craft_application/services/package.py
+++ b/craft_application/services/package.py
@@ -57,6 +57,9 @@ class PackageService(base.ProjectService):
         emit.debug(f"Update project variables: {update_vars}")
         self._project.__dict__.update(update_vars)
 
+        # Give subclasses a chance to update the project with their own logic
+        self._extra_project_updates()
+
         unset_fields = [
             field
             for field in self._app.mandatory_adoptable_fields
@@ -78,3 +81,6 @@ class PackageService(base.ProjectService):
         """
         path.mkdir(parents=True, exist_ok=True)
         self.metadata.to_yaml_file(path / "metadata.yaml")
+
+    def _extra_project_updates(self) -> None:
+        """Perform domain-specific updates to the project before packing."""


### PR DESCRIPTION
In line with _extra_yaml_transform(), add _extra_project_updates() as the place where subclasses can perform domain-specific updates to the Project when priming. The use-case here is to support Snapcraft's "parse-info" feature.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
