### PR TITLE
feat: render versions in doc urls

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -103,6 +103,14 @@ class AppMetadata:
             md = metadata.metadata(self.name)
             setter("summary", md["summary"])
 
+    @property
+    def versioned_docs_url(self) -> str | None:
+        """The ``docs_url`` with the proper app version."""
+        if self.docs_url is None:
+            return None
+
+        return util.render_doc_url(self.docs_url, self.version)
+
 
 class Application:
     """Craft Application Builder.
@@ -737,7 +745,7 @@ class Application:
             greeting=f"Starting {self.app.name}, version {self.app.version}",
             log_filepath=self.log_path,
             streaming_brief=True,
-            docs_base_url=self.app.docs_url,
+            docs_base_url=self.app.versioned_docs_url,
         )
 
         craft_cli.emit.debug(f"Log verbosity level set to {emitter_mode.name}")

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -16,6 +16,7 @@
 """Utilities for craft-application."""
 
 from craft_application.util.callbacks import get_unique_callbacks
+from craft_application.util.docs import render_doc_url
 from craft_application.util.logging import setup_loggers
 from craft_application.util.paths import get_filename_from_url_path, get_managed_logpath
 from craft_application.util.platforms import (
@@ -35,6 +36,7 @@ from craft_application.util.yaml import dump_yaml, safe_yaml_load
 
 __all__ = [
     "get_unique_callbacks",
+    "render_doc_url",
     "setup_loggers",
     "get_filename_from_url_path",
     "get_managed_logpath",

--- a/craft_application/util/docs.py
+++ b/craft_application/util/docs.py
@@ -1,0 +1,40 @@
+# This file is part of craft_application.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utility functions and helpers related to documentation."""
+
+
+def render_doc_url(url: str, version: str) -> str:
+    """Render ``url`` with the correct version for readthedocs.
+
+    This function generates urls following the readthedocs standard. Given an
+    input url containing a "{version}" placeholder, this function will return
+    an url where "{version}" is replaced with:
+    - ``latest``, if ``version`` is a development value like "1.0+g115121",
+      "1.0+git0293141" or "dev,
+    - the value of ``version`` otherwise.
+
+    :param url: an url with a possible {version} placeholder.
+    :param version: the application version.
+    """
+    version_var = "{version}"
+
+    if version_var not in url:
+        return url
+
+    if version == "dev" or "+g" in version:
+        version = "latest"
+
+    return url.replace(version_var, version)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ def app_metadata(features) -> craft_application.AppMetadata:
             "A fake app for testing craft-application",
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
             features=craft_application.AppFeatures(**features),
+            docs_url="www.craft-app.com/docs/{version}",
         )
 
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -50,6 +50,7 @@ from craft_application.models import BuildInfo
 from craft_application.util import (
     get_host_architecture,  # pyright: ignore[reportGeneralTypeIssues]
 )
+from craft_cli import emit
 from craft_parts.plugins.plugins import PluginType
 from craft_providers import bases
 from overrides import override
@@ -2056,3 +2057,19 @@ def test_build_planner_errors(tmp_path, monkeypatch, fake_services):
         "- bad value2: banana (in field 'value2')"
     )
     assert str(err.value) == expected
+
+
+def test_emitter_docs_url(monkeypatch, mocker, app):
+    """Test that the emitter is initialized with the correct url."""
+
+    assert app.app.docs_url == "www.craft-app.com/docs/{version}"
+    assert app.app.version == "3.14159"
+    expected_url = "www.craft-app.com/docs/3.14159"
+
+    spied_init = mocker.spy(emit, "init")
+
+    monkeypatch.setattr(sys, "argv", ["testcraft"])
+    with pytest.raises(SystemExit):
+        app.run()
+
+    assert spied_init.mock_calls[0].kwargs["docs_base_url"] == expected_url

--- a/tests/unit/util/test_docs.py
+++ b/tests/unit/util/test_docs.py
@@ -1,0 +1,49 @@
+# This file is part of craft-application.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for documentation functions."""
+import pytest
+from craft_application.util import docs
+
+
+@pytest.mark.parametrize(
+    ("url", "version", "expected"),
+    [
+        # Cases with precise versions (must use the version)
+        ("www.doc.com/tool/en/{version}", "1.0.0", "www.doc.com/tool/en/1.0.0"),
+        ("www.doc.com/tool/{version}/a", "1.2.3", "www.doc.com/tool/1.2.3/a"),
+        # Cases with interim versions (must use "latest")
+        # craft-application style
+        (
+            "www.doc.com/tool/en/{version}",
+            "3.1.0.post1+gb99d1e8",
+            "www.doc.com/tool/en/latest",
+        ),
+        # Snapcraft style
+        (
+            "www.doc.com/tool/en/{version}",
+            "8.3.1.post5+gitfb1834ce",
+            "www.doc.com/tool/en/latest",
+        ),
+        # fallback "dev" version
+        ("www.doc.com/tool/{version}", "dev", "www.doc.com/tool/latest"),
+        # Cases with no {version} variable (must be a passthrough)
+        ("www.doc.com/tool/en/latest", "1.0.0", "www.doc.com/tool/en/latest"),
+        ("www.doc.com/tool/en/stable", "1.0.0", "www.doc.com/tool/en/stable"),
+    ],
+)
+def test_render_doc_url(url, version, expected):
+    obtained = docs.render_doc_url(url, version)
+    assert obtained == expected


### PR DESCRIPTION
This commit adds two new features:

- An util.render_doc_url() which creates a versioned url given an url with a `{version}` placeholder and a version value;
- Support for passing a rendered base url to the Emitter's init(), so that helper documentation links in error messages can contain the correct version (instead of the default readthedocs "stable" or "latest").

Fixes #368

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
