### PR TITLE
feat: add SpdxLicenseStr and ProprietaryLicenseStr

### DIFF
--- a/craft_application/models/constraints.py
+++ b/craft_application/models/constraints.py
@@ -1,4 +1,4 @@
-# This file is part of craft_application.
+# This file is part of craft_application.modcon
 #
 # Copyright 2023 Canonical Ltd.
 #
@@ -212,7 +212,7 @@ def _parse_spdx_license(value: str) -> license_expression.LicenseExpression:
 def _validate_spdx_license(value: str) -> str:
     """Ensure the provided licence is a valid SPDX licence."""
     try:
-        lic = _parse_spdx_license(value)
+        _ = _parse_spdx_license(value)
     except (license_expression.ExpressionError, ValueError):
         raise PydanticCustomError(
             "not_spdx_license",
@@ -220,7 +220,7 @@ def _validate_spdx_license(value: str) -> str:
             {"wrong_license": value},
         ) from None
     else:
-        return str(lic.simplify())
+        return value
 
 
 SpdxLicenseStr = Annotated[

--- a/craft_application/models/constraints.py
+++ b/craft_application/models/constraints.py
@@ -1,4 +1,4 @@
-# This file is part of craft_application.modcon
+# This file is part of craft_application.
 #
 # Copyright 2023 Canonical Ltd.
 #

--- a/craft_application/models/constraints.py
+++ b/craft_application/models/constraints.py
@@ -227,7 +227,7 @@ SpdxLicenseStr = Annotated[
     str,
     pydantic.AfterValidator(_validate_spdx_license),
     pydantic.Field(
-        title="Licence",
+        title="License",
         description="SPDX license string.",
         examples=[
             "GPL-3.0",

--- a/craft_application/models/constraints.py
+++ b/craft_application/models/constraints.py
@@ -22,6 +22,7 @@ from typing import Annotated, Literal, TypeVar
 
 import license_expression  # type: ignore[import]
 import pydantic
+from pydantic_core import PydanticCustomError
 
 T = TypeVar("T")
 Tv = TypeVar("Tv")
@@ -213,8 +214,10 @@ def _validate_spdx_license(value: str) -> str:
     try:
         lic = _parse_spdx_license(value)
     except (license_expression.ExpressionError, ValueError):
-        raise ValueError(
-            f"License '{value}' not valid. It must be in SPDX format.",
+        raise PydanticCustomError(
+            "not_spdx_license",
+            "License '{wrong_license}' not valid. It must be in SPDX format.",
+            {"wrong_license": value},
         ) from None
     else:
         return str(lic.simplify())
@@ -236,3 +239,5 @@ SpdxLicenseStr = Annotated[
 ]
 
 ProprietaryLicenseStr = Literal["proprietary"]
+
+LicenseStr = SpdxLicenseStr | ProprietaryLicenseStr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,11 @@ dependencies = [
     "craft-cli>=2.6.0",
     "craft-grammar@git+https://github.com/canonical/craft-grammar@feature/pydantic-2",
     "craft-parts@git+https://github.com/canonical/craft-parts@feature/2.0",
-    "craft-providers@git+https://github.com/canonical/craft-providers@feature/2.0-git-modules",
+    "craft-providers@git+https://github.com/canonical/craft-providers@feature/2.0",
     "snap-helpers>=0.4.2",
     "platformdirs>=3.10",
     "pydantic~=2.0",
+    "license-expression>=30.0.0",
     # "pydantic-yaml<1.0",
     # Pygit2 and libgit2 need to match versions.
     # Further info: https://www.pygit2.org/install.html#version-numbers

--- a/tests/unit/models/test_constraints.py
+++ b/tests/unit/models/test_constraints.py
@@ -17,6 +17,7 @@
 
 import re
 from string import ascii_letters, ascii_lowercase, digits
+from typing import cast
 
 import pydantic.errors
 import pytest
@@ -216,23 +217,28 @@ def test_invalid_version_str(version):
 
 # endregion
 # region SpdxLicenseStr tests
+
+_VALID_SPDX_LICENCES = [
+    "MIT",
+    "GPL-3.0",
+    "GPL-3.0+",
+    "GPL-3.0+ and MIT",
+    "LGPL-3.0+ or BSD-3-Clause",
+]
+
+
+@pytest.fixture(params=_VALID_SPDX_LICENCES)
+def valid_spdx_license_str(request: pytest.FixtureRequest) -> str:
+    return cast(str, request.param)
+
+
 class _SpdxLicenseStrModel(pydantic.BaseModel):
     license: SpdxLicenseStr
 
 
-@pytest.mark.parametrize(
-    ("license_str", "license_value"),
-    [
-        ("MIT", "MIT"),
-        ("GPL-3.0", "GPL-3.0-only"),
-        ("GPL-3.0+", "GPL-3.0-or-later"),
-        ("GPL-3.0+ and MIT", "GPL-3.0-or-later AND MIT"),
-        ("LGPL-3.0+ or BSD-3-Clause", "BSD-3-Clause OR LGPL-3.0-or-later"),
-    ],
-)
-def test_spdx_license_str_valid(license_str, license_value):
-    model = _SpdxLicenseStrModel(license=license_str)
-    assert model.license == license_value
+def test_spdx_license_str_valid(valid_spdx_license_str: str) -> None:
+    model = _SpdxLicenseStrModel(license=valid_spdx_license_str)
+    assert model.license == valid_spdx_license_str
 
 
 @pytest.mark.parametrize("license_str", ["Copyright 1990", "Proprietary"])
@@ -280,19 +286,12 @@ class _LicenseStrModel(pydantic.BaseModel):
 
 
 @pytest.mark.parametrize(
-    ("license_str", "license_value"),
-    [
-        ("MIT", "MIT"),
-        ("GPL-3.0", "GPL-3.0-only"),
-        ("GPL-3.0+", "GPL-3.0-or-later"),
-        ("GPL-3.0+ and MIT", "GPL-3.0-or-later AND MIT"),
-        ("LGPL-3.0+ or BSD-3-Clause", "BSD-3-Clause OR LGPL-3.0-or-later"),
-        ("proprietary", "proprietary"),
-    ],
+    "license_str",
+    [*_VALID_SPDX_LICENCES, "proprietary"],
 )
-def test_license_str_valid(license_str, license_value):
+def test_license_str_valid(license_str):
     model = _LicenseStrModel(license=license_str)
-    assert model.license == license_value
+    assert model.license == license_str
 
 
 @pytest.mark.parametrize("license_str", ["Copyright 1990", "Proprietary"])


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

Instead of having distributed license check in apps, we should provide a valid way of generic license check.
Application that utilizes `pydantic` v2 may opt-in for this validation in it's code
