### PR TITLE
fix: set project variables in build environment

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -648,11 +648,7 @@ class Application:
 
     def _set_global_environment(self, info: craft_parts.ProjectInfo) -> None:
         """Populate the ProjectInfo's global environment."""
-        info.global_environment.update(
-            {
-                "CRAFT_PROJECT_VERSION": info.get_project_var("version", raw_read=True),
-            }
-        )
+        util.set_global_environment(info)
 
     def _render_secrets(self, yaml_data: dict[str, Any]) -> None:
         """Render build-secrets, in-place."""

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -149,6 +149,7 @@ class LifecycleService(base.ProjectService):
     def setup(self) -> None:
         """Initialize the LifecycleManager with previously-set arguments."""
         self._lcm = self._init_lifecycle_manager()
+        callbacks.register_prologue(util.set_global_environment)
         callbacks.register_post_step(self.post_prime, step_list=[Step.PRIME])
 
     def _init_lifecycle_manager(self) -> LifecycleManager:
@@ -189,6 +190,7 @@ class LifecycleService(base.ProjectService):
                 work_dir=self._work_dir,
                 ignore_local_sources=self._app.source_ignore_patterns,
                 parallel_build_count=self._get_parallel_build_count(),
+                project_name=self._project.name,
                 project_vars_part_name=self._project.adopt_info,
                 project_vars=self._project_vars,
                 track_stage_packages=True,

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -15,7 +15,10 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Utilities for craft-application."""
 
-from craft_application.util.callbacks import get_unique_callbacks
+from craft_application.util.callbacks import (
+    get_unique_callbacks,
+    set_global_environment,
+)
 from craft_application.util.logging import setup_loggers
 from craft_application.util.paths import get_filename_from_url_path, get_managed_logpath
 from craft_application.util.platforms import (
@@ -33,6 +36,7 @@ from craft_application.util.yaml import dump_yaml, safe_yaml_load
 
 __all__ = [
     "get_unique_callbacks",
+    "set_global_environment",
     "setup_loggers",
     "get_filename_from_url_path",
     "get_managed_logpath",

--- a/craft_application/util/callbacks.py
+++ b/craft_application/util/callbacks.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Literal, overload
 
+import craft_parts
+
 if TYPE_CHECKING:  # pragma: no cover
     # Caution: Removing these from type checking will result in circular imports.
     from craft_application.commands.base import ParserCallback, RunCallback
@@ -56,3 +58,12 @@ def get_unique_callbacks(  # pyright: ignore[reportUnknownParameterType]
         if callback is not None and callback not in callbacks:
             callbacks.append(callback)  # pyright: ignore[reportUnknownMemberType]
     return callbacks  # pyright: ignore[reportUnknownVariableType]
+
+
+def set_global_environment(info: craft_parts.ProjectInfo) -> None:
+    """Populate the ProjectInfo's global environment."""
+    info.global_environment.update(
+        {
+            "CRAFT_PROJECT_VERSION": info.get_project_var("version", raw_read=True),
+        }
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,10 +27,16 @@ import craft_parts
 import pytest
 from craft_application import application, models, services, util
 from craft_cli import EmitterMode, emit
+from craft_parts import callbacks
 from craft_providers import bases
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def unregister_callbacks():
+    callbacks.unregister_all()
 
 
 class Platform(models.CraftBaseModel):

--- a/tests/integration/data/valid_projects/environment/testcraft.yaml
+++ b/tests/integration/data/valid_projects/environment/testcraft.yaml
@@ -1,5 +1,5 @@
 name: environment-project
-summary: A project with environment variables
+summary: A project with project variables and environment variables
 version: 1.0
 base: ["ubuntu", "22.04"]
 
@@ -9,6 +9,13 @@ parts:
     override-build: |
         target_file=${CRAFT_PART_INSTALL}/variables.yaml
         touch $target_file
+
+        # project variables are evaluated within the yaml file
         echo "project_name:    \"${CRAFT_PROJECT_NAME}\""    >> $target_file
         echo "project_dir:     \"${CRAFT_PROJECT_DIR}\""     >> $target_file
         echo "project_version: \"${CRAFT_PROJECT_VERSION}\"" >> $target_file
+
+        # project variables are available in the build environment
+        echo "env_project_name:    $(env | grep '^CRAFT_PROJECT_NAME=' | cut -d '=' -f 2)"    >> $target_file
+        echo "env_project_dir:     $(env | grep '^CRAFT_PROJECT_DIR=' | cut -d '=' -f 2)"     >> $target_file
+        echo "env_project_version: $(env | grep '^CRAFT_PROJECT_VERSION=' | cut -d '=' -f 2)" >> $target_file

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -288,9 +288,15 @@ def test_global_environment(
     with variables_yaml.open() as file:
         variables = yaml.safe_yaml_load(file)
 
+    # project variables should be evaluated within the project's yaml file
     assert variables["project_name"] == "environment-project"
     assert variables["project_dir"] == str(tmp_path)
     assert variables["project_version"] == "1.0"
+
+    # project variables should be set in the build environment
+    assert variables["env_project_name"] == "environment-project"
+    assert variables["env_project_dir"] == str(tmp_path)
+    assert str(variables["env_project_version"]) == "1.0"
 
 
 @pytest.fixture()


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

As part of https://github.com/canonical/snapcraft/issues/4704, I discovered that `CRAFT_PROJECT_NAME` and `CRAFT_PROJECT_VERSION` were not being set in the build environment.

I'm not happy with this implementation and I want to get feedback from @tigarmo and @lengau before I spend any more time since this effort is already out of the scope of the original ticket.

(CRAFT-2657)