### PR TITLE
chore(lint): set user-provided pyright venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,8 +154,6 @@ exclude = ["craft_application/_version.py"]
 strict = ["craft_application"]
 pythonVersion = "3.10"
 pythonPlatform = "Linux"
-venvPath = ".tox"
-venv = "typing"
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
This removes using the tox-provided pyright venv

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
