### PR TITLE
feat: add `needs_project` property

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -504,7 +504,7 @@ class Application:
             self._pre_run(dispatcher)
 
             managed_mode = command.run_managed(dispatcher.parsed_args())
-            if managed_mode or command.always_load_project:
+            if managed_mode or command.needs_project(dispatcher.parsed_args()):
                 self.services.project = self.get_project(
                     platform=platform, build_for=build_for
                 )

--- a/craft_application/commands/__init__.py
+++ b/craft_application/commands/__init__.py
@@ -17,13 +17,17 @@
 
 from craft_application.commands.base import AppCommand, ExtensibleCommand
 from craft_application.commands import lifecycle
-from craft_application.commands.lifecycle import get_lifecycle_command_group
+from craft_application.commands.lifecycle import (
+    get_lifecycle_command_group,
+    LifecycleCommand,
+)
 from craft_application.commands.other import get_other_command_group
 
 __all__ = [
     "AppCommand",
     "ExtensibleCommand",
     "lifecycle",
+    "LifecycleCommand",
     "get_lifecycle_command_group",
     "get_other_command_group",
 ]

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -65,6 +65,20 @@ class AppCommand(BaseCommand):
         self._app: application.AppMetadata = config["app"]
         self._services: service_factory.ServiceFactory = config["services"]
 
+    def needs_project(
+        self,
+        parsed_args: argparse.Namespace,  # noqa: ARG002 (unused argument is for subclasses)
+    ) -> bool:
+        """Property to determine if the command needs a project loaded.
+
+        Defaults to `self.always_load_project`. Subclasses can override this property
+
+        :param parsed_args: Parsed arguments for the command.
+
+        :returns: True if the command needs a project loaded, False otherwise.
+        """
+        return self.always_load_project
+
     def run_managed(
         self,
         parsed_args: argparse.Namespace,  # noqa: ARG002 (the unused argument is for subclasses)

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -78,6 +78,14 @@ def test_without_config(emitter):
     assert not hasattr(command, "_services")
 
 
+@pytest.mark.parametrize("always_load_project", [True, False])
+def test_needs_project(fake_command, always_load_project):
+    """`needs_project()` defaults to `always_load_project`."""
+    fake_command.always_load_project = always_load_project
+
+    assert fake_command.needs_project(argparse.Namespace()) is always_load_project
+
+
 # region Tests for ExtensibleCommand
 @pytest.fixture()
 def fake_extensible_cls():


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Two things:

1. Refactors the LifecycleCommands classes in a slightly more organized way without changing any existing commands.  This is required for snapcraft to define its own `Pack` command with minimal duplicated code (https://github.com/canonical/snapcraft/pull/4794)
2. Add a `needs_project` property, which can determine if a project needs to be loaded based on the provided arguments.

Fixes https://github.com/canonical/snapcraft/issues/4769
(CRAFT-2861)