### PR TITLE
feat(remote-build): allow a user-provided project

### DIFF
--- a/craft_application/launchpad/models/project.py
+++ b/craft_application/launchpad/models/project.py
@@ -37,7 +37,7 @@ import launchpadlib.errors  # type: ignore[import-untyped]
 from typing_extensions import Self, Any
 from typing import TYPE_CHECKING
 
-from ..models.base import LaunchpadObject
+from ..models.base import InformationType, LaunchpadObject
 from .. import errors
 
 if TYPE_CHECKING:
@@ -64,6 +64,7 @@ class Project(LaunchpadObject):
     display_name: str
     summary: str
     description: str
+    information_type: InformationType
 
     @classmethod
     def new(  # pyright: ignore[reportIncompatibleMethodOverride]

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -73,7 +73,9 @@ class RemoteBuildService(base.AppService):
     def set_project(self, name: str) -> None:
         """Set the name of the project to use."""
         if self._is_setup:
-            raise RuntimeError("Project name may only be set before starting or resuming builds.")
+            raise RuntimeError(
+                "Project name may only be set before starting or resuming builds."
+            )
         self._project_name = name
         try:
             self._lp_project = self.lp.get_project(self._project_name)
@@ -89,9 +91,12 @@ class RemoteBuildService(base.AppService):
     def is_project_private(self) -> bool:
         """Check whether the named project is private."""
         if not self._lp_project:
-            raise RuntimeError("Cannot check if the project is private before setting its name.")
+            raise RuntimeError(
+                "Cannot check if the project is private before setting its name."
+            )
         return self._lp_project.information_type not in (
-            launchpad.models.InformationType.PUBLIC, launchpad.models.InformationType.PUBLIC_SECURITY,
+            launchpad.models.InformationType.PUBLIC,
+            launchpad.models.InformationType.PUBLIC_SECURITY,
         )
 
     def set_timeout(self, seconds_in_future: int) -> None:

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -76,6 +76,13 @@ class RemoteBuildService(base.AppService):
             raise RuntimeError("Project name may only be set before starting or resuming builds.")
         self._project_name = name
 
+    def is_project_private(self, name: str) -> bool:
+        """Check whether the named project is private."""
+        project = self.lp.get_project(name=name)
+        return project.information_type not in (
+            launchpad.models.InformationType.PUBLIC, launchpad.models.InformationType.PUBLIC_SECURITY,
+        )
+
     def set_timeout(self, seconds_in_future: int) -> None:
         """Set the deadline to a certain number of seconds in the future."""
         self._deadline = time.monotonic_ns() + (seconds_in_future * 10**9)

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -76,17 +76,17 @@ class RemoteBuildService(base.AppService):
             raise RuntimeError(
                 "Project name may only be set before starting or resuming builds."
             )
-        self._project_name = name
         try:
-            self._lp_project = self.lp.get_project(self._project_name)
+            self._lp_project = self.lp.get_project(name)
         except launchpad.errors.NotFoundError:
             raise errors.CraftError(
-                message=f"Could not find project on Launchpad: {self._project_name}",
+                message=f"Could not find project on Launchpad: {name}",
                 resolution="Ensure the project exists and that you have access to it.",
                 retcode=77,  # EX_NOPERM from sysexits.h
                 reportable=False,
                 logpath_report=False,
             )
+        self._project_name = name
 
     def is_project_private(self) -> bool:
         """Check whether the named project is private."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,18 @@ def features(request) -> dict[str, bool]:
     return features
 
 
+@pytest.fixture(scope="session")
+def default_app_metadata() -> craft_application.AppMetadata:
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr(metadata, "version", lambda _: "3.14159")
+        return craft_application.AppMetadata(
+            "testcraft",
+            "A fake app for testing craft-application",
+            BuildPlannerClass=MyBuildPlanner,
+            source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
+        )
+
+
 @pytest.fixture()
 def app_metadata(features) -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,9 @@ import sys
 import tempfile
 
 import pytest
+from craft_application import launchpad
 from craft_application.services import provider
+from craft_application.services import remotebuild
 from craft_providers import lxd, multipass
 
 
@@ -51,6 +53,19 @@ def provider_service(app_metadata, fake_project, fake_build_plan, fake_services)
         build_plan=fake_build_plan,
         install_snap=False,
     )
+
+
+@pytest.fixture()
+def anonymous_remote_build_service(app_metadata, fake_project, fake_build_plan, fake_services):
+    """Provider service with install snap disabled for integration tests"""
+    service = remotebuild.RemoteBuildService(
+        app_metadata,
+        fake_services
+    )
+
+    service.lp = launchpad.Launchpad.anonymous("testcraft", cache_dir=None)
+
+    return service
 
 
 @pytest.fixture()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,9 +18,11 @@ import os
 import pathlib
 import sys
 import tempfile
+from unittest import mock
 
 import pytest
 from craft_application import launchpad
+from craft_application import services
 from craft_application.services import provider
 from craft_application.services import remotebuild
 from craft_providers import lxd, multipass
@@ -55,16 +57,11 @@ def provider_service(app_metadata, fake_project, fake_build_plan, fake_services)
     )
 
 
-@pytest.fixture()
-def anonymous_remote_build_service(app_metadata, fake_project, fake_build_plan, fake_services):
+@pytest.fixture(scope="session")
+def anonymous_remote_build_service(default_app_metadata):
     """Provider service with install snap disabled for integration tests"""
-    service = remotebuild.RemoteBuildService(
-        app_metadata,
-        fake_services
-    )
-
-    service.lp = launchpad.Launchpad.anonymous("testcraft", cache_dir=None)
-
+    service = remotebuild.RemoteBuildService(default_app_metadata, services=mock.Mock())
+    service.lp = launchpad.Launchpad.anonymous("testcraft")
     return service
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,9 +22,7 @@ from unittest import mock
 
 import pytest
 from craft_application import launchpad
-from craft_application import services
-from craft_application.services import provider
-from craft_application.services import remotebuild
+from craft_application.services import provider, remotebuild
 from craft_providers import lxd, multipass
 
 

--- a/tests/integration/services/test_remotebuild.py
+++ b/tests/integration/services/test_remotebuild.py
@@ -20,12 +20,17 @@ import pytest
 from craft_application import errors, launchpad
 
 
-def test_use_public_project(anonymous_remote_build_service):
+@pytest.fixture(scope="module", params=["charmcraft", "coreutils", "dpkg", "sudo"])
+def public_project_name(request):
+    return request.param
+
+
+def test_use_public_project(anonymous_remote_build_service, public_project_name):
     """Test that we can get a real (public) project using an anonymous client."""
-    anonymous_remote_build_service.set_project_name("charmcraft")
+    anonymous_remote_build_service.set_project_name(public_project_name)
     project: launchpad.models.Project = anonymous_remote_build_service._ensure_project()
 
-    assert project.name == "charmcraft"
+    assert project.name == public_project_name
 
 
 def test_error_with_nonexistent_project(anonymous_remote_build_service):
@@ -36,3 +41,7 @@ def test_error_with_nonexistent_project(anonymous_remote_build_service):
     with pytest.raises(errors.CraftError, match="Could not find project on Launchpad"):
         anonymous_remote_build_service._ensure_project()
 
+
+def test_project_is_public(anonymous_remote_build_service, public_project_name):
+    """Test that the given project is public."""
+    assert not anonymous_remote_build_service.is_project_private(public_project_name)

--- a/tests/integration/services/test_remotebuild.py
+++ b/tests/integration/services/test_remotebuild.py
@@ -1,0 +1,38 @@
+#  This file is part of craft-application.
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the remote build service."""
+
+import pytest
+
+from craft_application import errors, launchpad
+
+
+def test_use_public_project(anonymous_remote_build_service):
+    """Test that we can get a real (public) project using an anonymous client."""
+    anonymous_remote_build_service.set_project_name("charmcraft")
+    project: launchpad.models.Project = anonymous_remote_build_service._ensure_project()
+
+    assert project.name == "charmcraft"
+
+
+def test_error_with_nonexistent_project(anonymous_remote_build_service):
+    """Test failing gracefully with a nonexistent project."""
+    name = "this launchpad project does not exist!"
+
+    anonymous_remote_build_service.set_project_name(name)
+    with pytest.raises(errors.CraftError, match="Could not find project on Launchpad"):
+        anonymous_remote_build_service._ensure_project()
+

--- a/tests/integration/services/test_remotebuild.py
+++ b/tests/integration/services/test_remotebuild.py
@@ -16,8 +16,7 @@
 """Tests for the remote build service."""
 
 import pytest
-
-from craft_application import errors, launchpad
+from craft_application import errors
 
 
 @pytest.fixture(scope="module", params=["charmcraft", "coreutils", "dpkg", "sudo"])
@@ -36,7 +35,9 @@ def test_error_with_nonexistent_project(anonymous_remote_build_service):
     """Test failing gracefully with a nonexistent project."""
     name = "this launchpad project does not exist!"
 
-    with pytest.raises(errors.CraftError, match=f"Could not find project on Launchpad: {name}"):
+    with pytest.raises(
+        errors.CraftError, match=f"Could not find project on Launchpad: {name}"
+    ):
         anonymous_remote_build_service.set_project(name)
 
 

--- a/tests/integration/services/test_remotebuild.py
+++ b/tests/integration/services/test_remotebuild.py
@@ -27,21 +27,20 @@ def public_project_name(request):
 
 def test_use_public_project(anonymous_remote_build_service, public_project_name):
     """Test that we can get a real (public) project using an anonymous client."""
-    anonymous_remote_build_service.set_project_name(public_project_name)
-    project: launchpad.models.Project = anonymous_remote_build_service._ensure_project()
+    anonymous_remote_build_service.set_project(public_project_name)
 
-    assert project.name == public_project_name
+    assert anonymous_remote_build_service._lp_project.name == public_project_name
 
 
 def test_error_with_nonexistent_project(anonymous_remote_build_service):
     """Test failing gracefully with a nonexistent project."""
     name = "this launchpad project does not exist!"
 
-    anonymous_remote_build_service.set_project_name(name)
-    with pytest.raises(errors.CraftError, match="Could not find project on Launchpad"):
-        anonymous_remote_build_service._ensure_project()
+    with pytest.raises(errors.CraftError, match=f"Could not find project on Launchpad: {name}"):
+        anonymous_remote_build_service.set_project(name)
 
 
 def test_project_is_public(anonymous_remote_build_service, public_project_name):
     """Test that the given project is public."""
-    assert not anonymous_remote_build_service.is_project_private(public_project_name)
+    anonymous_remote_build_service.set_project(public_project_name)
+    assert not anonymous_remote_build_service.is_project_private()

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -42,7 +42,7 @@ def mock_lp_project(fake_launchpad, mock_project_entry):
 
 
 @pytest.mark.parametrize("name", ["some-project", "another-project"])
-def test_set_project__success(remote_build_service, mock_project_entry, name):
+def test_set_project_success(remote_build_service, mock_project_entry, name):
     mock_project_entry.name = name
     remote_build_service.lp.lp.projects = {name: mock_project_entry}
 

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -26,6 +26,7 @@ from craft_application.remote import git
 
 from tests.unit.services.conftest import (
     get_mock_callable,
+    mock_project_entry,
 )
 
 
@@ -81,6 +82,26 @@ def test_ensure_project_new(remote_build_service):
     )
 
     remote_build_service._ensure_project()
