### PR TITLE
feat(platforms): support --build-for to select platform

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -265,11 +265,13 @@ class Application:
         full_build_plan = build_planner.get_build_plan()
         self._build_plan = _filter_plan(full_build_plan, platform, build_for)
 
-        if platform:
-            all_platforms = {b.platform: b for b in full_build_plan}
-            if platform not in all_platforms:
-                raise errors.InvalidPlatformError(platform, list(all_platforms.keys()))
-            build_for = all_platforms[platform].build_for
+        if platform and not build_for:
+            if self._build_plan:
+                build_for = self._build_plan[0].build_for
+            else:
+                raise errors.InvalidPlatformError(
+                    platform, list({p.platform for p in full_build_plan})
+                )
 
         # validate project grammar
         GrammarAwareProject.validate_grammar(yaml_data)
@@ -639,16 +641,29 @@ def _filter_plan(
     platform: str | None,
     build_for: str | None,
 ) -> list[BuildInfo]:
-    """Filter out builds not matching build-on and build-for."""
+    """Filter out builds not matching build-on, build-for, and platform."""
     host_arch = util.get_host_architecture()
 
-    plan: list[BuildInfo] = []
+    new_plan_matched_build_for: list[BuildInfo] = []
+    new_plan_matched_platform_name: list[BuildInfo] = []
+
     for build_info in build_plan:
-        platform_matches = not platform or build_info.platform == platform
-        build_on_matches = build_info.build_on == host_arch
-        build_for_matches = not build_for or build_info.build_for == build_for
+        if platform and build_info.platform != platform:
+            continue
 
-        if platform_matches and build_on_matches and build_for_matches:
-            plan.append(build_info)
+        if build_info.build_on != host_arch:
+            continue
 
-    return plan
+        if build_for and build_info.build_for != build_for:
+            continue
+
+        if build_for and build_info.platform == build_for:
+            # prioritize platform name if matched build_for
+            new_plan_matched_platform_name.append(build_info)
+            continue
+
+        new_plan_matched_build_for.append(build_info)
+
+    if new_plan_matched_platform_name:
+        return new_plan_matched_platform_name
+    return new_plan_matched_build_for

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -270,12 +270,10 @@ class Application:
         )
 
         if platform and not build_for:
-            if self._build_plan:
-                build_for = self._build_plan[0].build_for
-            else:
-                raise errors.InvalidPlatformError(
-                    platform, list({p.platform for p in self._full_build_plan})
-                )
+            all_platforms = {b.platform: b for b in self._full_build_plan}
+            if platform not in all_platforms:
+                raise errors.InvalidPlatformError(platform, list(all_platforms.keys()))
+            build_for = all_platforms[platform].build_for
 
         # validate project grammar
         GrammarAwareProject.validate_grammar(yaml_data)

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -126,7 +126,7 @@ class EmptyBuildPlanError(CraftError):
 
     def __init__(self) -> None:
         message = "No build matches the current platform."
-        resolution = 'Check the "--platform" parameter.'
+        resolution = 'Check the "--platform" and "--build-for" parameters.'
 
         super().__init__(message=message, resolution=resolution)
 
@@ -136,7 +136,7 @@ class MultipleBuildsError(CraftError):
 
     def __init__(self) -> None:
         message = "Multiple builds match the current platform."
-        resolution = 'Check the "--platform" parameter.'
+        resolution = 'Check the "--platform" and "--bulld-for" parameter.'
 
         super().__init__(message=message, resolution=resolution)
 

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -136,7 +136,7 @@ class MultipleBuildsError(CraftError):
 
     def __init__(self) -> None:
         message = "Multiple builds match the current platform."
-        resolution = 'Check the "--platform" and "--bulld-for" parameter.'
+        resolution = 'Check the "--platform" and "--bulld-for" parameters.'
 
         super().__init__(message=message, resolution=resolution)
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -598,85 +598,215 @@ def test_run_error_debug(monkeypatch, mock_dispatcher, app, fake_project, error)
 
 
 _base = bases.BaseName("", "")
