### PR TITLE
fix: apply yaml transforms first

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -576,18 +576,18 @@ class Application:
         Performs task such as environment expansion. Note that this transforms
         ``yaml_data`` in-place.
         """
+        # apply application-specific transformations first because an application may
+        # add advanced grammar, project variables, or secrets to the yaml
+        yaml_data = self._extra_yaml_transform(
+            yaml_data, build_on=build_on, build_for=build_for
+        )
+
         # Perform variable expansion.
         self._expand_environment(yaml_data)
 
         # Handle build secrets.
         if self.app.features.build_secrets:
             self._render_secrets(yaml_data)
-
-        # apply application-specific transformations before expanding grammar
-        # because an application may add advanced grammar to the yaml
-        yaml_data = self._extra_yaml_transform(
-            yaml_data, build_on=build_on, build_for=build_for
-        )
 
         # Expand grammar.
         if "parts" in yaml_data:

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -263,7 +263,7 @@ class LifecycleService(base.ProjectService):
             raise RuntimeError(f"Parts processing internal error: {err}") from err
         except OSError as err:
             raise errors.PartsLifecycleError.from_os_error(err) from err
-        except Exception as err:  # noqa: BLE001 - Converting general error.
+        except Exception as err:
             raise errors.PartsLifecycleError(f"Unknown error: {str(err)}") from err
 
     def post_prime(self, step_info: StepInfo) -> bool:

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -96,7 +96,7 @@ def test_get_parts_action_message_run(step: Step, message: str):
 
     actual = lifecycle._get_parts_action_message(action)
 
-    assert actual == message, "Unexpected %r" % actual
+    assert actual == message, f"Unexpected {actual!r}"
 
 
 @pytest.mark.parametrize(
@@ -118,7 +118,7 @@ def test_get_parts_re_action_message_run(step: Step, message: str):
 
     actual = lifecycle._get_parts_action_message(action)
 
-    assert actual == message, "Unexpected %r" % actual
+    assert actual == message, f"Unexpected {actual!r}"
 
 
 @pytest.mark.parametrize(
@@ -140,7 +140,7 @@ def test_get_parts_skip_action_message_run(step: Step, message: str):
 
     actual = lifecycle._get_parts_action_message(action)
 
-    assert actual == message, "Unexpected %r" % actual
+    assert actual == message, f"Unexpected {actual!r}"
 
 
 @pytest.mark.parametrize(
@@ -160,7 +160,7 @@ def test_get_parts_update_action_message_run(step: Step, message: str):
 
     actual = lifecycle._get_parts_action_message(action)
 
-    assert actual == message, "Unexpected %r" % actual
+    assert actual == message, f"Unexpected {actual!r}"
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def get_parts_action_message_with_reason(step: Step, message: str):
 
     actual = lifecycle._get_parts_action_message(action)
 
-    assert actual == message, "Unexpected %r" % actual
+    assert actual == message, f"Unexpected {actual!r}"
 
 
 def test_progress_messages(fake_parts_lifecycle, emitter):


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

As raised in Matrix ([source](https://matrix.to/#/!GGqzbFAUQprdPgYYCM:ubuntu.com/$5CJQkAjgqbNn48zcF06HS8a0_0cjfogVCA_BDFi7XZE?via=ubuntu.com&via=matrix.org&via=kde.org)), `_extra_yaml_transforms` needs to occur before evaluating project variables.

For example, snapcraft will expand extensions in `_extra_yaml_transforms` and some extensions add project variables to the yaml.

Fixes https://github.com/canonical/snapcraft/issues/4771