+
+
+@pytest.mark.parametrize(
+    ("information_type", "expected"),
+    [
+        (launchpad.models.InformationType.PUBLIC, False),
+        (launchpad.models.InformationType.PUBLIC_SECURITY, False),
+        (launchpad.models.InformationType.PRIVATE, True),
+        (launchpad.models.InformationType.PRIVATE_SECURITY, True),
+        (launchpad.models.InformationType.PROPRIETARY, True),
+        (launchpad.models.InformationType.EMBARGOED, True),
+    ]
+)
+def test_is_project_private(remote_build_service, mock_project_entry, information_type, expected):
+    mock_project_entry.information_type = str(information_type.value)
+    remote_build_service.lp.lp.projects = {
+        "test-project": mock_project_entry
+    }
+
+    assert remote_build_service.is_project_private("test-project") == expected
 
 
 def test_new_repository(

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -21,12 +21,11 @@ from unittest import mock
 import lazr.restfulclient.errors
 import lazr.restfulclient.resource
 import pytest
-from craft_application import errors, launchpad, services
+from craft_application import errors, launchpad
 from craft_application.remote import git
 
 from tests.unit.services.conftest import (
     get_mock_callable,
-    mock_project_entry,
 )
 
 
@@ -60,11 +59,15 @@ def test_set_project_name_error(remote_build_service, mock_project_entry, name):
         lazr.restfulclient.errors.NotFound("yo", "dawg")
     )
 
