### PR TITLE
fix(tests): update mozilla keyring

### DIFF
--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -165,6 +165,6 @@ def test_package_repositories_in_overlay(
     assert overlay_apt.is_dir()
 
     # Checking that the files are present should be enough
-    assert (overlay_apt / "keyrings/craft-CE49EC21.gpg").is_file()
+    assert (overlay_apt / "keyrings/craft-9BE21867.gpg").is_file()
     assert (overlay_apt / "sources.list.d/craft-ppa-mozillateam_ppa.sources").is_file()
     assert (overlay_apt / "preferences.d/craft-archives").is_file()


### PR DESCRIPTION
The Mozilla team PPA updated its signing key recently. See: https://launchpad.net/~mozillateam/+archive/ubuntu/ppa See also: https://keyserver.ubuntu.com/pks/lookup?fingerprint=on&op=index&search=0x738BEB9321D1AAEC13EA9391AEBDF4819BE21867

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
