### PR TITLE
fix: use `build-for` when evaluating project variables

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -583,7 +583,10 @@ class Application:
         )
 
         # Perform variable expansion.
-        self._expand_environment(yaml_data)
+        self._expand_environment(
+            yaml_data=yaml_data,
+            build_for=build_for or util.get_host_architecture(),
+        )
 
         # Handle build secrets.
         if self.app.features.build_secrets:
@@ -613,8 +616,12 @@ class Application:
 
         return yaml_data
 
-    def _expand_environment(self, yaml_data: dict[str, Any]) -> None:
-        """Perform expansion of project environment variables."""
+    def _expand_environment(self, yaml_data: dict[str, Any], build_for: str) -> None:
+        """Perform expansion of project environment variables.
+
+        :param yaml_data: The project's yaml data.
+        :param build_for: The architecture to build for.
+        """
         environment_vars = self._get_project_vars(yaml_data)
         project_dirs = craft_parts.ProjectDirs(
             work_dir=self._work_dir, partitions=self._partitions
@@ -623,6 +630,7 @@ class Application:
         info = craft_parts.ProjectInfo(
             application_name=self.app.name,  # not used in environment expansion
             cache_dir=pathlib.Path(),  # not used in environment expansion
+            arch=util.convert_architecture_deb_to_platform(build_for),
             project_name=yaml_data.get("name", ""),
             project_dirs=project_dirs,
             project_vars=environment_vars,

--- a/tests/integration/data/valid_projects/environment/testcraft.yaml
+++ b/tests/integration/data/valid_projects/environment/testcraft.yaml
@@ -9,6 +9,10 @@ parts:
     override-build: |
         target_file=${CRAFT_PART_INSTALL}/variables.yaml
         touch $target_file
-        echo "project_name:    \"${CRAFT_PROJECT_NAME}\""    >> $target_file
-        echo "project_dir:     \"${CRAFT_PROJECT_DIR}\""     >> $target_file
-        echo "project_version: \"${CRAFT_PROJECT_VERSION}\"" >> $target_file
+        echo "project_name:           \"${CRAFT_PROJECT_NAME}\""           >> $target_file
+        echo "project_dir:            \"${CRAFT_PROJECT_DIR}\""            >> $target_file
+        echo "project_version:        \"${CRAFT_PROJECT_VERSION}\""        >> $target_file
+        echo "arch_build_for:         \"${CRAFT_ARCH_BUILD_FOR}\""         >> $target_file
+        echo "arch_triplet_build_for: \"${CRAFT_ARCH_TRIPLET_BUILD_FOR}\"" >> $target_file
+        echo "arch_build_on:          \"${CRAFT_ARCH_BUILD_ON}\""         >> $target_file
+        echo "arch_triplet_build_on:  \"${CRAFT_ARCH_TRIPLET_BUILD_ON}\"" >> $target_file

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1306,10 +1306,10 @@ def test_extra_yaml_transform(tmp_path, app_metadata, fake_services):
 
     app = FakeApplication(app_metadata, fake_services)
     app.project_dir = tmp_path
-    _ = app.get_project(build_for="fake-build-for")
+    _ = app.get_project(build_for="s390x")
 
     assert app.build_on == util.get_host_architecture()
-    assert app.build_for == "fake-build-for"
+    assert app.build_for == "s390x"
 
 
 def test_mandatory_adoptable_fields(tmp_path, app_metadata, fake_services):


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----


As raised in Matrix ([source](https://matrix.to/#/!GGqzbFAUQprdPgYYCM:ubuntu.com/$ZP99NnFr-54yU3HEmz_LtWcaNtp8oxgHJ4pnix1uvNQ?via=ubuntu.com&via=matrix.org&via=kde.org)), `BUILD_FOR` variables aren't evaluated correctly because the `build-for` arch was not passed to craft-parts.

Builds on #334, so review last 2 commits only.

Fixes https://github.com/canonical/snapcraft/issues/4770