### PR TITLE
ci: fix checkout of tag in release workflow

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -15,12 +15,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-          fetch-depth: 1
-      - name: Check git tag
+      - name: Fetch tag annotations
         run: |
-          # Print out the output of 'git describe' for debugging
+          # Note: we fetch the tags here instead of using actions/checkout's "fetch-tags"
+          # because of https://github.com/actions/checkout/issues/1467
+          git fetch --force --tags --depth 1
           git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
This is a partial revert of 0115c28629; apparently actions/checkout's "fetch-tags" property is broken and gives errors at checkout time.

Ref: https://github.com/actions/checkout/issues/1467

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
