### PR TITLE
docs: add howto for using partitions

### DIFF
--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -1,7 +1,9 @@
 .. _howto:
 
-How-to guides
-*************
+How-To
+******
 
 .. toctree::
    :maxdepth: 1
+
+   partitions

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -1,0 +1,131 @@
+******************************************
+Add partition support to an application
+******************************************
+
+Partitions basics
+=================
+
+Applications implementing ``craft-application`` and its dependent suite of libraries can optionally make use of `disk partitions <https://en.wikipedia.org/wiki/Disk_partitioning>`_.  The supported list of partitions must be defined by the application itself (at runtime), and those defined partitions can then be used by application consumers' configuration yaml files.
+
+Optionally, partitions can be namespaced, for organizational purposes.
+
+Partition names and namespace names must consist of *only* lower-case alphabetic characters, unless a partition exists under a namespace, in which case it may also contain hyphen characters, though the first and last characters must still be alphabetic.
+
+``default`` must always be the first listed partition.
+
+In the below examples, we work with three partitions: ``default``, ``kernel``, and ``component/bar-baz``.  The ``default`` and ``kernel`` partitions do not have a namespace.  The ``bar-baz`` partition is part of the ``component`` namespace.
+
+.. _app_changes:
+
+Required application changes
+============================
+
+To add partition support to an application, two basic changes are needed:
+
+#. Enable the feature
+
+   Use the :class:`Features <craft_parts.Features>` class to specify that the application will use partitions:
+
+   .. code-block:: python
+
+     from craft_parts import Features
+
+     Features.reset()
+     Features(enable_partitions=True)
+
+   .. NOTE::
+      The ``craft-application`` class :class:`AppFeatures <craft_application.AppFeatures>` has a similar name and serves a similar purpose to ``craft-parts``'s :class:`Features <craft_parts.Features>`, but partitions cannot be enabled via :class:`AppFeatures <craft_application.AppFeatures>`!
+
+#. Define the list of partitions
+
+   We need to tell the :class:`LifecycleManager <craft_parts.LifecycleManager>` class about our partitions, but applications do not usually directly instantiate the LifecycleManager.
+
+   Instead, override your :class:`Application <craft_application.Application>`'s ``_setup_partitions`` method, and return a list of the partitions, which will eventually be passed to the :class:`LifecycleManager <craft_parts.LifecycleManager>`:
+
+   .. code-block:: python
+
+     class SnackcraftApplication(Application):
+
+       ...
+
+       @override
+       def _setup_partitions(self, yaml_data: dict[str, Any]) -> list[str] | None:
+           return ["default", "kernel", "component/bar-baz"]
+
+Using the partitions
+====================
+
+Partitions cannot be used until `after you have configured your application <#app-changes>`_.
+
+In configuration yaml
+---------------------
+
+Defined partitions may be referenced in the ``organize``, ``stage``, and ``prime`` sections of your configuration yaml files:
+
+.. code-block:: yaml
+
+  organize:
+    <source-path>: (<partition>)/<path>
+  stage:
+    - (<partition>)/<path>
+  prime:
+    - (<partition>)/<path>
+
+Paths in the configuration yaml not beginning with a partition label will implicitly use the default partition.
+
+The source path of an ``organize`` entry can only be from the default partition.  For example:
+
+.. code-block:: yaml
+
+  organize:
+    (kernel)/usr/local/bin/hello: bin/hello
+
+.. code-block:: text
+
+  Cannot organize files from 'kernel' partition.
+  Files can only be organized from the 'default' partition
+
+When the ``stage`` and ``prime`` keywords are not provided for a part, craft-parts' default behavior is to stage and prime all files for the part in all partitions.
+
+(If a stage or prime filter *is* applied to a partition, the default behavior will not be affected for the other partitions.)
+
+See also
+^^^^^^^^
+
+ * `Craft parts: part properties: organize <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/reference/part_properties.html#organize>`_
+ * `Craft parts: filesets: specifying paths <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/explanation/filesets.html#partitions>`_
+
+In environment variables
+------------------------
+
+You might use these variables in a lifecycle override section of a configuration yaml.  For instance:
+
+.. code-block:: yaml
+
+  override-prime: |
+    cp -R $CRAFT_KERNEL_STAGE/vmlinux $CRAFT_KERNEL_PRIME/
+    chmod -R 444 $CRAFT_KERNEL_PRIME/*
+    cp -R $CRAFT_STAGE/lib/modules/6.x/* $CRAFT_PRIME
+    chmod -R 600 $CRAFT_PRIME/*
+
+See also
+^^^^^^^^
+
+ * `Craft parts: parts and steps: environment variables <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/reference/parts_steps.html#partition-specific-output-directory-environment-variables>`_
+ * `Craft parts: part properties: override-prime <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/reference/part_properties.html#override-prime>`_
+
+From code
+---------
+
+Application code that can access ``Part`` or ``ProjectDirs`` objects may get partition information from them:
+
+.. code-block:: python-console
+
+  >>> Part(name="my-part").part_install_dirs["kernel"]
+  Path("partitions/kernel/parts/my-part/install")
+
+  >>> ProjectDirs.get_stage_dir(partition="kernel")
+  Path("/root/partitions/kernel/stage")
+
+  >>> ProjectDirs.get_prime_dir(partition="component/bar-baz")
+  Path("/root/partitions/component/bar-baz/prime")

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -172,15 +172,12 @@ See also
 In code
 -------
 
-Application code that can access ``Part`` or ``ProjectDirs`` objects may get
-partition information from them:
+Application code that can access ``ProjectDirs`` objects may get partition
+information from them:
 
 .. code-block:: python-console
 
-  >>> Part(name="my-part").part_install_dirs["kernel"]
-  Path("partitions/kernel/parts/my-part/install")
-
-  >>> # or, from within the LifecycleService:
+  >>> # from within the LifecycleService:
 
   >>> self.project_info.dirs.get_stage_dir(partition="kernel")
   Path("/root/partitions/kernel/stage")

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -5,9 +5,17 @@ Add partition support to an application
 Partitions basics
 =================
 
+.. Insert link below to new Snapcraft docs when this is merged and live:
+   https://github.com/canonical/snapcraft/issues/4857
+
 Applications implementing ``craft-application`` and its dependent suite of
-libraries can optionally make use of `disk partitions
-<https://en.wikipedia.org/wiki/Disk_partitioning>`_.  The supported list of
+libraries can optionally make use of *partitions* when organizing the files in their output artifact.  Partitions are a generic concept, and may be used to implement a concrete feature in your application.  For instance, partitions may refer to:
+
+* Snapcraft's *components*
+* `Disk partitions <https://en.wikipedia.org/wiki/Disk_partitioning>`_
+* Any other level of organization you may want to add to the application's output, such as layers in an OCI image
+
+The supported list of
 partitions must be defined by the application itself (at runtime), and those
 defined partitions can then be used by application consumers' configuration
 yaml files.

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -110,16 +110,30 @@ Paths in the configuration yaml not beginning with a partition label will
 implicitly use the default partition.
 
 The source path of an ``organize`` entry can only be from the default
-partition.  For example:
+partition.  For example, this is valid:
 
 .. code-block:: yaml
 
   organize:
-    (kernel)/usr/local/bin/hello: bin/hello
+    usr/local/bin/hello: (component/bar-baz)/bin/hello
+
+This is also valid, and equivalent to the above:
+
+.. code-block:: yaml
+
+  organize:
+    (default)/usr/local/bin/hello: (component/bar-baz)/bin/hello
+
+But this is invalid:
+
+.. code-block:: yaml
+
+  organize:
+    (component/bar-baz)/usr/local/bin/hello: bin/hello
 
 .. code-block:: text
 
-  Cannot organize files from 'kernel' partition.
+  Cannot organize files from 'component/bar-baz' partition.
   Files can only be organized from the 'default' partition
 
 When the ``stage`` and ``prime`` keywords are not provided for a part,

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -21,7 +21,7 @@ refer to:
 
 The supported list of partitions must be defined by the application itself (at
 runtime), and those defined partitions can then be used by application
-consumers' configuration yaml files.
+consumers' project files.
 
 Optionally, partitions can be namespaced, for organizational purposes.
 
@@ -91,11 +91,11 @@ Using the partitions
 Partitions cannot be used until `after you have configured your application
 <#app-changes>`_.
 
-In configuration yaml
----------------------
+In a project file
+-----------------
 
 Defined partitions may be referenced in the ``organize``, ``stage``, and
-``prime`` sections of your configuration yaml files:
+``prime`` sections of your project files:
 
 .. code-block:: yaml
 
@@ -106,8 +106,8 @@ Defined partitions may be referenced in the ``organize``, ``stage``, and
   prime:
     - (<partition>)/<path>
 
-Paths in the configuration yaml not beginning with a partition label will
-implicitly use the default partition.
+Paths in the project file not beginning with a partition label will implicitly
+use the default partition.
 
 The source path of an ``organize`` entry can only be from the default
 partition.  For example, this is valid:
@@ -152,8 +152,8 @@ See also
 In environment variables
 ------------------------
 
-You might use these variables in a lifecycle override section of a
-configuration yaml.  For instance:
+You might use these variables in a lifecycle override section of a project
+file.  For instance:
 
 .. code-block:: yaml
 

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -159,9 +159,9 @@ file.  For instance:
 .. code-block:: yaml
 
   override-prime: |
-    cp -R /vmlinux $CRAFT_KERNEL_PRIME/
+    cp -R vmlinux $CRAFT_KERNEL_PRIME/
     chmod -R 444 $CRAFT_KERNEL_PRIME/*
-    cp -R /lib/modules/6.x/* $CRAFT_PRIME
+    cp -R lib/modules/6.x/* $CRAFT_PRIME
     chmod -R 600 $CRAFT_PRIME/*
 
 See also

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -28,7 +28,8 @@ Optionally, partitions can be namespaced, for organizational purposes.
 Partition names and namespace names must consist of *only* lower-case
 alphabetic characters, unless a partition exists under a namespace, in which
 case it may also contain hyphen characters, though the first and last
-characters must still be alphabetic.
+characters must still be alphabetic.  Names containing hyphens also may not
+contain two or more hyphens in a row.
 
 ``default`` must always be the first listed partition.
 

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -146,8 +146,8 @@ will not be affected for the other partitions.)
 See also
 ^^^^^^^^
 
- * Craft parts: part properties: `organize`_
- * Craft parts: filesets: `specifying paths`_
+* Craft parts: part properties: `organize`_
+* Craft parts: filesets: `specifying paths`_
 
 In environment variables
 ------------------------
@@ -166,8 +166,8 @@ configuration yaml.  For instance:
 See also
 ^^^^^^^^
 
- * Craft parts: parts and steps: `environment variables`_
- * Craft parts: part properties: `override-prime`_
+* Craft parts: parts and steps: `environment variables`_
+* Craft parts: part properties: `override-prime`_
 
 In code
 -------

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -180,10 +180,12 @@ partition information from them:
   >>> Part(name="my-part").part_install_dirs["kernel"]
   Path("partitions/kernel/parts/my-part/install")
 
-  >>> ProjectDirs.get_stage_dir(partition="kernel")
+  >>> # or, from within the LifecycleService:
+
+  >>> self.project_info.dirs.get_stage_dir(partition="kernel")
   Path("/root/partitions/kernel/stage")
 
-  >>> ProjectDirs.get_prime_dir(partition="component/bar-baz")
+  >>> self.project_info.dirs.get_prime_dir(partition="component/bar-baz")
   Path("/root/partitions/component/bar-baz/prime")
 
 

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -158,9 +158,9 @@ configuration yaml.  For instance:
 .. code-block:: yaml
 
   override-prime: |
-    cp -R $CRAFT_KERNEL_STAGE/vmlinux $CRAFT_KERNEL_PRIME/
+    cp -R /vmlinux $CRAFT_KERNEL_PRIME/
     chmod -R 444 $CRAFT_KERNEL_PRIME/*
-    cp -R $CRAFT_STAGE/lib/modules/6.x/* $CRAFT_PRIME
+    cp -R /lib/modules/6.x/* $CRAFT_PRIME
     chmod -R 600 $CRAFT_PRIME/*
 
 See also

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -5,15 +5,26 @@ Add partition support to an application
 Partitions basics
 =================
 
-Applications implementing ``craft-application`` and its dependent suite of libraries can optionally make use of `disk partitions <https://en.wikipedia.org/wiki/Disk_partitioning>`_.  The supported list of partitions must be defined by the application itself (at runtime), and those defined partitions can then be used by application consumers' configuration yaml files.
+Applications implementing ``craft-application`` and its dependent suite of
+libraries can optionally make use of `disk partitions
+<https://en.wikipedia.org/wiki/Disk_partitioning>`_.  The supported list of
+partitions must be defined by the application itself (at runtime), and those
+defined partitions can then be used by application consumers' configuration
+yaml files.
 
 Optionally, partitions can be namespaced, for organizational purposes.
 
-Partition names and namespace names must consist of *only* lower-case alphabetic characters, unless a partition exists under a namespace, in which case it may also contain hyphen characters, though the first and last characters must still be alphabetic.
+Partition names and namespace names must consist of *only* lower-case
+alphabetic characters, unless a partition exists under a namespace, in which
+case it may also contain hyphen characters, though the first and last
+characters must still be alphabetic.
 
 ``default`` must always be the first listed partition.
 
-In the below examples, we work with three partitions: ``default``, ``kernel``, and ``component/bar-baz``.  The ``default`` and ``kernel`` partitions do not have a namespace.  The ``bar-baz`` partition is part of the ``component`` namespace.
+In the below examples, we work with three partitions: ``default``, ``kernel``,
+and ``component/bar-baz``.  The ``default`` and ``kernel`` partitions do not
+have a namespace.  The ``bar-baz`` partition is part of the ``component``
+namespace.
 
 .. _app_changes:
 
@@ -24,7 +35,8 @@ To add partition support to an application, two basic changes are needed:
 
 #. Enable the feature
 
-   Use the :class:`Features <craft_parts.Features>` class to specify that the application will use partitions:
+   Use the :class:`Features <craft_parts.Features>` class to specify that the
+   application will use partitions:
 
    .. code-block:: python
 
@@ -34,13 +46,22 @@ To add partition support to an application, two basic changes are needed:
      Features(enable_partitions=True)
 
    .. NOTE::
-      The ``craft-application`` class :class:`AppFeatures <craft_application.AppFeatures>` has a similar name and serves a similar purpose to ``craft-parts``'s :class:`Features <craft_parts.Features>`, but partitions cannot be enabled via :class:`AppFeatures <craft_application.AppFeatures>`!
+      The ``craft-application`` class :class:`AppFeatures
+      <craft_application.AppFeatures>` has a similar name and serves a similar
+      purpose to ``craft-parts``'s :class:`Features <craft_parts.Features>`,
+      but partitions cannot be enabled via :class:`AppFeatures
+      <craft_application.AppFeatures>`!
 
 #. Define the list of partitions
 
-   We need to tell the :class:`LifecycleManager <craft_parts.LifecycleManager>` class about our partitions, but applications do not usually directly instantiate the LifecycleManager.
+   We need to tell the :class:`LifecycleManager <craft_parts.LifecycleManager>`
+   class about our partitions, but applications do not usually directly
+   instantiate the LifecycleManager.
 
-   Instead, override your :class:`Application <craft_application.Application>`'s ``_setup_partitions`` method, and return a list of the partitions, which will eventually be passed to the :class:`LifecycleManager <craft_parts.LifecycleManager>`:
+   Instead, override your :class:`Application
+   <craft_application.Application>`'s ``_setup_partitions`` method, and return
+   a list of the partitions, which will eventually be passed to the
+   :class:`LifecycleManager <craft_parts.LifecycleManager>`:
 
    .. code-block:: python
 
@@ -55,12 +76,14 @@ To add partition support to an application, two basic changes are needed:
 Using the partitions
 ====================
 
-Partitions cannot be used until `after you have configured your application <#app-changes>`_.
+Partitions cannot be used until `after you have configured your application
+<#app-changes>`_.
 
 In configuration yaml
 ---------------------
 
-Defined partitions may be referenced in the ``organize``, ``stage``, and ``prime`` sections of your configuration yaml files:
+Defined partitions may be referenced in the ``organize``, ``stage``, and
+``prime`` sections of your configuration yaml files:
 
 .. code-block:: yaml
 
@@ -71,9 +94,11 @@ Defined partitions may be referenced in the ``organize``, ``stage``, and ``prime
   prime:
     - (<partition>)/<path>
 
-Paths in the configuration yaml not beginning with a partition label will implicitly use the default partition.
+Paths in the configuration yaml not beginning with a partition label will
+implicitly use the default partition.
 
-The source path of an ``organize`` entry can only be from the default partition.  For example:
+The source path of an ``organize`` entry can only be from the default
+partition.  For example:
 
 .. code-block:: yaml
 
@@ -85,20 +110,24 @@ The source path of an ``organize`` entry can only be from the default partition.
   Cannot organize files from 'kernel' partition.
   Files can only be organized from the 'default' partition
 
-When the ``stage`` and ``prime`` keywords are not provided for a part, craft-parts' default behavior is to stage and prime all files for the part in all partitions.
+When the ``stage`` and ``prime`` keywords are not provided for a part,
+craft-parts' default behavior is to stage and prime all files for the part in
+all partitions.
 
-(If a stage or prime filter *is* applied to a partition, the default behavior will not be affected for the other partitions.)
+(If a stage or prime filter *is* applied to a partition, the default behavior
+will not be affected for the other partitions.)
 
 See also
 ^^^^^^^^
 
- * `Craft parts: part properties: organize <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/reference/part_properties.html#organize>`_
- * `Craft parts: filesets: specifying paths <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/explanation/filesets.html#partitions>`_
+ * Craft parts: part properties: `organize`_
+ * Craft parts: filesets: `specifying paths`_
 
 In environment variables
 ------------------------
 
-You might use these variables in a lifecycle override section of a configuration yaml.  For instance:
+You might use these variables in a lifecycle override section of a
+configuration yaml.  For instance:
 
 .. code-block:: yaml
 
@@ -111,13 +140,14 @@ You might use these variables in a lifecycle override section of a configuration
 See also
 ^^^^^^^^
 
- * `Craft parts: parts and steps: environment variables <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/reference/parts_steps.html#partition-specific-output-directory-environment-variables>`_
- * `Craft parts: part properties: override-prime <https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/reference/part_properties.html#override-prime>`_
+ * Craft parts: parts and steps: `environment variables`_
+ * Craft parts: part properties: `override-prime`_
 
-From code
----------
+In code
+-------
 
-Application code that can access ``Part`` or ``ProjectDirs`` objects may get partition information from them:
+Application code that can access ``Part`` or ``ProjectDirs`` objects may get
+partition information from them:
 
 .. code-block:: python-console
 
@@ -129,3 +159,9 @@ Application code that can access ``Part`` or ``ProjectDirs`` objects may get par
 
   >>> ProjectDirs.get_prime_dir(partition="component/bar-baz")
   Path("/root/partitions/component/bar-baz/prime")
+
+
+.. _organize: https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/reference/part_properties.html#organize
+.. _specifying paths: https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/explanation/filesets.html#partitions
+.. _environment variables: https://canonical-craft-parts.readthedocs-hosted.com/en/latest/reference/parts_steps.html#partition-specific-output-directory-environment-variables
+.. _override-prime: https://canonical-craft-parts.readthedocs-hosted.com/en/latest/common/craft-parts/reference/part_properties.html#override-prime

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -9,16 +9,19 @@ Partitions basics
    https://github.com/canonical/snapcraft/issues/4857
 
 Applications implementing ``craft-application`` and its dependent suite of
-libraries can optionally make use of *partitions* when organizing the files in their output artifact.  Partitions are a generic concept, and may be used to implement a concrete feature in your application.  For instance, partitions may refer to:
+libraries can optionally make use of *partitions* when organizing the files in
+their output artifact.  Partitions are a generic concept, and may be used to
+implement a concrete feature in your application.  For instance, partitions may
+refer to:
 
 * Snapcraft's *components*
-* `Disk partitions <https://en.wikipedia.org/wiki/Disk_partitioning>`_
-* Any other level of organization you may want to add to the application's output, such as layers in an OCI image
+* `Disk partitions <https://en.wikipedia.org/wiki/Disk_partitioning>`_ * Any
+  other level of organization you may want to add to the application's output,
+  such as layers in an OCI image
 
-The supported list of
-partitions must be defined by the application itself (at runtime), and those
-defined partitions can then be used by application consumers' configuration
-yaml files.
+The supported list of partitions must be defined by the application itself (at
+runtime), and those defined partitions can then be used by application
+consumers' configuration yaml files.
 
 Optionally, partitions can be namespaced, for organizational purposes.
 

--- a/docs/howto/partitions.rst
+++ b/docs/howto/partitions.rst
@@ -110,14 +110,15 @@ Paths in the project file not beginning with a partition label will implicitly
 use the default partition.
 
 The source path of an ``organize`` entry can only be from the default
-partition.  For example, this is valid:
+partition.  For example, this organizes the file "usr/local/bin/hello" into the
+"bar-baz" partition in the "component" namespace:
 
 .. code-block:: yaml
 
   organize:
     usr/local/bin/hello: (component/bar-baz)/bin/hello
 
-This is also valid, and equivalent to the above:
+This is equivalent to the above:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
Add howto guide for using partitions.

You could argue that some of this content should really go into `craft-parts` documentation, but I would respond that doing that would make the document less useful.

(CRAFT-3068)