-_on_a_for_a = BuildInfo("p1", "a", "a", _base)
-_on_a_for_b = BuildInfo("p2", "a", "b", _base)
-_on_p3_for_p3 = BuildInfo("p3", "p3", "p3", _base)
-_on_p4_for_p3 = BuildInfo("p4", "p3", "p3", _base)
-_on_p4_for_p4 = BuildInfo("p4", "p4", "p4", _base)
+_pc_on_amd64_for_amd64 = BuildInfo(
+    platform="pc", build_on="amd64", build_for="amd64", base=_base
+)
+_pc_on_amd64_for_i386 = BuildInfo(
+    platform="legacy-pc", build_on="amd64", build_for="i386", base=_base
+)
+_amd64_on_amd64_for_amd64 = BuildInfo(
+    platform="amd64", build_on="amd64", build_for="amd64", base=_base
+)
+_i386_on_amd64_for_i386 = BuildInfo(
+    platform="i386", build_on="amd64", build_for="i386", base=_base
+)
+_i386_on_i386_for_i386 = BuildInfo(
+    platform="i386", build_on="i386", build_for="i386", base=_base
+)
 
 
 @pytest.mark.parametrize(
-    ("plan", "platform", "build_for", "host_arch", "result"),
+    ("_id", "plan", "platform", "build_for", "host_arch", "result"),
     [
-        ([_on_a_for_a], None, None, "a", [_on_a_for_a]),
-        ([_on_a_for_a], "p1", None, "a", [_on_a_for_a]),
-        ([_on_a_for_a], "p2", None, "a", []),
-        ([_on_a_for_a], None, "a", "a", [_on_a_for_a]),
-        ([_on_a_for_a], "p1", "a", "a", [_on_a_for_a]),
-        ([_on_a_for_a], "p2", "a", "a", []),
-        ([_on_a_for_a], None, "b", "a", []),
-        ([_on_a_for_a], None, "a", "b", []),
-        ([_on_a_for_a, _on_a_for_b], None, "b", "a", [_on_a_for_b]),
-        ([_on_a_for_a, _on_a_for_b], "p1", "b", "a", []),
-        ([_on_a_for_a, _on_a_for_b], "p2", "b", "a", [_on_a_for_b]),
-        ([_on_a_for_a, _on_a_for_b], None, "b", "b", []),
-        ([_on_a_for_a, _on_a_for_b], None, None, "b", []),
-        ([_on_a_for_a, _on_a_for_b], "p2", None, "b", []),
-        ([_on_a_for_a, _on_a_for_b], None, None, "a", [_on_a_for_a, _on_a_for_b]),
-        ([_on_a_for_a, _on_a_for_b], "p2", None, "a", [_on_a_for_b]),
-        ([_on_a_for_a, _on_p3_for_p3], None, "p3", "p3", [_on_p3_for_p3]),
-        ([_on_a_for_a, _on_p3_for_p3], "p3", None, "p3", [_on_p3_for_p3]),
-        ([_on_a_for_a, _on_p3_for_p3], "p3", "p3", "p3", [_on_p3_for_p3]),
-        ([_on_a_for_a, _on_p4_for_p3], None, "p3", "p3", [_on_p4_for_p3]),
-        ([_on_a_for_a, _on_p4_for_p3], "p3", None, "p3", []),
+        (0, [_pc_on_amd64_for_amd64], None, None, "amd64", [_pc_on_amd64_for_amd64]),
+        (1, [_pc_on_amd64_for_amd64], "pc", None, "amd64", [_pc_on_amd64_for_amd64]),
+        (2, [_pc_on_amd64_for_amd64], "legacy-pc", None, "amd64", []),
+        (3, [_pc_on_amd64_for_amd64], None, "amd64", "amd64", [_pc_on_amd64_for_amd64]),
+        (4, [_pc_on_amd64_for_amd64], "pc", "amd64", "amd64", [_pc_on_amd64_for_amd64]),
+        (5, [_pc_on_amd64_for_amd64], "legacy-pc", "amd64", "amd64", []),
+        (6, [_pc_on_amd64_for_amd64], None, "i386", "amd64", []),
+        (7, [_pc_on_amd64_for_amd64], None, "amd64", "i386", []),
         (
-            [_on_a_for_a, _on_p3_for_p3, _on_p4_for_p3],
+            8,
+            [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386],
             None,
-            "p3",
-            "p3",
-            [_on_p3_for_p3],
-        ),
-        ([_on_a_for_a, _on_p4_for_p3], "p4", "p3", "p3", [_on_p4_for_p3]),
-        (
-            [_on_a_for_a, _on_p3_for_p3, _on_p4_for_p3],
-            "p4",
-            "p3",
-            "p3",
-            [_on_p4_for_p3],
-        ),
-        ([_on_a_for_a, _on_p3_for_p3], None, "p4", "p3", []),
-        ([_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4], "p3", None, "p3", []),
-        ([_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4], "p3", None, "p4", []),
-        (
-            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
-            "p4",
-            None,
-            "p3",
-            [_on_p4_for_p3],
+            "i386",
+            "amd64",
+            [_pc_on_amd64_for_i386],
         ),
         (
-            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
-            "p4",
-            None,
-            "p4",
-            [_on_p4_for_p4],
+            9,
+            [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386],
+            "pc",
+            "amd64",
+            "i386",
+            [],
         ),
         (
-            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
+            10,
+            [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386],
+            "legacy-pc",
+            "i386",
+            "amd64",
+            [_pc_on_amd64_for_i386],
+        ),
+        (11, [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386], None, "i386", "i386", []),
+        (12, [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386], None, None, "i386", []),
+        (
+            13,
+            [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386],
+            "legacy-pc",
             None,
-            "p4",
-            "p4",
-            [_on_p4_for_p4],
+            "i386",
+            [],
         ),
         (
-            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
-            "p4",
+            14,
+            [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386],
             None,
             None,
-            [_on_p4_for_p3, _on_p4_for_p4],
+            "amd64",
+            [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386],
+        ),
+        (
+            15,
+            [_pc_on_amd64_for_amd64, _pc_on_amd64_for_i386],
+            "legacy-pc",
+            None,
+            "amd64",
+            [_pc_on_amd64_for_i386],
+        ),
+        (
+            16,
+            [_pc_on_amd64_for_amd64, _amd64_on_amd64_for_amd64],
+            None,
+            "amd64",
+            "amd64",
+            [_amd64_on_amd64_for_amd64],
+        ),
+        (
+            17,
+            [_pc_on_amd64_for_amd64, _amd64_on_amd64_for_amd64],
+            "amd64",
+            None,
+            "amd64",
+            [_amd64_on_amd64_for_amd64],
+        ),
+        (
+            18,
+            [_pc_on_amd64_for_amd64, _amd64_on_amd64_for_amd64],
+            "amd64",
+            "amd64",
+            "amd64",
+            [_amd64_on_amd64_for_amd64],
+        ),
+        (
+            19,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386],
+            None,
+            "i386",
+            "amd64",
+            [_i386_on_amd64_for_i386],
+        ),
+        (
+            20,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386],
+            "amd64",
+            None,
+            "amd64",
+            [],
+        ),
+        (
+            21,
+            [
+                _pc_on_amd64_for_amd64,
+                _amd64_on_amd64_for_amd64,
+                _i386_on_amd64_for_i386,
+            ],
+            None,
+            "amd64",
+            "amd64",
+            [_amd64_on_amd64_for_amd64],
+        ),
+        (
+            22,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386],
+            "i386",
+            "i386",
+            "amd64",
+            [_i386_on_amd64_for_i386],
+        ),
+        (
+            23,
+            [
+                _pc_on_amd64_for_amd64,
+                _amd64_on_amd64_for_amd64,
+                _i386_on_amd64_for_i386,
+            ],
+            None,
+            "i386",
+            "amd64",
+            [_i386_on_amd64_for_i386],
+        ),
+        (
+            24,
+            [_pc_on_amd64_for_amd64, _amd64_on_amd64_for_amd64],
+            None,
+            "i386",
+            "amd64",
+            [],
+        ),
+        (
+            25,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386, _i386_on_i386_for_i386],
+            "amd64",
+            None,
+            "amd64",
+            [],
+        ),
+        (
+            26,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386, _i386_on_i386_for_i386],
+            "amd64",
+            None,
+            "i386",
+            [],
+        ),
+        (
+            27,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386, _i386_on_i386_for_i386],
+            "i386",
+            None,
+            "amd64",
+            [_i386_on_amd64_for_i386],
+        ),
+        (
+            28,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386, _i386_on_i386_for_i386],
+            "i386",
+            None,
+            "i386",
+            [_i386_on_i386_for_i386],
+        ),
+        (
+            29,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386, _i386_on_i386_for_i386],
+            None,
+            "i386",
+            "i386",
+            [_i386_on_i386_for_i386],
+        ),
+        (
+            30,
+            [_pc_on_amd64_for_amd64, _i386_on_amd64_for_i386, _i386_on_i386_for_i386],
+            "i386",
+            None,
+            None,
+            [_i386_on_amd64_for_i386, _i386_on_i386_for_i386],
         ),
     ],
 )
