### PR TITLE
fix(yaml): allow use unicode in yaml

### DIFF
--- a/craft_application/util/yaml.py
+++ b/craft_application/util/yaml.py
@@ -132,6 +132,7 @@ def dump_yaml(data: Any, stream: TextIO | None = None, **kwargs: Any) -> str | N
         str, _repr_str, Dumper=cast(type[yaml.Dumper], yaml.SafeDumper)
     )
     kwargs.setdefault("sort_keys", False)
+    kwargs.setdefault("allow_unicode", True)
     return cast(  # This cast is needed for pyright but not mypy
         str | None, yaml.dump(data, stream, Dumper=yaml.SafeDumper, **kwargs)
     )

--- a/tests/unit/util/test_yaml.py
+++ b/tests/unit/util/test_yaml.py
@@ -81,6 +81,16 @@ def test_dump_yaml_to_string(data, kwargs, expected):
             {"sort_keys": True},
             "comes_first: true\nordered: 'yes'\n",
         ),
+        (
+            {"ordered": "no", "comes_first": False, "long_key": "123\n456\n789"},
+            {},
+            "ordered: 'no'\ncomes_first: false\nlong_key: |-\n  123\n  456\n  789\n",
+        ),
+        (
+            {"ordered": "no", "comes_first": False, "unicode": "👍"},
+            {},
+            "ordered: 'no'\ncomes_first: false\nunicode: 👍\n",
+        ),
     ],
 )
 def test_dump_yaml_to_stream(data, kwargs, expected):


### PR DESCRIPTION
When non-ASCII in the data, the entire text is escaped, especially in description.