### PR TITLE
tests: change snapcraft owner in launchpad

### DIFF
--- a/tests/integration/launchpad/test_anonymous_access.py
+++ b/tests/integration/launchpad/test_anonymous_access.py
@@ -47,7 +47,7 @@ def test_get_real_repository_by_path(anonymous_lp, name, path):
     [
         ("python-apt", "deity", "python-apt"),
         ("charmcraft", "charmcraft-team", "charmcraft"),
-        ("snapcraft", "sergiusens", "snapcraft"),
+        ("snapcraft", "canonical-starcraft", "snapcraft"),
     ],
 )
 def test_get_real_repository_by_name(anonymous_lp, name, owner, project):


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

The snapcraft project on launchpad was transferred to `canonical-starcraft` this week.