### PR TITLE
feat!: validate devel bases

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -70,6 +70,7 @@ class AppMetadata:
     """Metadata about a *craft application."""
 
     name: str
+    ProjectClass: type[models.Project]
     summary: str | None = None
     version: str = field(init=False)
     source_ignore_patterns: list[str] = field(default_factory=lambda: [])
@@ -78,7 +79,6 @@ class AppMetadata:
     project_variables: list[str] = field(default_factory=lambda: ["version"])
     mandatory_adoptable_fields: list[str] = field(default_factory=lambda: ["version"])
 
-    ProjectClass: type[models.Project] = models.Project  # type: ignore[type-abstract]
     BuildPlannerClass: type[models.BuildPlanner] = field(
         default=NotImplementedError  # type: ignore[assignment,type-abstract]
     )

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -78,7 +78,7 @@ class AppMetadata:
     project_variables: list[str] = field(default_factory=lambda: ["version"])
     mandatory_adoptable_fields: list[str] = field(default_factory=lambda: ["version"])
 
-    ProjectClass: type[models.Project] = models.Project
+    ProjectClass: type[models.Project] = models.Project  # type: ignore[type-abstract]
     BuildPlannerClass: type[models.BuildPlanner] = field(
         default=NotImplementedError  # type: ignore[assignment,type-abstract]
     )

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -26,8 +26,7 @@ from craft_application.models.constraints import (
 from craft_application.models.grammar import GrammarAwareProject
 from craft_application.models.metadata import BaseMetadata
 from craft_application.models.project import (
-    CURRENT_DEVEL_BASE,
-    DEVEL_BASE,
+    DEVEL_BASE_INFOS,
     BuildInfo,
     BuildPlanner,
     Project,
@@ -37,8 +36,7 @@ from craft_application.models.project import (
 __all__ = [
     "BaseMetadata",
     "BuildInfo",
-    "CURRENT_DEVEL_BASE",
-    "DEVEL_BASE",
+    "DEVEL_BASE_INFOS",
     "CraftBaseConfig",
     "CraftBaseModel",
     "GrammarAwareProject",

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -25,12 +25,20 @@ from craft_application.models.constraints import (
 )
 from craft_application.models.grammar import GrammarAwareProject
 from craft_application.models.metadata import BaseMetadata
-from craft_application.models.project import BuildInfo, BuildPlanner, Project
+from craft_application.models.project import (
+    CURRENT_DEVEL_BASE,
+    DEVEL_BASE_WARNING,
+    BuildInfo,
+    BuildPlanner,
+    Project,
+)
 
 
 __all__ = [
     "BaseMetadata",
     "BuildInfo",
+    "CURRENT_DEVEL_BASE",
+    "DEVEL_BASE_WARNING",
     "CraftBaseConfig",
     "CraftBaseModel",
     "GrammarAwareProject",

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -1,6 +1,6 @@
 # This file is part of craft_application.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -27,7 +27,7 @@ from craft_application.models.grammar import GrammarAwareProject
 from craft_application.models.metadata import BaseMetadata
 from craft_application.models.project import (
     CURRENT_DEVEL_BASE,
-    DEVEL_BASE_WARNING,
+    DEVEL_BASE,
     BuildInfo,
     BuildPlanner,
     Project,
@@ -38,7 +38,7 @@ __all__ = [
     "BaseMetadata",
     "BuildInfo",
     "CURRENT_DEVEL_BASE",
-    "DEVEL_BASE_WARNING",
+    "DEVEL_BASE",
     "CraftBaseConfig",
     "CraftBaseModel",
     "GrammarAwareProject",

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -27,6 +27,7 @@ from craft_application.models.grammar import GrammarAwareProject
 from craft_application.models.metadata import BaseMetadata
 from craft_application.models.project import (
     DEVEL_BASE_INFOS,
+    DEVEL_BASE_WARNING,
     BuildInfo,
     BuildPlanner,
     Project,
@@ -37,6 +38,7 @@ __all__ = [
     "BaseMetadata",
     "BuildInfo",
     "DEVEL_BASE_INFOS",
+    "DEVEL_BASE_WARNING",
     "CraftBaseConfig",
     "CraftBaseModel",
     "GrammarAwareProject",

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -139,12 +139,13 @@ class Project(CraftBaseModel):
 
     @classmethod
     @abc.abstractmethod
-    def _providers_base(cls, base: str) -> craft_providers.bases.BaseAlias:
+    def _providers_base(cls, base: str) -> craft_providers.bases.BaseAlias | None:
         """Get a BaseAlias from the application's base.
 
         :param base: The application-specific base name.
 
-        :returns: The BaseAlias for the base.
+        :returns: The BaseAlias for the base or None if the base does not map to
+          a BaseAlias.
 
         :raises CraftValidationError: If the project's base cannot be determined.
         """
@@ -155,12 +156,16 @@ class Project(CraftBaseModel):
     def _validate_devel(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate the build-base is 'devel' for the current devel base."""
         base = values.get("base")
-
-        # if base is None, we do not need to validate the build-base
+        # if there is no base, do not validate the build-base
         if not base:
             return values
 
         base_alias = cls._providers_base(base)
+
+        # if the base does not map to a base alias, do not validate the build-base
+        if not base_alias:
+            return values
+
         build_base = values.get("build_base") or base
         build_base_alias = cls._providers_base(build_base)
 

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -141,7 +141,9 @@ class Project(CraftBaseModel):
         """Validate the build-base is 'devel' for the current devel base."""
         base = values.get("base")
         base_alias = cls._providers_base(base)
-        build_base_alias = cls._providers_base(values.get("build_base"))
+
+        build_base = values.get("build_base") or base
+        build_base_alias = cls._providers_base(build_base)
 
         if base_alias == CURRENT_DEVEL_BASE and build_base_alias != DEVEL_BASE:
             raise errors.CraftValidationError(

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -32,6 +32,7 @@ from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
 from craft_application import util
+from craft_application.models import DEVEL_BASE
 from craft_application.services import base
 from craft_application.util import platforms, snap_config
 
@@ -105,7 +106,7 @@ class ProviderService(base.ProjectService):
     ) -> Generator[craft_providers.Executor, None, None]:
         """Context manager for getting a provider instance.
 
-        :param base_name: A craft_providers capable base name (tuple of name, version)
+        :param build_info: Build information for the instance.
         :param work_dir: Local path to mount inside the provider instance.
         :param allow_unstable: Whether to allow the use of unstable images.
         :returns: a context manager of the provider instance.
@@ -115,6 +116,13 @@ class ProviderService(base.ProjectService):
         base_name = build_info.base
         base = self.get_base(base_name, instance_name=instance_name, **kwargs)
         provider = self.get_provider(name=self.__provider_name)
+
+        if base.alias == DEVEL_BASE:
+            emit.message(
+                "The development build-base should only be used for testing purposes, "
+                "as its contents are bound to change with the opening of new Ubuntu "
+                "releases, suddenly and without warning."
+            )
 
         emit.progress(f"Launching managed {base_name[0]} {base_name[1]} instance...")
         with provider.launched_environment(

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -32,7 +32,7 @@ from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
 from craft_application import util
-from craft_application.models import DEVEL_BASE
+from craft_application.models import DEVEL_BASE_INFOS
 from craft_application.services import base
 from craft_application.util import platforms, snap_config
 
@@ -117,7 +117,10 @@ class ProviderService(base.ProjectService):
         base = self.get_base(base_name, instance_name=instance_name, **kwargs)
         provider = self.get_provider(name=self.__provider_name)
 
-        if base.alias == DEVEL_BASE:
+        devel_bases = {
+            devel_base_info.devel_base for devel_base_info in DEVEL_BASE_INFOS
+        }
+        if base.alias in devel_bases:
             emit.message(
                 "The development build-base should only be used for testing purposes, "
                 "as its contents are bound to change with the opening of new Ubuntu "

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -32,7 +32,6 @@ from craft_providers.lxd import LXDProvider
 from craft_providers.multipass import MultipassProvider
 
 from craft_application import util
-from craft_application.models import DEVEL_BASE_INFOS
 from craft_application.services import base
 from craft_application.util import platforms, snap_config
 
@@ -116,16 +115,6 @@ class ProviderService(base.ProjectService):
         base_name = build_info.base
         base = self.get_base(base_name, instance_name=instance_name, **kwargs)
         provider = self.get_provider(name=self.__provider_name)
-
-        devel_bases = {
-            devel_base_info.devel_base for devel_base_info in DEVEL_BASE_INFOS
-        }
-        if base.alias in devel_bases:
-            emit.message(
-                "The development build-base should only be used for testing purposes, "
-                "as its contents are bound to change with the opening of new Ubuntu "
-                "releases, suddenly and without warning."
-            )
 
         emit.progress(f"Launching managed {base_name[0]} {base_name[1]} instance...")
         with provider.launched_environment(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,12 +74,12 @@ def features(request) -> dict[str, bool]:
 
 
 @pytest.fixture(scope="session")
-def default_app_metadata(fake_project_class) -> craft_application.AppMetadata:
+def default_app_metadata() -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
             "testcraft",
-            fake_project_class,
+            FakeProject,
             "A fake app for testing craft-application",
             BuildPlannerClass=MyBuildPlanner,
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,11 +74,12 @@ def features(request) -> dict[str, bool]:
 
 
 @pytest.fixture(scope="session")
-def default_app_metadata() -> craft_application.AppMetadata:
+def default_app_metadata(fake_project_class) -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
             "testcraft",
+            fake_project_class,
             "A fake app for testing craft-application",
             BuildPlannerClass=MyBuildPlanner,
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
@@ -91,9 +92,9 @@ def app_metadata(features, fake_project_class) -> craft_application.AppMetadata:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
             "testcraft",
+            fake_project_class,
             "A fake app for testing craft-application",
             BuildPlannerClass=MyBuildPlanner,
-            ProjectClass=fake_project_class,
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
             features=craft_application.AppFeatures(**features),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ import pytest
 from craft_application import application, models, services, util
 from craft_cli import EmitterMode, emit
 from craft_providers import bases
+from typing_extensions import override
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
@@ -85,22 +86,37 @@ def default_app_metadata() -> craft_application.AppMetadata:
 
 
 @pytest.fixture()
-def app_metadata(features) -> craft_application.AppMetadata:
+def app_metadata(features, fake_project_class) -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
             "testcraft",
             "A fake app for testing craft-application",
             BuildPlannerClass=MyBuildPlanner,
+            ProjectClass=fake_project_class,
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
             features=craft_application.AppFeatures(**features),
         )
 
 
+class FakeProject(models.Project):
+    """A fake project for testing."""
+
+    @override
+    @classmethod
+    def _providers_base(cls, base: str | None) -> bases.BaseAlias | None:
+        return None
+
+
 @pytest.fixture()
-def fake_project() -> models.Project:
+def fake_project_class() -> type[models.Project]:
+    return FakeProject
+
+
+@pytest.fixture()
+def fake_project(fake_project_class) -> models.Project:
     arch = util.get_host_architecture()
-    return models.Project(
+    return fake_project_class(
         name="full-project",  # pyright: ignore[reportArgumentType]
         title="A fully-defined project",  # pyright: ignore[reportArgumentType]
         base="core24",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,8 +105,8 @@ class FakeProject(models.Project):
 
     @override
     @classmethod
-    def _providers_base(cls, base: str | None) -> bases.BaseAlias | None:
-        return None
+    def _providers_base(cls, base: str) -> bases.BaseAlias:
+        return bases.get_base_alias(("ubuntu", "24.04"))
 
 
 @pytest.fixture()

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -25,6 +25,7 @@ from craft_application import util
 from craft_application.errors import CraftValidationError
 from craft_application.models import (
     DEVEL_BASE_INFOS,
+    DEVEL_BASE_WARNING,
     BuildPlanner,
     Project,
     constraints,
@@ -266,7 +267,7 @@ def test_effective_base_unknown():
     assert exc_info.match("Could not determine effective base")
 
 
-def test_devel_base_devel_build_base():
+def test_devel_base_devel_build_base(emitter):
     """Base can be 'devel' when the build-base is 'devel'."""
     _ = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
         name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
@@ -275,6 +276,8 @@ def test_devel_base_devel_build_base():
         base=DEVEL_BASE_INFOS[0].current_devel_base.value,
         build_base=DEVEL_BASE_INFOS[0].current_devel_base.value,
     )
+
+    emitter.assert_message(DEVEL_BASE_WARNING)
 
 
 def test_devel_base_no_base():
@@ -322,7 +325,7 @@ def test_devel_base_error():
         )
 
     assert exc_info.match(
-        f"build-base must be 'devel' when base is '{DEVEL_BASE_INFOS[0].current_devel_base.value}'"
+        f"A development build-base must be used when base is '{DEVEL_BASE_INFOS[0].current_devel_base.value}'"
     )
 
 

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -278,7 +278,21 @@ def test_devel_base_devel_build_base():
 
 
 def test_devel_base_no_base():
-    """Do not validate if base can be devel if the base is not set."""
+    """Do not validate the build-base if there is no base."""
+    _ = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
+        name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
+        version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
+        parts={},
+    )
+
+
+def test_devel_base_no_base_alias(mocker):
+    """Do not validate the build base if there is no base alias."""
+    mocker.patch(
+        "tests.unit.models.test_project.FakeBuildBaseProject._providers_base",
+        return_value=None
+    )
+
     _ = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
         name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
         version="1.0",  # pyright: ignore[reportGeneralTypeIssues]

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -290,7 +290,7 @@ def test_devel_base_no_base_alias(mocker):
     """Do not validate the build base if there is no base alias."""
     mocker.patch(
         "tests.unit.models.test_project.FakeBuildBaseProject._providers_base",
-        return_value=None
+        return_value=None,
     )
 
     _ = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -1,6 +1,6 @@
 # This file is part of craft-application.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -19,38 +19,58 @@ import pathlib
 import textwrap
 from textwrap import dedent
 
+import craft_providers.bases
 import pytest
 from craft_application import util
 from craft_application.errors import CraftValidationError
-from craft_application.models import BuildPlanner, Project, constraints
+from craft_application.models import (
+    CURRENT_DEVEL_BASE,
+    DEVEL_BASE,
+    BuildPlanner,
+    Project,
+    constraints,
+)
+from typing_extensions import override
 
 PROJECTS_DIR = pathlib.Path(__file__).parent / "project_models"
 PARTS_DICT = {"my-part": {"plugin": "nil"}}
-# pyright doesn't like these types and doesn't have a pydantic plugin like mypy.
-# Because of this, we need to silence several errors in these constants.
-BASIC_PROJECT = Project(  # pyright: ignore[reportCallIssue]
-    name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
-    version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
-    parts=PARTS_DICT,
-)
+
+
+@pytest.fixture()
+def basic_project(fake_project_class):
+    # pyright doesn't like these types and doesn't have a pydantic plugin like mypy.
+    # Because of this, we need to silence several errors in these constants.
+    return fake_project_class(  # pyright: ignore[reportCallIssue]
+        name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
+        version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
+        parts=PARTS_DICT,
+    )
+
+
 BASIC_PROJECT_DICT = {
     "name": "project-name",
     "version": "1.0",
     "parts": PARTS_DICT,
 }
-FULL_PROJECT = Project(  # pyright: ignore[reportCallIssue]
-    name="full-project",  # pyright: ignore[reportGeneralTypeIssues]
-    title="A fully-defined project",  # pyright: ignore[reportGeneralTypeIssues]
-    base="core24",
-    version="1.0.0.post64+git12345678",  # pyright: ignore[reportGeneralTypeIssues]
-    contact="author@project.org",
-    issues="https://github.com/canonical/craft-application/issues",
-    source_code="https://github.com/canonical/craft-application",  # pyright: ignore[reportGeneralTypeIssues]
-    summary="A fully-defined craft-application project.",  # pyright: ignore[reportGeneralTypeIssues]
-    description="A fully-defined craft-application project.\nWith more than one line.\n",
-    license="LGPLv3",
-    parts=PARTS_DICT,
-)
+
+
+@pytest.fixture()
+def full_project(fake_project_class):
+    return fake_project_class(  # pyright: ignore[reportCallIssue]
+        name="full-project",  # pyright: ignore[reportGeneralTypeIssues]
+        title="A fully-defined project",  # pyright: ignore[reportGeneralTypeIssues]
+        base="core24",
+        version="1.0.0.post64+git12345678",  # pyright: ignore[reportGeneralTypeIssues]
+        contact="author@project.org",
+        issues="https://github.com/canonical/craft-application/issues",
+        source_code="https://github.com/canonical/craft-application",  # pyright: ignore[reportGeneralTypeIssues]
+        summary="A fully-defined craft-application project.",  # pyright: ignore[reportGeneralTypeIssues]
+        description="A fully-defined craft-application project.\nWith more than one line.\n",
+        license="LGPLv3",
+        parts=PARTS_DICT,
+    )
+
+
 FULL_PROJECT_DICT = {
     "base": "core24",
     "contact": "author@project.org",
@@ -78,35 +98,41 @@ def full_project_dict():
 
 
 @pytest.mark.parametrize(
-    ("project", "project_dict"),
-    [(BASIC_PROJECT, BASIC_PROJECT_DICT), (FULL_PROJECT, FULL_PROJECT_DICT)],
+    ("project_fixture", "project_dict"),
+    [("basic_project", BASIC_PROJECT_DICT), ("full_project", FULL_PROJECT_DICT)],
 )
-def test_marshal(project, project_dict):
+def test_marshal(project_fixture, project_dict, request):
+    project = request.getfixturevalue(project_fixture)
+
     assert project.marshal() == project_dict
 
 
 @pytest.mark.parametrize(
-    ("project", "project_dict"),
-    [(BASIC_PROJECT, BASIC_PROJECT_DICT), (FULL_PROJECT, FULL_PROJECT_DICT)],
+    ("project_fixture", "project_dict"),
+    [("basic_project", BASIC_PROJECT_DICT), ("full_project", FULL_PROJECT_DICT)],
 )
-def test_unmarshal_success(project, project_dict):
-    assert Project.unmarshal(project_dict) == project
+def test_unmarshal_success(project_fixture, project_dict, fake_project_class, request):
+    project = request.getfixturevalue(project_fixture)
+
+    assert fake_project_class.unmarshal(project_dict) == project
 
 
 @pytest.mark.parametrize("data", [None, [], (), 0, ""])
-def test_unmarshal_error(data):
+def test_unmarshal_error(data, fake_project_class):
     with pytest.raises(TypeError):
-        Project.unmarshal(data)
+        fake_project_class.unmarshal(data)
 
 
-@pytest.mark.parametrize("project", [BASIC_PROJECT, FULL_PROJECT])
-def test_marshal_then_unmarshal(project):
-    assert Project.unmarshal(project.marshal()) == project
+@pytest.mark.parametrize("project_fixture", ["basic_project", "full_project"])
+def test_marshal_then_unmarshal(project_fixture, fake_project_class, request):
+    project = request.getfixturevalue(project_fixture)
+
+    assert fake_project_class.unmarshal(project.marshal()) == project
 
 
 @pytest.mark.parametrize("project_dict", [BASIC_PROJECT_DICT, FULL_PROJECT_DICT])
-def test_unmarshal_then_marshal(project_dict):
-    assert Project.unmarshal(project_dict).marshal() == project_dict
+def test_unmarshal_then_marshal(project_dict, fake_project_class):
+    assert fake_project_class.unmarshal(project_dict).marshal() == project_dict
 
 
 def test_build_planner_abstract():
@@ -115,15 +141,19 @@ def test_build_planner_abstract():
 
 
 @pytest.mark.parametrize(
-    ("project_file", "expected"),
+    ("project_file", "expected_fixture"),
     [
-        (PROJECTS_DIR / "basic_project.yaml", BASIC_PROJECT),
-        (PROJECTS_DIR / "full_project.yaml", FULL_PROJECT),
+        (PROJECTS_DIR / "basic_project.yaml", "basic_project"),
+        (PROJECTS_DIR / "full_project.yaml", "full_project"),
     ],
 )
-def test_from_yaml_file_success(project_file, expected):
+def test_from_yaml_file_success(
+    project_file, expected_fixture, fake_project_class, request
+):
+    expected = request.getfixturevalue(expected_fixture)
+
     with project_file.open():
-        actual = Project.from_yaml_file(project_file)
+        actual = fake_project_class.from_yaml_file(project_file)
 
     assert expected == actual
 
@@ -135,23 +165,26 @@ def test_from_yaml_file_success(project_file, expected):
         (PROJECTS_DIR / "invalid_project.yaml", CraftValidationError),
     ],
 )
-def test_from_yaml_file_failure(project_file, error_class):
+def test_from_yaml_file_failure(project_file, error_class, fake_project_class):
     with pytest.raises(error_class):
-        Project.from_yaml_file(project_file)
+        fake_project_class.from_yaml_file(project_file)
 
 
 @pytest.mark.parametrize(
-    ("project_file", "expected"),
+    ("project_file", "expected_fixture"),
     [
-        (PROJECTS_DIR / "basic_project.yaml", BASIC_PROJECT),
-        (PROJECTS_DIR / "full_project.yaml", FULL_PROJECT),
+        (PROJECTS_DIR / "basic_project.yaml", "basic_project"),
+        (PROJECTS_DIR / "full_project.yaml", "full_project"),
     ],
 )
-def test_from_yaml_data_success(project_file, expected):
+def test_from_yaml_data_success(
+    project_file, expected_fixture, fake_project_class, request
+):
+    expected = request.getfixturevalue(expected_fixture)
     with project_file.open() as file:
         data = util.safe_yaml_load(file)
 
-    actual = Project.from_yaml_data(data, project_file)
+    actual = fake_project_class.from_yaml_data(data, project_file)
 
     assert expected == actual
 
@@ -162,22 +195,23 @@ def test_from_yaml_data_success(project_file, expected):
         (PROJECTS_DIR / "invalid_project.yaml", CraftValidationError),
     ],
 )
-def test_from_yaml_data_failure(project_file, error_class):
+def test_from_yaml_data_failure(project_file, error_class, fake_project_class):
     with project_file.open() as file:
         data = util.safe_yaml_load(file)
 
     with pytest.raises(error_class):
-        Project.from_yaml_data(data, project_file)
+        fake_project_class.from_yaml_data(data, project_file)
 
 
 @pytest.mark.parametrize(
-    ("project", "expected_file"),
+    ("project_fixture", "expected_file"),
     [
-        (BASIC_PROJECT, PROJECTS_DIR / "basic_project.yaml"),
-        (FULL_PROJECT, PROJECTS_DIR / "full_project.yaml"),
+        ("basic_project", PROJECTS_DIR / "basic_project.yaml"),
+        ("full_project", PROJECTS_DIR / "full_project.yaml"),
     ],
 )
-def test_to_yaml_file(project, expected_file, tmp_path):
+def test_to_yaml_file(project_fixture, expected_file, tmp_path, request):
+    project = request.getfixturevalue(project_fixture)
     actual_file = tmp_path / "out.yaml"
 
     project.to_yaml_file(actual_file)
@@ -185,13 +219,26 @@ def test_to_yaml_file(project, expected_file, tmp_path):
     assert actual_file.read_text() == expected_file.read_text()
 
 
-@pytest.mark.parametrize("project", [FULL_PROJECT])
-def test_effective_base_is_base(project):
-    assert project.effective_base == project.base
+def test_effective_base_is_base(full_project):
+    assert full_project.effective_base == full_project.base
 
 
 class FakeBuildBaseProject(Project):
     build_base: str | None
+
+    @override
+    @classmethod
+    def _providers_base(
+        cls, base: str | None
+    ) -> craft_providers.bases.BaseAlias | None:
+        """Get a BaseAlias from the application's base."""
+        if not base:
+            return None
+
+        try:
+            return craft_providers.bases.get_base_alias(("ubuntu", base))
+        except craft_providers.errors.BaseConfigurationError:
+            return None
 
 
 # As above, we need to tell pyright to ignore several typing issues.
@@ -224,6 +271,32 @@ def test_effective_base_unknown():
     assert exc_info.match("Could not determine effective base")
 
 
+def test_devel_base():
+    """Base can be 'devel' only when the build-base is 'devel'."""
+    _ = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
+        name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
+        version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
+        parts={},
+        base=CURRENT_DEVEL_BASE.value,
+        build_base=DEVEL_BASE.value,
+    )
+
+
+def test_devel_base_error():
+    """Raise an error if base is 'devel' and build-base is not 'devel'."""
+    with pytest.raises(CraftValidationError) as exc_info:
+        FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
+            name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
+            version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
+            parts={},
+            base=CURRENT_DEVEL_BASE.value,
+        )
+
+    assert exc_info.match(
+        f"build-base must be 'devel' when base is '{CURRENT_DEVEL_BASE.value}'"
+    )
+
+
 @pytest.mark.parametrize(
     ("field_name", "invalid_value", "expected_message"),
     [
@@ -239,14 +312,14 @@ def test_effective_base_unknown():
     ],
 )
 def test_invalid_field_message(
-    full_project_dict, field_name, invalid_value, expected_message
+    full_project_dict, field_name, invalid_value, expected_message, fake_project_class
 ):
     """Test that invalid regex-based fields generate expected messages."""
     full_project_dict[field_name] = invalid_value
     project_path = pathlib.Path("myproject.yaml")
 
     with pytest.raises(CraftValidationError) as exc:
-        Project.from_yaml_data(full_project_dict, project_path)
+        fake_project_class.from_yaml_data(full_project_dict, project_path)
 
     full_expected_message = textwrap.dedent(
         f"""
@@ -259,44 +332,44 @@ def test_invalid_field_message(
     assert message == full_expected_message
 
 
-def test_unmarshal_repositories(full_project_dict):
+def test_unmarshal_repositories(full_project_dict, fake_project_class):
     """Test that package-repositories are allowed in Project with package repositories feature."""
     full_project_dict["package-repositories"] = [{"ppa": "ppa/ppa", "type": "apt"}]
     project_path = pathlib.Path("myproject.yaml")
-    project = Project.from_yaml_data(full_project_dict, project_path)
+    project = fake_project_class.from_yaml_data(full_project_dict, project_path)
 
     assert project.package_repositories == [{"ppa": "ppa/ppa", "type": "apt"}]
 
 
-def test_unmarshal_no_repositories(full_project_dict):
+def test_unmarshal_no_repositories(full_project_dict, fake_project_class):
     """Test that package-repositories are allowed to be None in Project with package repositories feature."""
     full_project_dict["package-repositories"] = None
     project_path = pathlib.Path("myproject.yaml")
 
-    project = Project.from_yaml_data(full_project_dict, project_path)
+    project = fake_project_class.from_yaml_data(full_project_dict, project_path)
 
     assert project.package_repositories is None
 
 
-def test_unmarshal_undefined_repositories(full_project_dict):
+def test_unmarshal_undefined_repositories(full_project_dict, fake_project_class):
     """Test that package-repositories are allowed to not exist in Project with package repositories feature."""
     if "package-repositories" in full_project_dict:
         del full_project_dict["package-repositories"]
 
     project_path = pathlib.Path("myproject.yaml")
 
-    project = Project.from_yaml_data(full_project_dict, project_path)
+    project = fake_project_class.from_yaml_data(full_project_dict, project_path)
 
     assert project.package_repositories is None
 
 
-def test_unmarshal_invalid_repositories(full_project_dict):
+def test_unmarshal_invalid_repositories(full_project_dict, fake_project_class):
     """Test that package-repositories are validated in Project with package repositories feature."""
     full_project_dict["package-repositories"] = [[]]
     project_path = pathlib.Path("myproject.yaml")
 
     with pytest.raises(CraftValidationError) as error:
-        Project.from_yaml_data(full_project_dict, project_path)
+        fake_project_class.from_yaml_data(full_project_dict, project_path)
 
     assert error.value.args[0] == (
         "Bad myproject.yaml content:\n"

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -241,19 +241,20 @@ class FakeBuildBaseProject(Project):
             return None
 
 
-# As above, we need to tell pyright to ignore several typing issues.
-BUILD_BASE_PROJECT = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
-    name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
-    version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
-    parts={},
-    base="incorrect",
-    build_base="correct",
-)
+def test_effective_base_is_build_base():
+    base = craft_providers.bases.ubuntu.BuilddBaseAlias.JAMMY.value
+    build_base = craft_providers.bases.ubuntu.BuilddBaseAlias.NOBLE.value
 
+    # As above, we need to tell pyright to ignore several typing issues.
+    project = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
+        name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
+        version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
+        parts={},
+        base=base,
+        build_base=build_base,
+    )
 
-@pytest.mark.parametrize("project", [BUILD_BASE_PROJECT])
-def test_effective_base_is_build_base(project):
-    assert project.effective_base == project.build_base
+    assert project.effective_base == build_base
 
 
 def test_effective_base_unknown():
@@ -271,14 +272,24 @@ def test_effective_base_unknown():
     assert exc_info.match("Could not determine effective base")
 
 
-def test_devel_base():
-    """Base can be 'devel' only when the build-base is 'devel'."""
+def test_devel_base_devel_build_base():
+    """Base can be 'devel' when the build-base is 'devel'."""
     _ = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
         name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
         version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
         parts={},
         base=CURRENT_DEVEL_BASE.value,
         build_base=DEVEL_BASE.value,
+    )
+
+
+def test_devel_base_no_build_base():
+    """Base can be 'devel' if the build-base is not set."""
+    _ = FakeBuildBaseProject(  # pyright: ignore[reportCallIssue]
+        name="project-name",  # pyright: ignore[reportGeneralTypeIssues]
+        version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
+        parts={},
+        base=CURRENT_DEVEL_BASE.value,
     )
 
 
@@ -290,6 +301,7 @@ def test_devel_base_error():
             version="1.0",  # pyright: ignore[reportGeneralTypeIssues]
             parts={},
             base=CURRENT_DEVEL_BASE.value,
+            build_base=craft_providers.bases.ubuntu.BuilddBaseAlias.JAMMY.value,
         )
 
     assert exc_info.match(

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -25,7 +25,7 @@ import craft_parts
 import craft_parts.callbacks
 import pytest
 import pytest_check
-from craft_application import errors, models, util
+from craft_application import errors, util
 from craft_application.errors import InvalidParameterError, PartsLifecycleError
 from craft_application.services import lifecycle
 from craft_application.util import repositories
@@ -659,11 +659,11 @@ def test_get_parallel_build_count_error(
 
 
 def test_lifecycle_project_variables(
-    app_metadata, fake_services, tmp_path, fake_build_plan
+    app_metadata, fake_services, tmp_path, fake_build_plan, fake_project_class
 ):
     """Test that project variables are set after the lifecycle runs."""
 
-    class LocalProject(models.Project):
+    class LocalProject(fake_project_class):
         color: str | None
 
     fake_project = LocalProject.unmarshal(

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -324,13 +324,6 @@ def test_instance(
         )
     with check:
         emitter.assert_progress("Launching managed .+ instance...", regex=True)
-    with check:
-        if base_name == ("ubuntu", "devel"):
-            emitter.assert_message(
-                "The development build-base should only be used for testing purposes, "
-                "as its contents are bound to change with the opening of new Ubuntu "
-                "releases, suddenly and without warning."
-            )
 
 
 def test_load_bashrc(emitter):

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -324,6 +324,13 @@ def test_instance(
         )
     with check:
         emitter.assert_progress("Launching managed .+ instance...", regex=True)
+    with check:
+        if base_name == ("ubuntu", "devel"):
+            emitter.assert_message(
+                "The development build-base should only be used for testing purposes, "
+                "as its contents are bound to change with the opening of new Ubuntu "
+                "releases, suddenly and without warning."
+            )
 
 
 def test_load_bashrc(emitter):

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -144,9 +144,11 @@ def test_mandatory_adoptable_field(
     fake_project,
     fake_lifecycle_service_class,
     fake_package_service_class,
+    fake_project_class,
 ):
     app_metadata = AppMetadata(
         "testcraft",
+        fake_project_class,
         "A fake app for testing craft-application",
         mandatory_adoptable_fields=["license"],
     )

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -71,38 +71,58 @@ def test_app_metadata_post_init_correct(summary):
     pytest_check.is_not_none(app.summary)
 
 
-def test_app_metadata_version_attribute(tmp_path, monkeypatch):
+def test_app_metadata_version_attribute(tmp_path, monkeypatch, fake_project_class):
     """Set the AppMetadata version from the main app package."""
     monkeypatch.syspath_prepend(tmp_path)
     (tmp_path / "dummycraft_version.py").write_text("__version__ = '1.2.3'")
 
-    app = application.AppMetadata(name="dummycraft_version", summary="dummy craft")
+    app = application.AppMetadata(
+        name="dummycraft_version",
+        ProjectClass=fake_project_class,
+        summary="dummy craft",
+    )
     assert app.version == "1.2.3"
 
 
-def test_app_metadata_importlib(tmp_path, monkeypatch, mocker):
+def test_app_metadata_importlib(tmp_path, monkeypatch, mocker, fake_project_class):
     """Set the AppMetadata version via importlib."""
     monkeypatch.syspath_prepend(tmp_path)
     (tmp_path / "dummycraft_importlib.py").write_text("print('hi')")
 
     mocker.patch.object(importlib.metadata, "version", return_value="4.5.6")
 
-    app = application.AppMetadata(name="dummycraft_importlib", summary="dummy craft")
+    app = application.AppMetadata(
+        name="dummycraft_importlib",
+        ProjectClass=fake_project_class,
+        summary="dummy craft",
+    )
     assert app.version == "4.5.6"
 
 
-def test_app_metadata_dev():
-    app = application.AppMetadata(name="dummycraft_dev", summary="dummy craft")
+def test_app_metadata_dev(fake_project_class):
+    app = application.AppMetadata(
+        name="dummycraft_dev",
+        ProjectClass=fake_project_class,
+        summary="dummy craft",
+    )
     assert app.version == "dev"
 
 
-def test_app_metadata_default_project_variables():
-    app = application.AppMetadata(name="dummycraft_dev", summary="dummy craft")
+def test_app_metadata_default_project_variables(fake_project_class):
+    app = application.AppMetadata(
+        name="dummycraft_dev",
+        ProjectClass=fake_project_class,
+        summary="dummy craft",
+    )
     assert app.project_variables == ["version"]
 
 
-def test_app_metadata_default_mandatory_adoptable_fields():
-    app = application.AppMetadata(name="dummycraft_dev", summary="dummy craft")
+def test_app_metadata_default_mandatory_adoptable_fields(fake_project_class):
+    app = application.AppMetadata(
+        name="dummycraft_dev",
+        ProjectClass=fake_project_class,
+        summary="dummy craft",
+    )
     assert app.mandatory_adoptable_fields == ["version"]
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Upstream `build-base` `devel` validation for all *craft applications.  This draft treats `devel` as the devel base, but I will update this to ~~26.04 before this PR can land~~ 24.10 when it is available.

Downstream integrations:
- https://github.com/canonical/charmcraft/pull/1634
- https://github.com/canonical/snapcraft/pull/4721
- https://github.com/canonical/rockcraft/pull/532

Fixes #298 
(CRAFT-2675)