### PR TITLE
fix(log): allows set logging verbosity level from env

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -684,6 +684,8 @@ class Application:
             streaming_brief=True,
         )
 
+        craft_cli.emit.debug(f"Log verbosity level set to {emitter_mode.name}")
+
         if invaild_emitter_level:
             craft_cli.emit.progress(
                 f"Invalid verbosity level '{emitter_verbosity_level_env}', using default 'BRIEF'.\n"

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -662,7 +662,7 @@ class Application:
         # the specific application doesn't use a specific library, the call does not
         # import the package.
         emitter_mode: craft_cli.EmitterMode = craft_cli.EmitterMode.BRIEF
-        invaild_emitter_level = False
+        invalid_emitter_level = False
         util.setup_loggers(*self._cli_loggers)
 
         # environment variable takes precedence over the default
@@ -674,7 +674,7 @@ class Application:
                     emitter_verbosity_level_env.strip().upper()
                 ]
             except KeyError:
-                invaild_emitter_level = True
+                invalid_emitter_level = True
 
         craft_cli.emit.init(
             mode=emitter_mode,
@@ -686,7 +686,7 @@ class Application:
 
         craft_cli.emit.debug(f"Log verbosity level set to {emitter_mode.name}")
 
-        if invaild_emitter_level:
+        if invalid_emitter_level:
             craft_cli.emit.progress(
                 f"Invalid verbosity level '{emitter_verbosity_level_env}', using default 'BRIEF'.\n"
                 f"Valid levels are: {', '.join(emitter.name for emitter in craft_cli.EmitterMode)}",

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -323,7 +323,10 @@ class Application:
             if build_for and build_for != build_info.build_for:
                 continue
 
-            env = {"CRAFT_PLATFORM": build_info.platform}
+            env = {
+                "CRAFT_PLATFORM": build_info.platform,
+                "CRAFT_VERBOSITY_LEVEL": craft_cli.emit.get_mode().name,
+            }
 
             if self.app.features.build_secrets:
                 # If using build secrets, put them in the environment of the managed

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -666,9 +666,7 @@ class Application:
         util.setup_loggers(*self._cli_loggers)
 
         # environment variable takes precedence over the default
-        emitter_verbosity_level_env = os.environ.get(
-            f"{self.app.name.upper()}_VERBOSITY_LEVEL", None
-        ) or os.environ.get("CRAFT_VERBOSITY_LEVEL", None)
+        emitter_verbosity_level_env = os.environ.get("CRAFT_VERBOSITY_LEVEL", None)
 
         if emitter_verbosity_level_env:
             try:

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -461,7 +461,7 @@ def test_set_verbosity_from_env(monkeypatch, capsys, app, verbosity):
 
     _, err = capsys.readouterr()
     assert "testcraft [help]" in err
-    assert craft_cli.emit.get_mode() == verbosity
+    assert craft_cli.emit._mode == verbosity
 
 
 def test_set_verbosity_from_env_incorrect(monkeypatch, capsys, app):
@@ -476,7 +476,7 @@ def test_set_verbosity_from_env_incorrect(monkeypatch, capsys, app):
     assert "testcraft [help]" in err
     assert "Invalid verbosity level 'incorrect'" in err
     assert "Valid levels are: QUIET, BRIEF, VERBOSE, DEBUG, TRACE" in err
-    assert craft_cli.emit.get_mode() == craft_cli.EmitterMode.BRIEF
+    assert craft_cli.emit._mode == craft_cli.EmitterMode.BRIEF
 
 
 def test_pre_run_project_dir_managed(app):

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -451,13 +451,10 @@ def test_show_app_name_and_version(monkeypatch, capsys, app):
 
 
 @pytest.mark.parametrize("verbosity", list(craft_cli.EmitterMode))
-@pytest.mark.parametrize(
-    "env_name", ["CRAFT_VERBOSITY_LEVEL", "TESTCRAFT_VERBOSITY_LEVEL"]
-)
-def test_set_verbosity_from_env(monkeypatch, capsys, app, verbosity, env_name):
+def test_set_verbosity_from_env(monkeypatch, capsys, app, verbosity):
     """Test that the emitter verbosity is set from the environment."""
     monkeypatch.setattr(sys, "argv", ["testcraft"])
-    monkeypatch.setenv(env_name, verbosity.name)
+    monkeypatch.setenv("CRAFT_VERBOSITY_LEVEL", verbosity.name)
 
     with pytest.raises(SystemExit):
         app.run()
@@ -467,13 +464,10 @@ def test_set_verbosity_from_env(monkeypatch, capsys, app, verbosity, env_name):
     assert craft_cli.emit._mode == verbosity
 
 
-@pytest.mark.parametrize(
-    "env_name", ["CRAFT_VERBOSITY_LEVEL", "TESTCRAFT_VERBOSITY_LEVEL"]
-)
-def test_set_verbosity_from_env_incorrect(monkeypatch, capsys, app, env_name):
+def test_set_verbosity_from_env_incorrect(monkeypatch, capsys, app):
     """Test that the emitter verbosity is using the default level when invalid."""
     monkeypatch.setattr(sys, "argv", ["testcraft"])
-    monkeypatch.setenv(env_name, "incorrect")
+    monkeypatch.setenv("CRAFT_VERBOSITY_LEVEL", "incorrect")
 
     with pytest.raises(SystemExit):
         app.run()

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -461,7 +461,7 @@ def test_set_verbosity_from_env(monkeypatch, capsys, app, verbosity):
 
     _, err = capsys.readouterr()
     assert "testcraft [help]" in err
-    assert craft_cli.emit._mode == verbosity
+    assert craft_cli.emit.get_mode() == verbosity
 
 
 def test_set_verbosity_from_env_incorrect(monkeypatch, capsys, app):
@@ -476,7 +476,7 @@ def test_set_verbosity_from_env_incorrect(monkeypatch, capsys, app):
     assert "testcraft [help]" in err
     assert "Invalid verbosity level 'incorrect'" in err
     assert "Valid levels are: QUIET, BRIEF, VERBOSE, DEBUG, TRACE" in err
-    assert craft_cli.emit._mode == craft_cli.EmitterMode.BRIEF
+    assert craft_cli.emit.get_mode() == craft_cli.EmitterMode.BRIEF
 
 
 def test_pre_run_project_dir_managed(app):


### PR DESCRIPTION
Use `CRAFT_VERBOSITY_LEVEL` to set log emitter level. If the level is invaild, default to BRIEF and continue.
