### PR TITLE
feat: always process the project's grammar

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -551,7 +551,20 @@ class Application:
             self._render_secrets(yaml_data)
 
         # Expand grammar.
-        if build_for and "parts" in yaml_data:
+        if "parts" in yaml_data:
+            if not build_for:
+                # At the moment there is no perfect solution for what do to do
+                # resolve the grammar if there's no explicitly-provided target
+                # arch. However, we must resolve it with *something* otherwise
+                # we might have an invalid parts definition full of grammar
+                # declarations.
+                if self._build_plan:
+                    # If we have a build plan use one of its items, because
+                    # it's likely contemplated on the grammar.
+                    build_for = self._build_plan[0].build_for
+                else:
+                    # As a last resort, default to the same arch as the host.
+                    build_for = build_on
             craft_cli.emit.debug(f"Processing grammar (on {build_on} for {build_for})")
             yaml_data["parts"] = grammar.process_parts(
                 parts_yaml_data=yaml_data["parts"],

--- a/tests/integration/data/valid_projects/grammar/src/on-amd64-to-amd64/hello.txt
+++ b/tests/integration/data/valid_projects/grammar/src/on-amd64-to-amd64/hello.txt
@@ -1,0 +1,1 @@
+on-amd64-to-amd64

--- a/tests/integration/data/valid_projects/grammar/src/on-amd64-to-arm64/hello.txt
+++ b/tests/integration/data/valid_projects/grammar/src/on-amd64-to-arm64/hello.txt
@@ -1,0 +1,1 @@
+on-amd64-to-arm64

--- a/tests/integration/data/valid_projects/grammar/stderr
+++ b/tests/integration/data/valid_projects/grammar/stderr
@@ -1,0 +1,1 @@
+Packed package_1.0.tar.zst

--- a/tests/integration/data/valid_projects/grammar/testcraft.yaml
+++ b/tests/integration/data/valid_projects/grammar/testcraft.yaml
@@ -1,0 +1,11 @@
+name: empty
+title: A most basic project
+version: 1.0
+base: ["ubuntu", "22.04"]
+
+parts:
+  hello-world:
+    plugin: dump
+    source:
+      - on amd64 to amd64: src/on-amd64-to-amd64
+      - on amd64 to arm64: src/on-amd64-to-arm64

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -34,7 +34,15 @@ import craft_parts
 import craft_providers
 import pytest
 import pytest_check
-from craft_application import application, commands, errors, secrets, services, util
+from craft_application import (
+    application,
+    commands,
+    errors,
+    models,
+    secrets,
+    services,
+    util,
+)
 from craft_application.models import BuildInfo
 from craft_application.util import (
     get_host_architecture,  # pyright: ignore[reportGeneralTypeIssues]
@@ -42,6 +50,8 @@ from craft_application.util import (
 from craft_parts.plugins.plugins import PluginType
 from craft_providers import bases
 from overrides import override
+
+from tests.conftest import MyBuildPlanner
 
 EMPTY_COMMAND_GROUP = craft_cli.CommandGroup("FakeCommands", [])
 BASIC_PROJECT_YAML = """
@@ -876,3 +886,81 @@ def test_mandatory_adoptable_fields(tmp_path, app_metadata, fake_services):
         str(exc_info.value)
         == "Required field 'license' is not set and 'adopt-info' not used."
     )
+
+
+@pytest.fixture()
+def grammar_project(tmp_path):
+    """A project that builds on amd64 to riscv64 and s390x."""
+    contents = dedent(
+        """\
+    name: myproject
+    version: 1.0
+    parts:
+      mypart:
+        plugin: nil
+        source:
+        - on amd64 to riscv64: on-amd64-to-riscv64
+        - on amd64 to s390x: on-amd64-to-s390x
+    """
+    )
+    project_file = tmp_path / "testcraft.yaml"
+    project_file.write_text(contents)
+
+
+@pytest.fixture()
+def grammar_build_plan(mocker):
+    """A build plan to build on amd64 to riscv64 and s390x."""
+    host_arch = "amd64"
+    base = util.get_host_base()
+    build_plan = []
+    for build_for in ("riscv64", "s390x"):
+        build_plan.append(
+            models.BuildInfo(
+                f"platform-{build_for}",
+                host_arch,
+                build_for,
+                base,
+            )
+        )
+
+    mocker.patch.object(MyBuildPlanner, "get_build_plan", return_value=build_plan)
+
+
+@pytest.fixture()
+def grammar_app(
+    tmp_path,
+    grammar_project,  # noqa: ARG001
+    grammar_build_plan,  # noqa: ARG001
+    app_metadata,
+    fake_services,
+):
+    app = application.Application(app_metadata, fake_services)
+    app.project_dir = tmp_path
+
+    return app
+
+
+def test_process_grammar_build_for(grammar_app):
+    """Test that a provided build-for is used to process the grammar."""
+    project = grammar_app.get_project(build_for="s390x")
+    assert project.parts["mypart"]["source"] == "on-amd64-to-s390x"
+
+
+def test_process_grammar_platform(grammar_app):
+    """Test that a provided platform is used to process the grammar."""
+    project = grammar_app.get_project(platform="platform-riscv64")
+    assert project.parts["mypart"]["source"] == "on-amd64-to-riscv64"
+
+
+def test_process_grammar_default(grammar_app):
+    """Test that if nothing is provided the first BuildInfo is used by the grammar."""
+    project = grammar_app.get_project()
+    assert project.parts["mypart"]["source"] == "on-amd64-to-riscv64"
+
+
+def test_process_grammar_no_match(grammar_app, mocker):
+    """Test that if the build plan is empty, the grammar uses the host as target arch."""
+    mocker.patch("craft_application.util.get_host_architecture", return_value="i386")
+    project = grammar_app.get_project()
+    # "source" is empty because "i386" doesn't match any of the grammar statements.
+    assert project.parts["mypart"]["source"] is None


### PR DESCRIPTION
The problem this commit addresses is this: Consider the following snippet:

```
parts:
  hello-world:
    plugin: dump
    source:
      - on amd64 to arm64: src/on-amd64-to-arm64
      - on amd64 to armhf: src/on-amd64-to-armhf
```

... what should happen if the command `toolname clean --destructive-mode` is executed? Currently it breaks, because the grammar is not processed without an explict target arch (provided directly through the "--build-for" parameter or indirectly via the "--platform" one). This is at least inconvenient, and goes against the guideline we adopted for cleaning projects with multiple infos on the build-plan (accept the "wrong" config and remove the files).

There is no obvious, perfect answer here because at the stage that the grammar is currently processed we don't know yet what kind of command we are dealing with. Maybe the command needs the parts, maybe it doesn't. Possibly as a stop gap,
 this commit introduces the following logic:

- If build-for is provided, use that (current behavior);
- If the build plan has items, use the build-for of the first one arbitrarily, just to be able to resolve and remove the grammar statements;
- Otherwise, use the host arch as build-for.

This last option is risky because there's a chance it won't generate a valid parts declaration (see the new tests). That's not as bad as it looks, because either the command won't need the parts (and thus that declaration will be ignored), or it will and the lifecycle service will then generate its own error.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
