### PR TITLE
feat: accept build-for: [all] in platforms

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -630,6 +630,16 @@ class Application:
         :param yaml_data: The project's yaml data.
         :param build_for: The architecture to build for.
         """
+        if build_for == "all":
+            build_for_arch = util.get_host_architecture()
+            craft_cli.emit.debug(
+                "Expanding environment variables with the host architecture "
+                f"{build_for_arch!r} as the build-for architecture because 'all' was "
+                "specified."
+            )
+        else:
+            build_for_arch = build_for
+
         environment_vars = self._get_project_vars(yaml_data)
         project_dirs = craft_parts.ProjectDirs(
             work_dir=self._work_dir, partitions=self._partitions
@@ -638,7 +648,7 @@ class Application:
         info = craft_parts.ProjectInfo(
             application_name=self.app.name,  # not used in environment expansion
             cache_dir=pathlib.Path(),  # not used in environment expansion
-            arch=util.convert_architecture_deb_to_platform(build_for),
+            arch=util.convert_architecture_deb_to_platform(build_for_arch),
             project_name=yaml_data.get("name", ""),
             project_dirs=project_dirs,
             project_vars=environment_vars,

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -160,12 +160,15 @@ class LifecycleService(base.ProjectService):
         emit.debug(f"Initialising lifecycle manager in {self._work_dir}")
         emit.trace(f"Lifecycle: {repr(self)}")
 
-        host_arch = util.get_host_architecture()
         # Note: we fallback to the host's architecture here if the build plan
         # is empty just to be able to create the LifecycleManager; this will
         # correctly fail later on when run() is called (but not necessarily when
         # something else like clean() is called).
-        build_for = self._build_plan[0].build_for if self._build_plan else host_arch
+        # We also use the host arch if the build-for is 'all'
+        if self._build_plan and self._build_plan[0].build_for != "all":
+            build_for = self._build_plan[0].build_for
+        else:
+            build_for = util.get_host_architecture()
 
         if self._project.package_repositories:
             self._manager_kwargs["package_repositories"] = (

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -313,6 +313,14 @@ class RemoteBuildService(base.AppService):
         """Create a new recipe for the given repository."""
         repository.lp_refresh()  # Prevents a race condition on new repositories.
         git_ref = parse.urlparse(str(repository.git_https_url)).path + "/+ref/main"
+
+        # if kwargs has a collection of 'architectures',  replace 'all' with 'amd64'
+        # because the amd64 runners are fast to build on
+        if kwargs.get("architectures"):
+            kwargs["architectures"] = [
+                "amd64" if arch == "all" else arch for arch in kwargs["architectures"]
+            ]
+
         return self.RecipeClass.new(
             self.lp,
             name,

--- a/docs/explanation/build-plans.rst
+++ b/docs/explanation/build-plans.rst
@@ -1,0 +1,76 @@
+Build plans
+===========
+
+A build plan is a collection of platforms to build. It can be defined in the
+project's metadata file and filtered with command-line arguments.
+
+Filtering build plans
+---------------------
+
+A build plan contains all possible platforms to build. When loading the project
+model, the build plan is filtered to builds that match all of the following:
+
+* where ``build-on`` matches the host's architecture
+* where ``build-for`` matches the command line argument ``--build-for``
+* where ``platform`` matches the command line argument ``--platform``
+
+Note that ``--build-for`` and ``--platform`` are mutually exclusive.
+
+Consider the following project metadata:
+
+.. code-block:: yaml
+
+  base: ubuntu@24.04
+  platforms:
+    amd64:
+    riscv64:
+      build-on: [amd64, riscv64]
+      build-for: [riscv64]
+
+The application will create a build plan with three elements:
+
+.. code-block:: text
+
+  platform: amd64, build-on amd64, build-for amd64, base: ubuntu@24.04
+  platform: riscv64, build-on amd64, build-for riscv64, base: ubuntu@24.04
+  platform: riscv64, build-on riscv64, build-for riscv64, base: ubuntu@24.04
+
+If the application executes on an ``amd64`` platform, the build plan will be
+filtered to:
+
+.. code-block:: text
+
+  platform: amd64, build-on amd64, build-for amd64, base: ubuntu@24.04
+  platform: riscv64, build-on amd64, build-for riscv64, base: ubuntu@24.04
+
+If the application executes on an ``amd64`` platform and ``--platform riscv64``
+is provided, the build plan will be filtered to:
+
+.. code-block:: text
+
+  platform: riscv64, build-on amd64, build-for riscv64, base: ubuntu@24.04
+
+If the application executes on a ``riscv64`` platform, the build plan will be
+filtered to:
+
+.. code-block:: text
+
+  platform: riscv64, build-on riscv64, build-for riscv64, base: ubuntu@24.04
+
+Building with a provider
+------------------------
+
+When using a provider like LXD or Multipass, each build in the build plan
+occurs sequentially in its own build environment.
+
+The build plan's ``base`` determines the container image to use.
+
+Destructive mode
+----------------
+
+When using destructive mode, only one build will occur. If multiple items in
+the build plan match the host environment, the application will fail to run.
+The build plan must be filtered to a single item with the ``--build-for`` and
+``-platform`` arguments.
+
+The host OS much match the build plan's ``base``.

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -5,3 +5,5 @@ Explanation
 
 .. toctree::
    :maxdepth: 1
+
+   build-plans

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -6,6 +6,8 @@ Reference
 .. toctree::
    :maxdepth: 1
 
+   platforms
+
 Indices and tables
 ==================
 

--- a/docs/reference/platforms.rst
+++ b/docs/reference/platforms.rst
@@ -1,0 +1,44 @@
+Platforms
+=========
+
+.. code-block:: yaml
+
+  platforms:
+    <platform 1>:
+      build-on: [<arch 1>, <arch 2>]
+      build-for: [<arch 1>]
+    <platform 2>:
+      build-on: [<arch 3>]
+      build-for: [<arch 4>]
+    ...
+
+platform
+""""""""
+
+The platform name describes a ``build-on``/``build-for`` pairing. If the
+platform name is a valid debian architecture, then ``build-on`` and
+``build-for`` can be omitted.
+
+The recommended platform name is the ``build-for`` arch.
+
+build-on
+""""""""
+
+The ``build-on`` field is an optional list of architectures where the artefact
+can be built. It can contain multiple architectures.
+
+If the platform name is a valid architecture and ``build-for`` is not defined,
+then ``build-on`` can be omitted. ``build-on`` will assume the platform name.
+
+build-for
+"""""""""
+
+The ``build-for`` field is an optional single-element list containing the
+architecture where the artefact should run.
+
+If the platform name is a valid architecture, then ``build-for`` will
+assume the platform name.
+
+``build-for: [all]`` is a special keyword to denote an architecture-independent
+artefact. If the ``all`` keyword is used, no other ``build-on/build-for`` pairs
+can be defined.

