### PR TITLE
fix(app): always "emit" version message

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -384,8 +384,8 @@ class Application:
                 global_args = dispatcher.pre_parse_args(sys.argv[1:])
 
             if global_args.get("version"):
+                craft_cli.emit.message(f"{self.app.name} {self.app.version}")
                 craft_cli.emit.ended_ok()
-                print(f"{self.app.name} {self.app.version}")
                 sys.exit(0)
         except craft_cli.ProvideHelpException as err:
             print(err, file=sys.stderr)  # to stderr, as argparse normally does

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -103,7 +103,7 @@ INVALID_PROJECTS_DIR = TEST_DATA_DIR / "invalid_projects"
         (["-h"], "", BASIC_USAGE, 0),
         (["--version"], VERSION_INFO, "", 0),
         (["-V"], VERSION_INFO, "", 0),
-        (["-q", "--version"], VERSION_INFO, "", 0),
+        (["-q", "--version"], "", "", 0),
         (["--invalid-parameter"], "", BASIC_USAGE, 64),
         (["non-command"], "", INVALID_COMMAND, 64),
     ],

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -430,14 +430,13 @@ def test_fails_without_project(
     "argv",
     [["testcraft", "--version"], ["testcraft", "-V"], ["testcraft", "pull", "-V"]],
 )
-def test_run_outputs_version(monkeypatch, capsys, app, argv):
+def test_run_outputs_version(monkeypatch, emitter, app, argv):
     monkeypatch.setattr(sys, "argv", argv)
 
     with pytest.raises(SystemExit):
         app._get_dispatcher()
 
-    out, _ = capsys.readouterr()
-    assert out == "testcraft 3.14159\n"
+    emitter.assert_message("testcraft 3.14159")
 
 
 def test_show_app_name_and_version(monkeypatch, capsys, app):


### PR DESCRIPTION
This fixes an inconsistency between the command and the global flag as now both use the emitter to print the version.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
