### PR TITLE
chore: drop mantic from provider test

### DIFF
--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -27,9 +27,11 @@ from craft_providers import bases
 @pytest.mark.parametrize(
     "base_name",
     [
-        pytest.param(("ubuntu", "23.10"), id="ubuntu_latest"),
-        pytest.param(("ubuntu", "22.04"), id="ubuntu_lts"),
-        pytest.param(("ubuntu", "20.04"), id="ubuntu_old_lts"),
+        # Skipping Oracular test for now; see
+        # https://github.com/canonical/craft-providers/issues/593
+        pytest.param(("ubuntu", "24.10"), id="ubuntu_latest", marks=pytest.mark.skip),
+        pytest.param(("ubuntu", "24.04"), id="ubuntu_lts"),
+        pytest.param(("ubuntu", "22.04"), id="ubuntu_old_lts"),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Mantic is no longer supported in craft-providers

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