--- a/tests/integration/data/valid_projects/build-for-all/stderr
+++ b/tests/integration/data/valid_projects/build-for-all/stderr
@@ -1,0 +1,1 @@
+Packed package_1.0.tar.zst

--- a/tests/integration/data/valid_projects/build-for-all/testcraft.yaml
+++ b/tests/integration/data/valid_projects/build-for-all/testcraft.yaml
@@ -1,0 +1,12 @@
+name: build-for-all
+title: Build one artefact for all architectures
+version: 1.0
+base: "ubuntu@22.04"
+platforms:
+  platform1:
+    build-on: [amd64, arm64, armhf, i386, powerpc, ppc64el, riscv64, s390x]
+    build-for: [all]
+
+parts:
+  my-part:
+    plugin: nil

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -459,6 +459,38 @@ def test_post_prime_wrong_step(fake_parts_lifecycle, step):
         fake_parts_lifecycle.post_prime(step_info)
 
 
+def test_run_lifecycle_build_for_all(
+    app_metadata,
+    fake_project,
+    fake_services,
+    tmp_path,
+):
+    """'build-for: [all]' should be converted to the host arch."""
+    build_plan = [
+        models.BuildInfo(
+            platform="platform1",
+            build_on=util.get_host_architecture(),
+            build_for="all",
+            base=util.get_host_base(),
+        )
+    ]
+    work_dir = tmp_path / "work"
+
+    service = lifecycle.LifecycleService(
+        app_metadata,
+        fake_services,
+        project=fake_project,
+        work_dir=work_dir,
+        cache_dir=tmp_path / "cache",
+        platform=None,
+        build_plan=build_plan,
+    )
+    service.setup()
+
+    assert service.project_info.target_arch == util.get_host_architecture()
+    assert service.project_info.arch_build_for == util.get_host_architecture()
+
+
 # endregion
 # region Feature package repositories tests
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Allows `build-for: [all]` in a platform definition.  When this is defined, no other platforms may be defined.

Related to https://github.com/canonical/snapcraft/issues/4854
Fixes #360
(CRAFT-3016)