### PR TITLE
feat: exponential backoff for launchpad retries

### DIFF
--- a/craft_application/launchpad/models/recipe.py
+++ b/craft_application/launchpad/models/recipe.py
@@ -271,7 +271,13 @@ class SnapRecipe(_StoreRecipe):
         try:
             return cls(
                 lp,
-                lp.lp.snaps.getByName(owner=util.get_person_link(owner), name=name),
+                retry(
+                    f"get snap recipe {name!r}",
+                    lazr.restfulclient.errors.NotFound,
+                    lp.lp.snaps.getByName,
+                    owner=util.get_person_link(owner),
+                    name=name,
+                ),
             )
         except lazr.restfulclient.errors.NotFound:
             raise ValueError(
@@ -401,7 +407,10 @@ class CharmRecipe(_StoreRecipe):
         try:
             return cls(
                 lp,
-                lp.lp.charm_recipes.getByName(
+                retry(
+                    f"get charm recipe {name!r}",
+                    lazr.restfulclient.errors.NotFound,
+                    lp.lp.charm_recipes.getByName,
                     name=name,
                     owner=util.get_person_link(owner),
                     project=f"/{project}",

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -23,6 +23,7 @@ from craft_application.util.platforms import (
     convert_architecture_deb_to_platform,
     get_host_base,
 )
+from craft_application.util.retry import retry
 from craft_application.util.snap_config import (
     SnapConfig,
     get_snap_config,
@@ -46,4 +47,5 @@ __all__ = [
     "get_host_base",
     "dump_yaml",
     "safe_yaml_load",
+    "retry",
 ]

--- a/craft_application/util/retry.py
+++ b/craft_application/util/retry.py
@@ -1,0 +1,75 @@
+#  This file is part of craft-application.
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utilities to retry fickle calls."""
+
+import time
+from typing import Any, Protocol, TypeVar
+
+from craft_cli import emit
+
+_ATTEMPT_COUNT = 4
+
+
+R_co = TypeVar("R_co", covariant=True)  # the variable return type
+
+
+class RetryCallable(Protocol[R_co]):
+    """Protocol for callables to be retried.
+
+    The main purpose is to annotate the return type (R_co), so that ``retry``
+    can declare that it returns whatever ``call_to_retry`` returns.
+    """
+
+    def __call__(self, *args: Any, **kwargs: Any) -> R_co:  # noqa: ANN401 (Use of Any)
+        """Call the callable."""
+        ...
+
+
+def retry(
+    action_message: str,
+    retry_exception: type[Exception] | tuple[type[Exception], ...],
+    call_to_retry: RetryCallable[R_co],
+    /,
+    *call_args: Any,  # noqa: ANN401 (Use of Any)
+    **call_kwargs: Any,  # noqa: ANN401 (Use of Any)
+) -> R_co:
+    """Retry a flaky call multiple times.
+
+    :param action_message: a short description of the call's intent, usually in
+      the form <verb> <noun>, to log the retry attempts. Example: "create snap X".
+    :param retry_exception: the exception, or group of exceptions, that can
+      trigger a retry attempt. Any other exception will just be propagated up
+      without retrying.
+    :param call_to_retry: the callable to be retried.
+    :param call_args: the args to be passed to when calling
+      ``call_to_retry``.
+    :param call_kwargs: the kwargs to be passed to when calling
+      ``call_to_retry``.
+    """
+    for attempt in range(_ATTEMPT_COUNT):
+        emit.debug(
+            f"Trying to {action_message} (attempt {attempt + 1}/{_ATTEMPT_COUNT})"
+        )
+        try:
+            return call_to_retry(*call_args, **call_kwargs)
+        except retry_exception as err:
+            emit.debug(str(err))
+            if attempt >= _ATTEMPT_COUNT - 1:
+                raise
+            time.sleep(3)
+            continue
+
+    raise AssertionError("This code is unreachable!")

--- a/tests/unit/launchpad/test_launchpad.py
+++ b/tests/unit/launchpad/test_launchpad.py
@@ -208,8 +208,8 @@ def test_recipe_snap_new_retry(emitter, mocker):
     assert isinstance(recipe, models.SnapRecipe)
     assert mock_launchpad.lp.snaps.new.call_count == 2  # noqa: PLR2004
 
-    emitter.assert_debug("Trying to create snap recipe 'my_recipe' (attempt 1/4)")
-    emitter.assert_debug("Trying to create snap recipe 'my_recipe' (attempt 2/4)")
+    emitter.assert_debug("Trying to create snap recipe 'my_recipe' (attempt 1/6)")
+    emitter.assert_debug("Trying to create snap recipe 'my_recipe' (attempt 2/6)")
 
 
 @pytest.mark.parametrize("type_", ["charm", "Charm", models.RecipeType.CHARM])
@@ -258,8 +258,8 @@ def test_recipe_charm_new_retry(emitter, mocker):
     assert isinstance(recipe, models.CharmRecipe)
     assert mock_launchpad.lp.charm_recipes.new.call_count == 2  # noqa: PLR2004
 
-    emitter.assert_debug("Trying to create charm recipe 'my_recipe' (attempt 1/4)")
-    emitter.assert_debug("Trying to create charm recipe 'my_recipe' (attempt 2/4)")
+    emitter.assert_debug("Trying to create charm recipe 'my_recipe' (attempt 1/6)")
+    emitter.assert_debug("Trying to create charm recipe 'my_recipe' (attempt 2/6)")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -55,10 +55,14 @@ def test_set_project_success(remote_build_service, mock_project_entry, name):
 
 
 @pytest.mark.parametrize("name", ["some-project", "another-project"])
-def test_set_project_name_error(remote_build_service, mock_project_entry, name):
+def test_set_project_name_error(remote_build_service, mock_project_entry, name, mocker):
+    mocker.patch("time.sleep")
     mock_project_entry.name = name
+    response = mocker.Mock(
+        status=400, reason="Bad Request", items=mocker.Mock(return_value=[])
+    )
     remote_build_service.lp.lp.projects.__getitem__.side_effect = (
-        lazr.restfulclient.errors.NotFound("yo", "dawg")
+        lazr.restfulclient.errors.NotFound(response, "dawg")
     )
 
     with pytest.raises(
@@ -80,9 +84,13 @@ def test_ensure_project_existing(remote_build_service, mock_project_entry):
     remote_build_service._ensure_project()
 
 
-def test_ensure_project_new(remote_build_service):
+def test_ensure_project_new(remote_build_service, mocker):
+    mocker.patch("time.sleep")
+    response = mocker.Mock(
+        status=400, reason="Bad Request", items=mocker.Mock(return_value=[])
+    )
     remote_build_service.lp.lp.projects.__getitem__.side_effect = (
-        lazr.restfulclient.errors.NotFound("yo", "dawg")
+        lazr.restfulclient.errors.NotFound(response, "dawg")
     )
 
     remote_build_service._ensure_project()

--- a/tests/unit/util/test_retry.py
+++ b/tests/unit/util/test_retry.py
@@ -1,0 +1,102 @@
+# This file is part of craft-application.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for retry()."""
+import time
+from unittest.mock import call
+
+import pytest
+from craft_application.util import retry
+
+EXPECTED_ATTEMPTS = 3
+
+
+class MyError(Exception):
+    pass
+
+
+def never_raises(*_args, **_kwargs) -> str:
+    return "success"
+
+
+def always_raises(*_args, **_kwargs) -> None:
+    raise MyError("raised an error!")
+
+
+@pytest.fixture()
+def mocked_sleep(mocker):
+    return mocker.patch.object(time, "sleep")
+
+
+def test_retry_success(mocked_sleep, emitter):
+    assert retry("call never_raises", MyError, never_raises) == "success"
+
+    # sleep() is not called.
+    assert not mocked_sleep.called
+
+    # Attempts get logged.
+    emitter.assert_debug("Trying to call never_raises (attempt 1/4)")
+
+
+def test_retry_args_kwargs():
+    def full_func(*args, **kwargs) -> str:
+        return f"{args}, {kwargs}"
+
+    result = retry("call full_func", Exception, full_func, 1, 2, 3, val=True)
+
+    assert result == "(1, 2, 3), {'val': True}"
+
+
+@pytest.mark.parametrize("exceptions", [MyError, (ValueError, MyError)])
+def test_retry_failure(mocked_sleep, exceptions, emitter):
+    with pytest.raises(MyError):
+        retry("call always_raises", exceptions, always_raises)
+
+    # sleep() is called multiple times.
+    assert mocked_sleep.mock_calls == [call(3)] * EXPECTED_ATTEMPTS
+
+    # Attempts get logged.
+    emitter.assert_debug("Trying to call always_raises (attempt 1/4)")
+    emitter.assert_debug("Trying to call always_raises (attempt 2/4)")
+    emitter.assert_debug("Trying to call always_raises (attempt 3/4)")
+    emitter.assert_debug("Trying to call always_raises (attempt 4/4)")
+
+
+def test_retry_eventual_success(mocked_sleep, emitter):
+    attempt = 0
+    should_raise = [True, True, False]
+
+    def fails_twice(*_args, **_kwargs):
+        nonlocal attempt
+
+        if should_raise[attempt]:
+            attempt += 1
+            raise MyError
+
+        return "eventual success"
+
+    result = retry("call fails_twice", MyError, fails_twice)
+
+    assert result == "eventual success"
+    assert mocked_sleep.mock_calls == [call(3), call(3)]
+    emitter.assert_debug("Trying to call fails_twice (attempt 1/4)")
+    emitter.assert_debug("Trying to call fails_twice (attempt 2/4)")
+
+
+def test_retry_wrong_exception(mocked_sleep):
+    with pytest.raises(MyError):
+        retry("call always_raises", ValueError, always_raises)
+
+    assert not mocked_sleep.called


### PR DESCRIPTION
Builds on top of #352, only the last commit is new.

This commit changes the retry() strategy: instead of sleeping a constant
3 seconds between attempts, each attempt sleeps twice as much as the previous
one (starting at 2 seconds). There is a cap of 5 attempts, so that the call
to retry can sleep() for at most 2+4+8+16+32 = 62 seconds.
