### PR TITLE
feat: add a method to enable craft-parts Features

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -488,7 +488,7 @@ class Application:
     ) -> int:
         """Bootstrap and run the application."""
         self._setup_logging()
-        self._register_default_plugins()
+        self._initialize_craft_parts()
         dispatcher = self._get_dispatcher()
         craft_cli.emit.debug("Preparing application...")
 
@@ -745,6 +745,14 @@ class Application:
                 f"Valid levels are: {', '.join(emitter.name for emitter in craft_cli.EmitterMode)}",
                 permanent=True,
             )
+
+    def _enable_craft_parts_features(self) -> None:
+        """Enable any specific craft-parts Feature that the application will need."""
+
+    def _initialize_craft_parts(self) -> None:
+        """Perform craft-parts-specific initialization, like features and plugins."""
+        self._enable_craft_parts_features()
+        self._register_default_plugins()
 
 
 def filter_plan(

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1863,3 +1863,24 @@ def test_process_grammar_full(grammar_app_full):
         {"path": "riscv64-perm-1", "owner": 123, "group": 123, "mode": "777"},
         {"path": "riscv64-perm-2", "owner": 456, "group": 456, "mode": "666"},
     ]
+
+
+def test_enable_features(app, mocker):
+    calls = []
+
+    def enable_features(*_args, **_kwargs):
+        calls.append("enable-features")
+
+    def register_plugins(*_args, **_kwargs):
+        calls.append("register-plugins")
+
+    mocker.patch.object(
+        app, "_enable_craft_parts_features", side_effect=enable_features
+    )
+    mocker.patch.object(app, "_register_default_plugins", side_effect=register_plugins)
+
+    with pytest.raises(SystemExit):
+        app.run()
+
+    # Check that features were enabled very early, before plugins are registered.
+    assert calls == ["enable-features", "register-plugins"]


### PR DESCRIPTION
The correct location to add craft-parts Features is a bit tricky:

- it must happen soon enough that things that happen early have the correct features enabled. For example, building the default command groups takes into account whether overlays are enabled;
- it must happen late enough that the craft-cli logging support has already been set-up.

Therefore, provide a method that Application subclasses can override to enable their features, and the Application itself takes care of calling it at the correct time.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
