### PR TITLE
revert: abstract Project class and `_providers_base()`

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -70,7 +70,6 @@ class AppMetadata:
     """Metadata about a *craft application."""
 
     name: str
-    ProjectClass: type[models.Project]
     summary: str | None = None
     version: str = field(init=False)
     source_ignore_patterns: list[str] = field(default_factory=lambda: [])
@@ -79,6 +78,7 @@ class AppMetadata:
     project_variables: list[str] = field(default_factory=lambda: ["version"])
     mandatory_adoptable_fields: list[str] = field(default_factory=lambda: ["version"])
 
+    ProjectClass: type[models.Project] = models.Project
     BuildPlannerClass: type[models.BuildPlanner] = field(
         default=NotImplementedError  # type: ignore[assignment,type-abstract]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # This file is part of craft_application.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -28,7 +28,6 @@ import pytest
 from craft_application import application, models, services, util
 from craft_cli import EmitterMode, emit
 from craft_providers import bases
-from typing_extensions import override
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
@@ -79,7 +78,6 @@ def default_app_metadata() -> craft_application.AppMetadata:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
             "testcraft",
-            FakeProject,
             "A fake app for testing craft-application",
             BuildPlannerClass=MyBuildPlanner,
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
@@ -87,12 +85,11 @@ def default_app_metadata() -> craft_application.AppMetadata:
 
 
 @pytest.fixture()
-def app_metadata(features, fake_project_class) -> craft_application.AppMetadata:
+def app_metadata(features) -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
             "testcraft",
-            fake_project_class,
             "A fake app for testing craft-application",
             BuildPlannerClass=MyBuildPlanner,
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
@@ -100,27 +97,13 @@ def app_metadata(features, fake_project_class) -> craft_application.AppMetadata:
         )
 
 
-class FakeProject(models.Project):
-    """A fake project for testing."""
-
-    @override
-    @classmethod
-    def _providers_base(cls, base: str) -> bases.BaseAlias:
-        return bases.get_base_alias(("ubuntu", "24.04"))
-
-
 @pytest.fixture()
-def fake_project_class() -> type[models.Project]:
-    return FakeProject
-
-
-@pytest.fixture()
-def fake_project(fake_project_class) -> models.Project:
+def fake_project() -> models.Project:
     arch = util.get_host_architecture()
