### PR TITLE
fix(remotebuild): push git tags to launchpad

### DIFF
--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -297,7 +297,7 @@ class RemoteBuildService(base.AppService):
         )
 
         local_repository = GitRepo(work_tree.repo_dir)
-        local_repository.push_url(push_url.geturl(), "main")
+        local_repository.push_url(push_url.geturl(), "main", push_tags=True)
 
         return work_tree, lp_repository
 

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -146,6 +146,7 @@ def test_ensure_repository_creation(
     mock_push_url.assert_called_once_with(
         "https://craft_test_user:super_secret_token@git.launchpad.net/~user/+git/my_repo",
         "main",
+        push_tags=True,
     )
     expiry = wrapped_repository.get_access_token.call_args.kwargs["expiry"]
 
@@ -184,6 +185,7 @@ def test_ensure_repository_already_exists(
     mock_push_url.assert_called_once_with(
         "https://craft_test_user:super_secret_token@git.launchpad.net/~user/+git/my_repo",
         "main",
+        push_tags=True,
     )
     expiry = wrapped_repository.get_access_token.call_args.kwargs["expiry"]
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Craft Application should push tags to Launchpad so that applications can derive versions from git tags.

source: 
- https://matrix.to/#/!GGqzbFAUQprdPgYYCM:ubuntu.com/$EpLRd25TPvDcrTxIVTcvHQsT6XJ-_BVrYMX0-Y2p980?via=ubuntu.com&via=matrix.org&via=kde.org
- https://github.com/canonical/pebble/pull/450