### PR TITLE
fix: use correct package for version

### DIFF
--- a/craft_application/__init__.py
+++ b/craft_application/__init__.py
@@ -32,7 +32,7 @@ except ImportError:  # pragma: no cover
     from importlib.metadata import version, PackageNotFoundError
 
     try:
-        __version__ = version("craft-archives")
+        __version__ = version("craft-application")
     except PackageNotFoundError:
         __version__ = "dev"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,11 @@ line_length = 88
 minversion = "7.0"
 testpaths = "tests"
 xfail_strict = true
+addopts = "--strict-markers"
 markers = [
     "enable_features: Tests that require specific features",
+    "lxd: Tests that launch lxd containers",
+    "multipass: Tests that launch multipass VMs."
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
This ensures that all lxd/multipass containers/VMs for testcraft are
removed after testing.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
