### PR TITLE
fix: do not process non-grammar keywords

### DIFF
--- a/craft_application/grammar.py
+++ b/craft_application/grammar.py
@@ -22,6 +22,7 @@ from craft_grammar import GrammarProcessor  # type: ignore[import-untyped]
 from craft_grammar.errors import GrammarSyntaxError  # type: ignore[import-untyped]
 
 from craft_application.errors import CraftValidationError
+from craft_application.models import get_grammar_aware_part_keywords
 
 # Values that should return as a single object / list / dict.
 _NON_SCALAR_VALUES = [
@@ -55,14 +56,23 @@ def process_part(
         unprocessed_grammar = part_yaml_data[key]
         craft_cli.emit.debug(f"Processing grammar for {key}: {unprocessed_grammar}")
 
+        # ignore non-grammar keywords
+        if key not in get_grammar_aware_part_keywords():
+            continue
+
         # grammar aware models can be strings or list of dicts and strings
         if isinstance(unprocessed_grammar, list):
             # all items in the list must be a dict or a string
             if any(not isinstance(d, dict | str) for d in unprocessed_grammar):  # type: ignore[reportUnknownVariableType]
                 continue
+
             # all keys in the dictionary must be a string
-            if any(not isinstance(key, str) for d in unprocessed_grammar for key in d):  # type: ignore[reportUnknownVariableType]
-                continue
+            for item in unprocessed_grammar:  # type: ignore[reportUnknownVariableType]
+                if isinstance(item, dict) and any(
+                    not isinstance(key, str) for key in item  # type: ignore[reportUnknownVariableType]
+                ):
+                    continue
+
             unprocessed_grammar = cast(list[dict[str, Any] | str], unprocessed_grammar)
         # grammar aware models can be a string
         elif isinstance(unprocessed_grammar, str):
@@ -78,9 +88,9 @@ def process_part(
                 f"Invalid grammar syntax while processing '{key}' in '{part_yaml_data}': {e}"
             ) from e
 
-        # special cases
-        # scalar values should return as a single object, not in a list.
-        # dict values should return as a dict, not in a list.
+        # special cases:
+        # - scalar values should return as a single object, not in a list.
+        # - dict values should return as a dict, not in a list.
         if key not in _NON_SCALAR_VALUES or key in _DICT_ONLY_VALUES:
             processed_grammar = processed_grammar[0] if processed_grammar else None
 

--- a/craft_application/grammar.py
+++ b/craft_application/grammar.py
@@ -54,12 +54,15 @@ def process_part(
     """Process grammar for a given part."""
     for key in part_yaml_data:
         unprocessed_grammar = part_yaml_data[key]
-        craft_cli.emit.debug(f"Processing grammar for {key}: {unprocessed_grammar}")
 
         # ignore non-grammar keywords
         if key not in get_grammar_aware_part_keywords():
+            craft_cli.emit.debug(
+                f"Not processing grammar for non-grammar enabled keyword {key}"
+            )
             continue
 
+        craft_cli.emit.debug(f"Processing grammar for {key}: {unprocessed_grammar}")
         # grammar aware models can be strings or list of dicts and strings
         if isinstance(unprocessed_grammar, list):
             # all items in the list must be a dict or a string

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -23,7 +23,10 @@ from craft_application.models.constraints import (
     UniqueStrList,
     VersionStr,
 )
-from craft_application.models.grammar import GrammarAwareProject
+from craft_application.models.grammar import (
+    GrammarAwareProject,
+    get_grammar_aware_part_keywords,
+)
 from craft_application.models.metadata import BaseMetadata
 from craft_application.models.project import BuildInfo, BuildPlanner, Project
 
@@ -33,6 +36,7 @@ __all__ = [
     "BuildInfo",
     "CraftBaseConfig",
     "CraftBaseModel",
+    "get_grammar_aware_part_keywords",
     "GrammarAwareProject",
     "Project",
     "BuildPlanner",

--- a/craft_application/models/grammar.py
+++ b/craft_application/models/grammar.py
@@ -1,6 +1,6 @@
 # This file is part of craft_application.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -61,10 +61,10 @@ class _GrammarAwarePart(_GrammarAwareModel):
     build_packages: GrammarStrList | None
     build_environment: GrammarSingleEntryDictList | None
     build_attributes: GrammarStrList | None
-    organize_files: GrammarDict | None
-    overlay_files: GrammarStrList | None
-    stage_files: GrammarStrList | None
-    prime_files: GrammarStrList | None
+    organize_files: GrammarDict | None = pydantic.Field(alias="organize")
+    overlay_files: GrammarStrList | None = pydantic.Field(alias="overlay")
+    stage_files: GrammarStrList | None = pydantic.Field(alias="stage")
+    prime_files: GrammarStrList | None = pydantic.Field(alias="prime")
     override_pull: GrammarStr | None
     overlay_script: GrammarStr | None
     override_build: GrammarStr | None
@@ -72,6 +72,12 @@ class _GrammarAwarePart(_GrammarAwareModel):
     override_prime: GrammarStr | None
     permissions: GrammarDictList | None
     parse_info: GrammarStrList | None
+
+
+def get_grammar_aware_part_keywords() -> list[str]:
+    """Return all supported grammar keywords for a part."""
+    keywords: list[str] = [item.alias for item in _GrammarAwarePart.__fields__.values()]
+    return keywords
 
 
 class GrammarAwareProject(_GrammarAwareModel):

--- a/tests/unit/models/test_grammar.py
+++ b/tests/unit/models/test_grammar.py
@@ -1,0 +1,55 @@
+# This file is part of craft_application.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for grammar-aware project models."""
+
+from craft_application.models import get_grammar_aware_part_keywords
+
+
+def test_get_grammar_aware_part_keywords():
+    """Test get_grammar_aware_part_keywords."""
+    assert get_grammar_aware_part_keywords() == [
+        "plugin",
+        "source",
+        "source-checksum",
+        "source-branch",
+        "source-commit",
+        "source-depth",
+        "source-subdir",
+        "source-submodules",
+        "source-tag",
+        "source-type",
+        "disable-parallel",
+        "after",
+        "overlay-packages",
+        "stage-snaps",
+        "stage-packages",
+        "build-snaps",
+        "build-packages",
+        "build-environment",
+        "build-attributes",
+        "organize",
+        "overlay",
+        "stage",
+        "prime",
+        "override-pull",
+        "overlay-script",
+        "override-build",
+        "override-stage",
+        "override-prime",
+        "permissions",
+        "parse-info",
+    ]

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1341,12 +1341,13 @@ def grammar_project_mini(tmp_path):
     version: 1.0
     parts:
       mypart:
-        plugin: nil
+        plugin: meson
 
         # grammar-only string
         source:
         - on amd64 to riscv64: on-amd64-to-riscv64
         - on amd64 to s390x: on-amd64-to-s390x
+        - else: other
 
         # list of grammar and non-grammar data
         build-packages:
@@ -1355,6 +1356,11 @@ def grammar_project_mini(tmp_path):
           - on-amd64-to-riscv64
         - on amd64 to s390x:
           - on-amd64-to-s390x
+
+        # non-grammar data in a non-grammar keyword
+        meson-parameters:
+        - foo
+        - bar
     """
     )
     project_file = tmp_path / "testcraft.yaml"
@@ -1487,8 +1493,7 @@ def test_process_grammar_no_match(grammar_app_mini, mocker):
     mocker.patch("craft_application.util.get_host_architecture", return_value="i386")
     project = grammar_app_mini.get_project()
 
-    # "source" is empty because "i386" doesn't match any of the grammar statements.
-    assert project.parts["mypart"]["source"] is None
+    assert project.parts["mypart"]["source"] == "other"
     assert project.parts["mypart"]["build-packages"] == ["test-package"]
 
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1478,6 +1478,13 @@ def test_process_grammar_platform(grammar_app_mini):
     ]
 
 
+def test_process_grammar_non_grammar(grammar_app_mini):
+    """Non-grammar keywords should not be modified."""
+    project = grammar_app_mini.get_project(platform="platform-riscv64")
+
+    assert project.parts["mypart"]["meson-parameters"] == ["foo", "bar"]
+
+
 def test_process_grammar_default(grammar_app_mini):
     """Test that if nothing is provided the first BuildInfo is used by the grammar."""
     project = grammar_app_mini.get_project()


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Another grammar-related fix.

This is caused by [this](https://github.com/canonical/craft-application/pull/296/files#diff-1ef92b4ea98b9954fdb242a2697c47c5e275c45e703e54995980b2307da3187aR81) line augmenting data for non-grammar keywords.

It was causing errors like this:
```
Bad snapcraft.yaml content:
- value is not a valid list (in field 'parts.gnome-calculator.meson-parameters')
Full execution log: '/root/.local/state/snapcraft/log/snapcraft-20240429-201308.751985.log'
```

My solution is not to process grammar for non-grammar keywords.
