### PR TITLE
build(deps): bump craft-parts to 2.0

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -629,7 +629,7 @@ class Application:
         info = craft_parts.ProjectInfo(
             application_name=self.app.name,  # not used in environment expansion
             cache_dir=pathlib.Path(),  # not used in environment expansion
-            arch=util.convert_architecture_deb_to_platform(build_for),
+            arch=build_for,
             project_name=yaml_data.get("name", ""),
             project_dirs=project_dirs,
             project_vars=environment_vars,

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -38,7 +38,7 @@ from typing_extensions import override
 
 from craft_application import errors, models, util
 from craft_application.services import base
-from craft_application.util import convert_architecture_deb_to_platform, repositories
+from craft_application.util import repositories
 
 if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
@@ -184,7 +184,7 @@ class LifecycleService(base.ProjectService):
             return LifecycleManager(
                 {"parts": self._project.parts},
                 application_name=self._app.name,
-                arch=convert_architecture_deb_to_platform(build_for),
+                arch=build_for,
                 cache_dir=self._cache_dir,
                 work_dir=self._work_dir,
                 ignore_local_sources=self._app.source_ignore_patterns,

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -18,11 +18,7 @@
 from craft_application.util.callbacks import get_unique_callbacks
 from craft_application.util.logging import setup_loggers
 from craft_application.util.paths import get_filename_from_url_path, get_managed_logpath
-from craft_application.util.platforms import (
-    get_host_architecture,
-    convert_architecture_deb_to_platform,
-    get_host_base,
-)
+from craft_application.util.platforms import get_host_architecture, get_host_base
 from craft_application.util.snap_config import (
     SnapConfig,
     get_snap_config,
@@ -37,7 +33,6 @@ __all__ = [
     "get_filename_from_url_path",
     "get_managed_logpath",
     "get_host_architecture",
-    "convert_architecture_deb_to_platform",
     "get_snap_config",
     "is_running_from_snap",
     "SnapConfig",

--- a/craft_application/util/platforms.py
+++ b/craft_application/util/platforms.py
@@ -30,15 +30,6 @@ def get_host_architecture() -> str:
     return _ARCH_TRANSLATIONS_PLATFORM_TO_DEB.get(machine, machine)
 
 
-def convert_architecture_deb_to_platform(arch: str) -> str:
-    """Convert an architecture from deb/snap syntax to platform syntax.
-
-    :param architecture: architecture string in debian/snap syntax
-    :return: architecture in platform syntax
-    """
-    return _ARCH_TRANSLATIONS_DEB_TO_PLATFORM.get(arch, arch)
-
-
 @functools.lru_cache(maxsize=1)
 def get_host_base() -> bases.BaseName:
     """Get the craft-providers base for the running host."""
@@ -59,18 +50,6 @@ _ARCH_TRANSLATIONS_PLATFORM_TO_DEB = {
     "ppc64le": "ppc64el",
     "x86_64": "amd64",
     "AMD64": "amd64",  # Windows support
-    "s390x": "s390x",
-    "riscv64": "riscv64",
-}
-
-# architecture translations from the deb/snap syntax to the platform syntax
-_ARCH_TRANSLATIONS_DEB_TO_PLATFORM = {
-    "arm64": "aarch64",
-    "armhf": "armv7l",
-    "i386": "i686",
-    "powerpc": "ppc",
-    "ppc64el": "ppc64le",
-    "amd64": "x86_64",
     "s390x": "s390x",
     "riscv64": "riscv64",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "craft-archives>=1.1.3",
     "craft-cli>=2.4.0",
     "craft-grammar>=1.2.0",
-    "craft-parts>=1.21.1",
+    "craft-parts @ git+https://github.com/canonical/craft-parts@work/normalize-api-arch",
     "craft-providers>=1.20.0,<2.0",
     "snap-helpers>=0.4.2",
     "platformdirs>=3.10",

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -14,6 +14,7 @@
 """Integration tests for the Application."""
 import argparse
 import pathlib
+import platform
 import shutil
 import textwrap
 
@@ -323,9 +324,7 @@ def test_global_environment(
     assert variables["arch_triplet_build_for"] == "s390x-linux-gnu"
     assert variables["arch_build_on"] == "amd64"
     # craft-application doesn't have utility for getting arch triplets
-    assert variables["arch_triplet_build_on"].startswith(
-        util.convert_architecture_deb_to_platform(util.get_host_architecture())
-    )
+    assert variables["arch_triplet_build_on"].startswith(platform.machine())
 
 
 @pytest.fixture()

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -280,7 +280,7 @@ def test_init_parts_error(
         build_plan=fake_build_plan,
     )
 
-    with pytest.raises(type(expected)) as exc_info:
+    with pytest.raises(type(expected)) as exc_info:  # pyright: ignore[reportArgumentType]
         service.setup()
 
     assert exc_info.value.args == expected.args


### PR DESCRIPTION
Craft Parts 2.0 expects architectures to be passed in Debian format
instead of Python platform machine format.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