-    return fake_project_class(
+    return models.Project(
         name="full-project",  # pyright: ignore[reportArgumentType]
         title="A fully-defined project",  # pyright: ignore[reportArgumentType]
-        base="core24",
+        base="ubuntu@24.04",
         version="1.0.0.post64+git12345678",  # pyright: ignore[reportArgumentType]
         contact="author@project.org",
         issues="https://github.com/canonical/craft-application/issues",

--- a/tests/integration/data/build-secrets/testcraft.yaml
+++ b/tests/integration/data/build-secrets/testcraft.yaml
@@ -1,7 +1,7 @@
 name: build-secrets
 description: A project with build-time secrets
 version: git
-base: ["ubuntu", "22.04"]
+base: "ubuntu@22.04"
 
 parts:
   my-part:

--- a/tests/integration/data/invalid_projects/build-error/testcraft.yaml
+++ b/tests/integration/data/invalid_projects/build-error/testcraft.yaml
@@ -1,7 +1,7 @@
 name: build-error
 title: A project that fails to build
 version: git
-base: ["ubuntu", "22.04"]
+base: "ubuntu@22.04"
 
 parts:
   my-part:

--- a/tests/integration/data/valid_projects/adoption/testcraft.yaml
+++ b/tests/integration/data/valid_projects/adoption/testcraft.yaml
@@ -1,6 +1,6 @@
 name: empty
 title: A version adoption test project
-base: ["ubuntu", "22.04"]
+base: "ubuntu@22.04"
 
 adopt-info: my-part
 

--- a/tests/integration/data/valid_projects/basic/testcraft.yaml
+++ b/tests/integration/data/valid_projects/basic/testcraft.yaml
@@ -1,7 +1,7 @@
 name: empty
 title: A most basic project
 version: 1.0
-base: ["ubuntu", "22.04"]
+base: "ubuntu@22.04"
 
 parts:
   my-part:

--- a/tests/integration/data/valid_projects/environment/testcraft.yaml
+++ b/tests/integration/data/valid_projects/environment/testcraft.yaml
@@ -1,7 +1,7 @@
 name: environment-project
 summary: A project with environment variables
 version: 1.0
-base: ["ubuntu", "22.04"]
+base: "ubuntu@22.04"
 
 parts:
   my-part:

--- a/tests/integration/data/valid_projects/grammar/testcraft.yaml
+++ b/tests/integration/data/valid_projects/grammar/testcraft.yaml
@@ -1,7 +1,7 @@
 name: empty
 title: A most basic project
 version: 1.0
-base: ["ubuntu", "22.04"]
+base: "ubuntu@22.04"
 
 parts:
   hello-world:

--- a/tests/unit/models/project_models/full_project.yaml
+++ b/tests/unit/models/project_models/full_project.yaml
@@ -5,7 +5,7 @@ summary: A fully-defined craft-application project.
 description: |
   A fully-defined craft-application project.
   With more than one line.
-base: core24
+base: ubuntu@24.04
 contact: author@project.org
 issues: https://github.com/canonical/craft-application/issues
 source-code: https://github.com/canonical/craft-application

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -25,7 +25,7 @@ import craft_parts
 import craft_parts.callbacks
 import pytest
 import pytest_check
-from craft_application import errors, util
+from craft_application import errors, models, util
 from craft_application.errors import InvalidParameterError, PartsLifecycleError
 from craft_application.services import lifecycle
 from craft_application.util import repositories
@@ -673,17 +673,17 @@ def test_get_parallel_build_count_error(
 
 
 def test_lifecycle_project_variables(
-    app_metadata, fake_services, tmp_path, fake_build_plan, fake_project_class
+    app_metadata, fake_services, tmp_path, fake_build_plan
 ):
     """Test that project variables are set after the lifecycle runs."""
 
-    class LocalProject(fake_project_class):
+    class LocalProject(models.Project):
         color: str | None
 
     fake_project = LocalProject.unmarshal(
         {
             "name": "project",
-            "base": "core24",
+            "base": "ubuntu@24.04",
             "version": "1.0.0.post64+git12345678",
             "parts": {"my-part": {"plugin": "nil"}},
             "adopt-info": "my-part",

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -144,11 +144,9 @@ def test_mandatory_adoptable_field(
     fake_project,
     fake_lifecycle_service_class,
     fake_package_service_class,
-    fake_project_class,
 ):
     app_metadata = AppMetadata(
         "testcraft",
-        fake_project_class,
         "A fake app for testing craft-application",
         mandatory_adoptable_fields=["license"],
     )

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -301,20 +301,19 @@ def test_app_metadata_post_init_correct(summary):
     pytest_check.is_not_none(app.summary)
 
 
-def test_app_metadata_version_attribute(tmp_path, monkeypatch, fake_project_class):
+def test_app_metadata_version_attribute(tmp_path, monkeypatch):
     """Set the AppMetadata version from the main app package."""
     monkeypatch.syspath_prepend(tmp_path)
     (tmp_path / "dummycraft_version.py").write_text("__version__ = '1.2.3'")
 
     app = application.AppMetadata(
         name="dummycraft_version",
-        ProjectClass=fake_project_class,
         summary="dummy craft",
     )
     assert app.version == "1.2.3"
 
 
-def test_app_metadata_importlib(tmp_path, monkeypatch, mocker, fake_project_class):
+def test_app_metadata_importlib(tmp_path, monkeypatch, mocker):
     """Set the AppMetadata version via importlib."""
     monkeypatch.syspath_prepend(tmp_path)
     (tmp_path / "dummycraft_importlib.py").write_text("print('hi')")
@@ -323,34 +322,30 @@ def test_app_metadata_importlib(tmp_path, monkeypatch, mocker, fake_project_clas
 
     app = application.AppMetadata(
         name="dummycraft_importlib",
-        ProjectClass=fake_project_class,
         summary="dummy craft",
     )
     assert app.version == "4.5.6"
 
 
-def test_app_metadata_dev(fake_project_class):
+def test_app_metadata_dev():
     app = application.AppMetadata(
         name="dummycraft_dev",
-        ProjectClass=fake_project_class,
         summary="dummy craft",
     )
     assert app.version == "dev"
 
 
-def test_app_metadata_default_project_variables(fake_project_class):
+def test_app_metadata_default_project_variables():
     app = application.AppMetadata(
         name="dummycraft_dev",
-        ProjectClass=fake_project_class,
         summary="dummy craft",
     )
     assert app.project_variables == ["version"]
 
 
-def test_app_metadata_default_mandatory_adoptable_fields(fake_project_class):
+def test_app_metadata_default_mandatory_adoptable_fields():
     app = application.AppMetadata(
         name="dummycraft_dev",
-        ProjectClass=fake_project_class,
         summary="dummy craft",
     )
     assert app.mandatory_adoptable_fields == ["version"]

--- a/tests/unit/util/invalid_yaml/unhashable.yaml-invalid
+++ b/tests/unit/util/invalid_yaml/unhashable.yaml-invalid
@@ -1,2 +1,2 @@
-base: core22
+base: "ubuntu@22.04"
 entry: {{value}}


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This is a partial revert of 'aeae554 feat!: validate devel bases (#302)'.

The base validation from #302 has not been reverted, but there is now a default implementation for `Project._providers_base()` such that applications do not need to subclass the Project model.

The default naming convention for bases is `name@channel`.  Examples:
- `ubuntu@24.04`
- `ubuntu@devel`
- `almalinux@9`

Charmcraft is the only public application that can use this default `_providers_base()`.  

A default BuildPlanner will come in a subsequent PR.

(CRAFT-2824)