### PR TITLE
fix(application): return the correct error code

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -491,6 +491,7 @@ class Application:
             return_code = 128 + signal.SIGINT
         except craft_cli.CraftError as err:
             self._emit_error(err)
+            return_code = err.retcode
         except craft_parts.PartsError as err:
             self._emit_error(
                 craft_cli.CraftError(

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -563,6 +563,11 @@ def test_run_success_managed_inside_managed(
             64,
             "Argument parsing error\n",
         ),
+        (
+            craft_cli.CraftError("Arbitrary return code", retcode=69),
+            69,
+            "Arbitrary return code\n",
+        ),
     ],
 )
 def test_run_error(


### PR DESCRIPTION
If a CraftError (or subclass) is raised when running the application, use its return code.

Credit for finding this bug goes to @syu-w 

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