+@pytest.mark.usefixtures("_id")
 def test_filter_plan(mocker, plan, platform, build_for, host_arch, result):
     mocker.patch("craft_application.util.get_host_architecture", return_value=host_arch)
     assert application._filter_plan(plan, platform, build_for, host_arch) == result

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -600,6 +600,8 @@ def test_run_error_debug(monkeypatch, mock_dispatcher, app, fake_project, error)
 _base = bases.BaseName("", "")
 _on_a_for_a = BuildInfo("p1", "a", "a", _base)
 _on_a_for_b = BuildInfo("p2", "a", "b", _base)
+_on_p3_for_p3 = BuildInfo("p3", "p3", "p3", _base)
+_on_p4_for_p3 = BuildInfo("p4", "p3", "p3", _base)
 
 
 @pytest.mark.parametrize(
@@ -621,6 +623,27 @@ _on_a_for_b = BuildInfo("p2", "a", "b", _base)
         ([_on_a_for_a, _on_a_for_b], "p2", None, "b", []),
         ([_on_a_for_a, _on_a_for_b], None, None, "a", [_on_a_for_a, _on_a_for_b]),
         ([_on_a_for_a, _on_a_for_b], "p2", None, "a", [_on_a_for_b]),
+        ([_on_a_for_a, _on_p3_for_p3], None, "p3", "p3", [_on_p3_for_p3]),
+        ([_on_a_for_a, _on_p3_for_p3], "p3", None, "p3", [_on_p3_for_p3]),
+        ([_on_a_for_a, _on_p3_for_p3], "p3", "p3", "p3", [_on_p3_for_p3]),
+        ([_on_a_for_a, _on_p4_for_p3], None, "p3", "p3", [_on_p4_for_p3]),
+        ([_on_a_for_a, _on_p4_for_p3], "p3", None, "p3", []),
+        (
+            [_on_a_for_a, _on_p3_for_p3, _on_p4_for_p3],
+            None,
+            "p3",
+            "p3",
+            [_on_p3_for_p3],
+        ),
+        ([_on_a_for_a, _on_p4_for_p3], "p4", "p3", "p3", [_on_p4_for_p3]),
+        (
+            [_on_a_for_a, _on_p3_for_p3, _on_p4_for_p3],
+            "p4",
+            "p3",
+            "p3",
+            [_on_p4_for_p3],
+        ),
+        ([_on_a_for_a, _on_p3_for_p3], None, "p4", "p3", []),
     ],
 )
 def test_filter_plan(mocker, plan, platform, build_for, host_arch, result):

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -602,6 +602,7 @@ _on_a_for_a = BuildInfo("p1", "a", "a", _base)
 _on_a_for_b = BuildInfo("p2", "a", "b", _base)
 _on_p3_for_p3 = BuildInfo("p3", "p3", "p3", _base)
 _on_p4_for_p3 = BuildInfo("p4", "p3", "p3", _base)