-    with pytest.raises(errors.CraftError, match=f"Could not find project on Launchpad: {name}") as exc_info:
+    with pytest.raises(
+        errors.CraftError, match=f"Could not find project on Launchpad: {name}"
+    ) as exc_info:
         remote_build_service.set_project(name)
 
-    assert exc_info.value.resolution == "Ensure the project exists and that you have access to it."
-
+    assert (
+        exc_info.value.resolution
+        == "Ensure the project exists and that you have access to it."
+    )
 
 
 def test_ensure_project_existing(remote_build_service, mock_project_entry):
@@ -92,20 +95,23 @@ def test_ensure_project_new(remote_build_service):
         (launchpad.models.InformationType.PRIVATE_SECURITY, True),
         (launchpad.models.InformationType.PROPRIETARY, True),
         (launchpad.models.InformationType.EMBARGOED, True),
-    ]
+    ],
 )
-def test_is_project_private(remote_build_service, mock_project_entry, information_type, expected):
+def test_is_project_private(
+    remote_build_service, mock_project_entry, information_type, expected
+):
     mock_project_entry.information_type = str(information_type.value)
-    remote_build_service.lp.lp.projects = {
-        "test-project": mock_project_entry
-    }
+    remote_build_service.lp.lp.projects = {"test-project": mock_project_entry}
 
     remote_build_service.set_project("test-project")
     assert remote_build_service.is_project_private() == expected
 
 
 def test_is_project_private_error(remote_build_service):
-    with pytest.raises(RuntimeError, match="Cannot check if the project is private before setting its name."):
+    with pytest.raises(
+        RuntimeError,
+        match="Cannot check if the project is private before setting its name.",
+    ):
         remote_build_service.is_project_private()
 
 


### PR DESCRIPTION
This allows a command to set a user-provided project for remote build.
No protections are set up around this.
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
