### PR TITLE
fix(remotebuild): use full project name in log files

### DIFF
--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -176,7 +176,6 @@ class RemoteBuildService(base.AppService):
             raise RuntimeError(
                 "RemoteBuildService must be set up using start_builds or resume_builds before fetching logs."
             )
-        project_name = self._name.split("-", maxsplit=2)[1]
         logs: dict[str, pathlib.Path | None] = {}
         log_downloads: dict[str, pathlib.Path] = {}
         fetch_time = datetime.datetime.now().isoformat(timespec="seconds")
@@ -185,7 +184,7 @@ class RemoteBuildService(base.AppService):
             if not url:
                 logs[build.arch_tag] = None
                 continue
-            filename = f"{project_name}_{build.arch_tag}-{fetch_time}.txt"
+            filename = f"{self._name}_{build.arch_tag}_{fetch_time}.txt"
             logs[build.arch_tag] = output_dir / filename
             log_downloads[url] = output_dir / filename
         self.request.download_files_with_progress(log_downloads)

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -281,7 +281,10 @@ def test_monitor_builds_timeout(remote_build_service):
         [{"build_log_url": "http://whatever", "arch_tag": "riscv64"}],
     ],
 )
-def test_fetch_logs(tmp_path, remote_build_service, logs):
+def test_fetch_logs(tmp_path, remote_build_service, logs, mocker):
+    mock_datetime = mocker.patch("datetime.datetime")
+    mock_datetime.now().isoformat.return_value = "2024-01-01T12:34:56"
+
     remote_build_service._name = "appname-project-checksum"
     remote_build_service._builds = [mock.Mock(**log) for log in logs]
     remote_build_service._is_setup = True
@@ -292,7 +295,11 @@ def test_fetch_logs(tmp_path, remote_build_service, logs):
     assert list(actual) == [item["arch_tag"] for item in logs]
 
     remote_build_service.request.download_files_with_progress.assert_called_once_with(
-        {log["build_log_url"]: mock.ANY for log in logs}
+        {
+            log["build_log_url"]: tmp_path
+            / f"appname-project-checksum_{log['arch_tag']}_2024-01-01T12:34:56.txt"
+            for log in logs
+        }
     )
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Use the full project name in log files.

Fixes https://github.com/canonical/snapcraft/issues/4781