+_on_p4_for_p4 = BuildInfo("p4", "p4", "p4", _base)
 
 
 @pytest.mark.parametrize(
@@ -644,11 +645,41 @@ _on_p4_for_p3 = BuildInfo("p4", "p3", "p3", _base)
             [_on_p4_for_p3],
         ),
         ([_on_a_for_a, _on_p3_for_p3], None, "p4", "p3", []),
+        ([_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4], "p3", None, "p3", []),
+        ([_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4], "p3", None, "p4", []),
+        (
+            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
+            "p4",
+            None,
+            "p3",
+            [_on_p4_for_p3],
+        ),
+        (
+            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
+            "p4",
+            None,
+            "p4",
+            [_on_p4_for_p4],
+        ),
+        (
+            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
+            None,
+            "p4",
+            "p4",
+            [_on_p4_for_p4],
+        ),
+        (
+            [_on_a_for_a, _on_p4_for_p3, _on_p4_for_p4],
+            "p4",
+            None,
+            None,
+            [_on_p4_for_p3, _on_p4_for_p4],
+        ),
     ],
 )
 def test_filter_plan(mocker, plan, platform, build_for, host_arch, result):
     mocker.patch("craft_application.util.get_host_architecture", return_value=host_arch)
-    assert application._filter_plan(plan, platform, build_for) == result
+    assert application._filter_plan(plan, platform, build_for, host_arch) == result
 
 
 @pytest.fixture()


### PR DESCRIPTION
Filter plans based on `platform`, `build-on`, and `build-for`.

Use `platform` if it matched `build-for`

There is an API change that `_filter_plan` now need `host_arch` parameter, which can be used in remote builds.

Fixes: #254