### PR TITLE
fix(remote): hash the project directory

### DIFF
--- a/craft_application/remote/utils.py
+++ b/craft_application/remote/utils.py
@@ -85,7 +85,7 @@ def _compute_hash(directory: Path) -> str:
             "a directory."
         )
 
-    files = sorted([file for file in Path().glob("**/*") if file.is_file()])
+    files = sorted([file for file in directory.glob("**/*") if file.is_file()])
     hashes: list[str] = []
 
     for file_path in files:

--- a/craft_application/remote/utils.py
+++ b/craft_application/remote/utils.py
@@ -85,7 +85,7 @@ def _compute_hash(directory: Path) -> str:
             "a directory."
         )
 
-    files = sorted([file for file in directory.glob("**/*") if file.is_file()])
+    files = sorted(file for file in directory.glob("**/*") if file.is_file())
     hashes: list[str] = []
 
     for file_path in files:


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

I've been hitting this bug when I run `tox run -m lint` in one terminal and `pytest` in another.  It causes the remote-build unit tests to occasionally fail when reading short-lived files in `craft-application/.tox/`, when it should be hashing the pytest temp directory.