### PR TITLE
feat(remotebuild): add property for launchpad credentials filepath

### DIFF
--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -21,8 +21,9 @@ from unittest import mock
 import launchpadlib.errors
 import lazr.restfulclient.errors
 import lazr.restfulclient.resource
+import platformdirs
 import pytest
-from craft_application import errors, launchpad
+from craft_application import errors, launchpad, services
 from craft_application.remote import git
 from craft_application.remote.errors import RemoteBuildInvalidGitRepoError
 
@@ -367,3 +368,15 @@ def test_new_build_not_git_repo(
 ):
     with pytest.raises(RemoteBuildInvalidGitRepoError):
         remote_build_service.start_builds(tmp_path, None)
+
+
+def test_credentials_filepath(app_metadata, fake_services):
+    """Test that the credentials file path is correctly generated."""
+    credentials_filepath = services.RemoteBuildService(
+        app_metadata, fake_services
+    ).credentials_filepath
+
+    assert (
+        credentials_filepath
+        == platformdirs.user_data_path(app_metadata.name) / "launchpad-credentials"
+    )


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Adds a `credentials_filepath` property so applications can point to a different credentials file.

(CRAFT-3077)