### PR TITLE
feat: add a configuration service

### DIFF
--- a/craft_application/__init__.py
+++ b/craft_application/__init__.py
@@ -25,6 +25,7 @@ from craft_application.services import (
     ProviderService,
     ServiceFactory,
 )
+from craft_application._config import ConfigModel
 
 try:
     from ._version import __version__
@@ -42,6 +43,7 @@ __all__ = [
     "AppFeatures",
     "AppMetadata",
     "AppService",
+    "ConfigModel",
     "models",
     "ProjectService",
     "LifecycleService",

--- a/craft_application/_config.py
+++ b/craft_application/_config.py
@@ -1,0 +1,37 @@
+# This file is part of craft-application.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Configuration model for craft applications."""
+from __future__ import annotations
+
+import pydantic
+import craft_cli
+
+
+class ConfigModel(pydantic.BaseModel):
+    """A configuration model for a craft application."""
+
+    verbosity_level: craft_cli.EmitterMode = craft_cli.EmitterMode.BRIEF
+    debug: bool = False
+    build_environment: str | None = None
+    secrets: str
+
+    platform: str | None = None
+    build_for: str | None = None
+
+    parallel_build_count: int
+    max_parallel_build_count: int
+    lxd_remote: str = "local"
+    launchpad_instance: str = "production"

--- a/craft_application/_config.py
+++ b/craft_application/_config.py
@@ -16,8 +16,8 @@
 """Configuration model for craft applications."""
 from __future__ import annotations
 
-import pydantic
 import craft_cli
+import pydantic
 
 
 class ConfigModel(pydantic.BaseModel):

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -37,7 +37,7 @@ from craft_parts.plugins.plugins import PluginType
 from platformdirs import user_cache_path
 
 from craft_application import commands, errors, grammar, models, secrets, util
-from craft_application._config import ConfigModel
+from craft_application import _config
 from craft_application.errors import PathInvalidError
 from craft_application.models import BuildInfo, GrammarAwareProject
 
@@ -81,7 +81,7 @@ class AppMetadata:
     features: AppFeatures = AppFeatures()
     project_variables: list[str] = field(default_factory=lambda: ["version"])
     mandatory_adoptable_fields: list[str] = field(default_factory=lambda: ["version"])
-    config_model: type[ConfigModel] = ConfigModel
+    ConfigModel: type[_config.ConfigModel] = _config.ConfigModel
 
     ProjectClass: type[models.Project] = models.Project
     BuildPlannerClass: type[models.BuildPlanner] = models.BuildPlanner

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -494,7 +494,9 @@ class Application:
                     resolution="Ensure the path entered is correct.",
                 )
 
-    def get_arg_or_config(self, parsed_args: argparse.Namespace, item: str) -> Any:
+    def get_arg_or_config(
+        self, parsed_args: argparse.Namespace, item: str
+    ) -> Any:  # noqa: ANN401
         """Get a configuration option that could be overridden by a command argument.
 
         :param parsed_args: The argparse Namespace to check.

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -503,9 +503,7 @@ class Application:
         :param item: the name of the namespace or config item.
         :returns: the requested value.
         """
-        if hasattr(parsed_args, item):
-            return getattr(parsed_args, item)
-        return self.services.config.get(item)
+        return getattr(parsed_args, item, self.services.config.get(item))
 
     def run(  # noqa: PLR0912,PLR0915  (too many branches, too many statements)
         self,

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -36,6 +36,7 @@ from craft_parts.plugins.plugins import PluginType
 from platformdirs import user_cache_path
 
 from craft_application import commands, errors, grammar, models, secrets, util
+from craft_application._config import ConfigModel
 from craft_application.errors import PathInvalidError
 from craft_application.models import BuildInfo, GrammarAwareProject
 
@@ -79,6 +80,7 @@ class AppMetadata:
     features: AppFeatures = AppFeatures()
     project_variables: list[str] = field(default_factory=lambda: ["version"])
     mandatory_adoptable_fields: list[str] = field(default_factory=lambda: ["version"])
+    config_model: type[ConfigModel] = ConfigModel
 
     ProjectClass: type[models.Project] = models.Project
     BuildPlannerClass: type[models.BuildPlanner] = models.BuildPlanner
@@ -429,7 +431,7 @@ class Application:
                     f"Internal error while loading {self.app.name}: {err!r}"
                 )
             )
-            if os.getenv("CRAFT_DEBUG") == "1":
+            if self.services.config.get("debug"):
                 raise
             sys.exit(os.EX_SOFTWARE)
 
@@ -572,7 +574,7 @@ class Application:
                 craft_cli.CraftError(f"{self.app.name} internal error: {err!r}"),
                 cause=err,
             )
-            if os.getenv("CRAFT_DEBUG") == "1":
+            if self.services.config.get("debug"):
                 raise
             return_code = os.EX_SOFTWARE
         else:

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -36,8 +36,7 @@ import craft_providers
 from craft_parts.plugins.plugins import PluginType
 from platformdirs import user_cache_path
 
-from craft_application import commands, errors, grammar, models, secrets, util
-from craft_application import _config
+from craft_application import _config, commands, errors, grammar, models, secrets, util
 from craft_application.errors import PathInvalidError
 from craft_application.models import BuildInfo, GrammarAwareProject
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -147,14 +147,14 @@ class LifecycleCommand(_BaseLifecycleCommand):
             "--platform",
             type=str,
             metavar="name",
-            default=os.getenv("CRAFT_PLATFORM"),
+            default=self._services.config.get("platform"),
             help="Set platform to build for",
         )
         group.add_argument(
             "--build-for",
             type=str,
             metavar="arch",
-            default=os.getenv("CRAFT_BUILD_FOR"),
+            default=self._services.config.get("build_for"),
             help="Set architecture to build for",
         )
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -147,14 +147,12 @@ class LifecycleCommand(_BaseLifecycleCommand):
             "--platform",
             type=str,
             metavar="name",
-            default=self._services.config.get("platform"),
             help="Set platform to build for",
         )
         group.add_argument(
             "--build-for",
             type=str,
             metavar="arch",
-            default=self._services.config.get("build_for"),
             help="Set architecture to build for",
         )
 

--- a/craft_application/launchpad/__init__.py
+++ b/craft_application/launchpad/__init__.py
@@ -22,6 +22,7 @@ from . import errors
 from .errors import LaunchpadError
 from .launchpad import Launchpad
 from .models import LaunchpadObject, RecipeType, Recipe, SnapRecipe, CharmRecipe
+from .util import Architecture
 
 __all__ = [
     "errors",
@@ -32,4 +33,5 @@ __all__ = [
     "Recipe",
     "SnapRecipe",
     "CharmRecipe",
+    "Architecture",
 ]

--- a/craft_application/services/__init__.py
+++ b/craft_application/services/__init__.py
@@ -16,6 +16,7 @@
 """Service classes for the business logic of various categories of command."""
 
 from craft_application.services.base import AppService, ProjectService
+from craft_application.services.config import ConfigService
 from craft_application.services.lifecycle import LifecycleService
 from craft_application.services.package import PackageService
 from craft_application.services.provider import ProviderService
@@ -26,6 +27,7 @@ from craft_application.services.service_factory import ServiceFactory
 __all__ = [
     "AppService",
     "ProjectService",
+    "ConfigService",
     "LifecycleService",
     "PackageService",
     "ProviderService",

--- a/craft_application/services/config.py
+++ b/craft_application/services/config.py
@@ -1,0 +1,184 @@
+#  This file is part of craft-application.
+#
+#  Copyright 2024 Canonical Ltd.
+#
+#  This program is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License version 3, as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+#  SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Configuration service."""
+from __future__ import annotations
+
+import abc
+import contextlib
+import enum
+import os
+from typing import TYPE_CHECKING, Any, cast, Iterable, TypeVar, final
+from craft_cli import emit
+import pydantic
+import pydantic_core
+import snaphelpers
+from typing_extensions import override
+
+from craft_application import application, util
+from craft_application.services import base
+
+if TYPE_CHECKING:
+    from craft_application.services.service_factory import ServiceFactory
+
+
+T = TypeVar("T")
+
+
+class ConfigHandler(abc.ABC):
+    """An abstract class for configuration handlers."""
+
+    def __init__(self, app: application.AppMetadata) -> None:
+        self._app = app
+
+    @abc.abstractmethod
+    def get_raw(self, item: str) -> Any:
+        """Get the string value for a configuration item.
+
+        :param item: the name of the configuration item.
+        :returns: The raw value of the item.
+        :raises: KeyError if the item cannot be found.
+        """
+
+
+@final
+class AppEnvironmentHandler(ConfigHandler):
+    """Configuration handler to get values from app-specific environment variables."""
+
+    def __init__(self, app: application.AppMetadata) -> None:
+        super().__init__(app)
+        self._environ_prefix = f"{app.name.upper()}"
+
+    @override
+    def get_raw(self, item: str) -> str:
+        return os.environ[f"{self._environ_prefix}_{item.upper()}"]
+
+
+@final
+class CraftEnvironmentHandler(ConfigHandler):
+    """Configuration handler to get values from CRAFT environment variables."""
+
+    @override
+    def get_raw(self, item: str) -> str:
+        return os.environ[f"CRAFT_{item.upper()}"]
+
+
+class SnapConfigHandler(ConfigHandler):
+    """Configuration handler that gets values from snap."""
+
+    def __init__(self, app: application.AppMetadata) -> None:
+        super().__init__(app)
+        try:
+            self._snap = snaphelpers.SnapConfig()
+        except KeyError:
+            raise EnvironmentError("Not running as a snap.")
+
+    @override
+    def get_raw(self, item: str) -> Any:
+        try:
+            return self._snap.get(item)
+        except snaphelpers.UnknownConfigKey as exc:
+            raise KeyError(f"unknown snap config item: {item!r}") from exc
+
+
+
+@final
+class DefaultConfigHandler(ConfigHandler):
+    """Configuration handler for getting default values."""
+
+    def __init__(self, app: application.AppMetadata) -> None:
+        super().__init__(app)
+        self._config_model = app.config_model
+        self._cache: dict[str, str] = {}
+
+    @override
+    def get_raw(self, item: str) -> Any:
+        if item in self._cache:
+            return self._cache[item]
+
+        field = self._config_model.model_fields[item]
+        if field.default is not pydantic_core.PydanticUndefined:
+            self._cache[item] = field.default
+            return field.default
+        if field.default_factory is not None:
+            default = field.default_factory()
+            self._cache[item] = default
+            return default
+
+        raise KeyError(f"config item {item!r} has no default value.")
+
+class ConfigService(base.AppService):
+    """Application-wide configuration access."""
+
+    _handlers: list[ConfigHandler]
+
+    def __init__(
+        self,
+        app: application.AppMetadata,
+        services: ServiceFactory,
+        *,
+        extra_handlers: Iterable[type[ConfigHandler]] = ()
+    ) -> None:
+        super().__init__(app, services)
+        self._extra_handlers = extra_handlers
+        self._default_handler = DefaultConfigHandler(self._app)
+
+    @override
+    def setup(self) -> None:
+        super().setup()
+        self._handlers = [
+            AppEnvironmentHandler(self._app),
+            CraftEnvironmentHandler(self._app),
+            *(handler(self._app) for handler in self._extra_handlers),
+        ]
+        try:
+            snap_handler = SnapConfigHandler(self._app)
+        except EnvironmentError:
+            emit.debug("App is not running as a snap - snap config handler not created.")
+        else:
+            self._handlers.append(snap_handler)
+
+    def get(self, item: str) -> Any:
+        """Get the given configuration item."""
+        if item not in self._app.config_model.model_fields:
+            raise KeyError(r"unknown config item: {item!r}")
+        field_info = self._app.config_model.model_fields[item]
+
+        for handler in self._handlers:
+            try:
+                value = handler.get_raw(item)
+            except KeyError:
+                continue
+            else:
+                break
+        else:
+            return self._default_handler.get_raw(item)
+
+        return self._convert_type(value, field_info.annotation)  # type: ignore[return-value]
+
+    def _convert_type(self, value: str, field_type: type[T]) -> T:
+        """Convert the value to the appropriate type."""
+        if isinstance(field_type, type):
+            if issubclass(field_type, str):
+                return field_type(value)
+            if issubclass(field_type, bool):
+                return cast(T, util.strtobool(value))
+            if issubclass(field_type, enum.Enum):
+                with contextlib.suppress(KeyError):
+                    return field_type[value]
+                with contextlib.suppress(KeyError):
+                    return field_type[value.upper()]
+        field_adapter = pydantic.TypeAdapter(field_type)
+        return field_adapter.validate_strings(value)

--- a/craft_application/services/config.py
+++ b/craft_application/services/config.py
@@ -98,8 +98,9 @@ class SnapConfigHandler(ConfigHandler):
 
     @override
     def get_raw(self, item: str) -> Any:
+        snap_item = item.replace("_", "-")
         try:
-            return self._snap.get(item)
+            return self._snap.get(snap_item)
         except snaphelpers.UnknownConfigKey as exc:
             raise KeyError(f"unknown snap config item: {item!r}") from exc
 
@@ -110,7 +111,7 @@ class DefaultConfigHandler(ConfigHandler):
 
     def __init__(self, app: application.AppMetadata) -> None:
         super().__init__(app)
-        self._config_model = app.config_model
+        self._config_model = app.ConfigModel
         self._cache: dict[str, str] = {}
 
     @override
@@ -165,9 +166,9 @@ class ConfigService(base.AppService):
 
     def get(self, item: str) -> Any:  # noqa: ANN401
         """Get the given configuration item."""
-        if item not in self._app.config_model.model_fields:
+        if item not in self._app.ConfigModel.model_fields:
             raise KeyError(r"unknown config item: {item!r}")
-        field_info = self._app.config_model.model_fields[item]
+        field_info = self._app.ConfigModel.model_fields[item]
 
         for handler in self._handlers:
             try:

--- a/craft_application/services/config.py
+++ b/craft_application/services/config.py
@@ -170,19 +170,19 @@ class ConfigService(base.AppService):
         else:
             return self._default_handler.get_raw(item)
 
-        return self._convert_type(value, field_info.annotation)  # type: ignore[return-value]
+        return self._convert_type(value, field_info.annotation)  # type: ignore[arg-type,return-value]
 
     def _convert_type(self, value: str, field_type: type[T]) -> T:
         """Convert the value to the appropriate type."""
         if isinstance(field_type, type):
             if issubclass(field_type, str):
-                return field_type(value)
+                return cast(T, field_type(value))
             if issubclass(field_type, bool):
                 return cast(T, util.strtobool(value))
             if issubclass(field_type, enum.Enum):
                 with contextlib.suppress(KeyError):
-                    return field_type[value]
+                    return cast(T, field_type[value])
                 with contextlib.suppress(KeyError):
-                    return field_type[value.upper()]
+                    return cast(T, field_type[value.upper()])
         field_adapter = pydantic.TypeAdapter(field_type)
         return field_adapter.validate_strings(value)

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -211,7 +211,7 @@ class ProviderService(base.ProjectService):
             emit.debug(f"Using provider {provider!r} from system configuration.")
             chosen_provider = provider
 
-        # (3) use provider specified in provider
+        # (3) use provider specified in snap configuration
         elif snap_provider := self._get_provider_from_snap_config():
             emit.debug(f"Using provider {snap_provider!r} from snap config.")
             chosen_provider = snap_provider

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -199,12 +199,12 @@ class ProviderService(base.ProjectService):
             emit.debug(f"Using provider {name!r} passed as an argument.")
             chosen_provider: str = name
 
-        # (2) get the provider from the environment (CRAFT_BUILD_ENVIRONMENT),
-        elif env_provider := os.getenv("CRAFT_BUILD_ENVIRONMENT"):
-            emit.debug(f"Using provider {env_provider!r} from environment.")
-            chosen_provider = env_provider
+        # (2) get the provider from build_environment
+        elif provider := self._services.config.get("build_environment"):
+            emit.debug(f"Using provider {provider!r} from system configuration.")
+            chosen_provider = provider
 
-        # (3) use provider specified with snap configuration,
+        # (3) use provider specified in provider
         elif snap_provider := self._get_provider_from_snap_config():
             emit.debug(f"Using provider {snap_provider!r} from snap config.")
             chosen_provider = snap_provider
@@ -278,7 +278,7 @@ class ProviderService(base.ProjectService):
 
     def _get_lxd_provider(self) -> LXDProvider:
         """Get the LXD provider for this manager."""
-        lxd_remote = os.getenv("CRAFT_LXD_REMOTE", "local")
+        lxd_remote = self._services.config.get("lxd_remote")
         return LXDProvider(lxd_project=self._app.name, lxd_remote=lxd_remote)
 
     def _get_multipass_provider(self) -> MultipassProvider:

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -47,10 +47,6 @@ if TYPE_CHECKING:  # pragma: no cover
 DEFAULT_POLL_INTERVAL = 30
 
 
-def _get_launchpad_instance(default: str = "production") -> str:
-    return os.getenv("CRAFT_LAUNCHPAD_INSTANCE", default)
-
-
 class RemoteBuildService(base.AppService):
     """Abstract service for performing remote builds."""
 
@@ -254,7 +250,7 @@ class RemoteBuildService(base.AppService):
         with craft_cli.emit.pause():
             return launchpad.Launchpad.login(
                 f"{self._app.name}/{self._app.version}",
-                root=_get_launchpad_instance(),
+                root=self._services.config.get("launchpad_instance"),
                 credentials_file=credentials_filepath,
             )
 

--- a/craft_application/services/service_factory.py
+++ b/craft_application/services/service_factory.py
@@ -41,6 +41,7 @@ class ServiceFactory:
     ProviderClass: type[services.ProviderService] = services.ProviderService
     RemoteBuildClass: type[services.RemoteBuildService] = services.RemoteBuildService
     RequestClass: type[services.RequestService] = services.RequestService
+    ConfigClass: type[services.ConfigService] = services.ConfigService
 
     project: models.Project | None = None
 
@@ -52,6 +53,7 @@ class ServiceFactory:
         provider: services.ProviderService = None  # type: ignore[assignment]
         remote_build: services.RemoteBuildService = None  # type: ignore[assignment]
         request: services.RequestService = None  # type: ignore[assignment]
+        config: services.ConfigService = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         self._service_kwargs: dict[str, dict[str, Any]] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pytest-cov==5.0.0",
     "pytest-mock==3.14.0",
     "pytest-rerunfailures==14.0",
+    "pytest-subprocess~=1.5.2",
     "pytest-time>=0.3.1",
     # Pin requests because of https://github.com/msabramo/requests-unixsocket/issues/73
     "requests<2.32.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def default_app_metadata(fake_config_model) -> craft_application.AppMetadata:
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_metadata(features, fake_config_model) -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:
         m.setattr(metadata, "version", lambda _: "3.14159")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ import shutil
 from importlib import metadata
 from typing import TYPE_CHECKING, Any
 
+import pydantic
+
 import craft_application
 import craft_parts
 import pytest
@@ -58,19 +60,36 @@ def features(request) -> dict[str, bool]:
     return features
 
 
+class FakeConfigModel(craft_application.ConfigModel):
+
+    my_str: str
+    my_int: int
+    my_bool: bool
+    my_default_str: str = "default"
+    my_default_int: int = -1
+    my_default_bool: bool = True
+    my_default_factory: dict[str, str] = pydantic.Field(default_factory=lambda: {"dict": "yes"})
+
+
 @pytest.fixture(scope="session")
-def default_app_metadata() -> craft_application.AppMetadata:
+def fake_config_model() -> type[FakeConfigModel]:
+    return FakeConfigModel
+
+
+@pytest.fixture(scope="session")
+def default_app_metadata(fake_config_model) -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
             "testcraft",
             "A fake app for testing craft-application",
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
+            config_model=fake_config_model
         )
 
 
 @pytest.fixture()
-def app_metadata(features) -> craft_application.AppMetadata:
+def app_metadata(features, fake_config_model) -> craft_application.AppMetadata:
     with pytest.MonkeyPatch.context() as m:
         m.setattr(metadata, "version", lambda _: "3.14159")
         return craft_application.AppMetadata(
@@ -79,6 +98,7 @@ def app_metadata(features) -> craft_application.AppMetadata:
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
             features=craft_application.AppFeatures(**features),
             docs_url="www.craft-app.com/docs/{version}",
+            config_model=fake_config_model
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,10 +22,9 @@ import shutil
 from importlib import metadata
 from typing import TYPE_CHECKING, Any
 
-import pydantic
-
 import craft_application
 import craft_parts
+import pydantic
 import pytest
 from craft_application import application, models, services, util
 from craft_cli import EmitterMode, emit
@@ -68,7 +67,9 @@ class FakeConfigModel(craft_application.ConfigModel):
     my_default_str: str = "default"
     my_default_int: int = -1
     my_default_bool: bool = True
-    my_default_factory: dict[str, str] = pydantic.Field(default_factory=lambda: {"dict": "yes"})
+    my_default_factory: dict[str, str] = pydantic.Field(
+        default_factory=lambda: {"dict": "yes"}
+    )
 
 
 @pytest.fixture(scope="session")
@@ -84,7 +85,7 @@ def default_app_metadata(fake_config_model) -> craft_application.AppMetadata:
             "testcraft",
             "A fake app for testing craft-application",
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
-            config_model=fake_config_model
+            config_model=fake_config_model,
         )
 
 
@@ -98,7 +99,7 @@ def app_metadata(features, fake_config_model) -> craft_application.AppMetadata:
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
             features=craft_application.AppFeatures(**features),
             docs_url="www.craft-app.com/docs/{version}",
-            config_model=fake_config_model
+            config_model=fake_config_model,
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ import craft_application
 import craft_parts
 import pydantic
 import pytest
-from craft_application import application, models, services, util
+from craft_application import application, launchpad, models, services, util
 from craft_cli import EmitterMode, emit
 from craft_providers import bases
 
@@ -70,6 +70,7 @@ class FakeConfigModel(craft_application.ConfigModel):
     my_default_factory: dict[str, str] = pydantic.Field(
         default_factory=lambda: {"dict": "yes"}
     )
+    my_arch: launchpad.Architecture
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def default_app_metadata(fake_config_model) -> craft_application.AppMetadata:
             "testcraft",
             "A fake app for testing craft-application",
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
-            config_model=fake_config_model,
+            ConfigModel=fake_config_model,
         )
 
 
@@ -99,7 +99,7 @@ def app_metadata(features, fake_config_model) -> craft_application.AppMetadata:
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
             features=craft_application.AppFeatures(**features),
             docs_url="www.craft-app.com/docs/{version}",
-            config_model=fake_config_model,
+            ConfigModel=fake_config_model,
         )
 
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -429,7 +429,7 @@ def test_lifecycle_error_logging(monkeypatch, tmp_path, create_app):
     assert parts_message in log_contents
 
 
-@pytest.mark.usefixtures("pretend_jammy")
+@pytest.mark.usefixtures("pretend_jammy", "emitter")
 def test_runtime_error_logging(monkeypatch, tmp_path, create_app, mocker):
     monkeypatch.chdir(tmp_path)
     shutil.copytree(INVALID_PROJECTS_DIR / "build-error", tmp_path, dirs_exist_ok=True)

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -197,6 +197,7 @@ def test_version(capsys, monkeypatch, app):
     assert captured.out == "testcraft 3.14159\n"
 
 
+@pytest.mark.usefixtures("emitter")
 def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):
     """Run a command without having a project instance shall not fail."""
     monkeypatch.setattr("sys.argv", ["testcraft", "nothing"])

--- a/tests/unit/services/test_config.py
+++ b/tests/unit/services/test_config.py
@@ -1,0 +1,204 @@
+# This file is part of craft-application.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the configuration service."""
+
+import itertools
+import json
+import string
+import subprocess
+from typing import Iterator
+
+from hypothesis import given, strategies
+import craft_cli
+import pytest
+import pytest_subprocess
+
+from craft_application import ConfigModel
+from craft_application.services import config
+
+
+CRAFT_APPLICATION_TEST_ENTRY_VALUES = [
+    *(
+        ("verbosity_level", mode.name.lower(), mode)
+        for mode in craft_cli.messages.EmitterMode
+    ),
+    *(
+        ("verbosity_level", mode.name, mode)
+        for mode in craft_cli.messages.EmitterMode
+    ),
+    ("debug", "true", True),
+    ("debug", "false", False),
+    ("build_environment", "host", "host"),
+    ("secrets", "Cara likes Butterscotch.", "Cara likes Butterscotch."),
+    ("platform", "laptop", "laptop"),
+    ("platform", "mainframe", "mainframe"),
+    ("build_for", "riscv64", "riscv64"),
+    ("build_for", "s390x", "s390x"),
+    *(("parallel_build_count", str(i), i) for i in range(10)),
+    *(("max_parallel_build_count", str(i), i) for i in range(10)),
+]
+APP_SPECIFIC_TEST_ENTRY_VALUES = [
+    ("my_str", "some string", "some string"),
+    ("my_int", "1", 1),
+    ("my_int", "2", 2),
+    ("my_bool", "true", True),
+    ("my_bool", "false", False),
+    ("my_default_str", "something", "something"),
+    ("my_default_int", "4294967296", 2**32),
+    ("my_bool", "1", True),
+]
+TEST_ENTRY_VALUES = CRAFT_APPLICATION_TEST_ENTRY_VALUES + APP_SPECIFIC_TEST_ENTRY_VALUES
+
+
+@pytest.fixture(scope="module")
+def app_environment_handler(default_app_metadata) -> config.AppEnvironmentHandler:
+    return config.AppEnvironmentHandler(default_app_metadata)
+
+
+@pytest.fixture(scope="module")
+def craft_environment_handler(default_app_metadata) -> config.CraftEnvironmentHandler:
+    return config.CraftEnvironmentHandler(default_app_metadata)
+
+
+@pytest.fixture(scope="module")
+def snap_config_handler(default_app_metadata) -> Iterator[config.SnapConfigHandler]:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("SNAP", "/snap/testcraft/x1")
+        monkeypatch.setenv("SNAP_COMMON", "/")
+        monkeypatch.setenv("SNAP_DATA", "/")
+        monkeypatch.setenv("SNAP_REAL_HOME", "/")
+        monkeypatch.setenv("SNAP_USER_COMMON", "/")
+        monkeypatch.setenv("SNAP_USER_DATA", "/")
+        monkeypatch.setenv("SNAP_INSTANCE_NAME", "testcraft")
+        monkeypatch.setenv("SNAP_INSTANCE_KEY", "")
+        yield config.SnapConfigHandler(default_app_metadata)
+
+
+@pytest.fixture(scope="module")
+def default_config_handler(default_app_metadata) -> config.DefaultConfigHandler:
+    return config.DefaultConfigHandler(default_app_metadata)
+
+
+@given(
+    item=strategies.text(alphabet=string.ascii_letters + "_", min_size=1),
+    content=strategies.text(
+        alphabet=strategies.characters(categories=["L", "M", "N", "P", "S", "Z"])
+    ),
+)
+def test_app_environment_handler(app_environment_handler, item: str, content: str):
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv(f"TESTCRAFT_{item.upper()}", content)
+
+        assert app_environment_handler.get_raw(item) == content
+
+
+@given(
+    item=strategies.text(alphabet=string.ascii_letters + "_", min_size=1),
+    content=strategies.text(
+        alphabet=strategies.characters(categories=["L", "M", "N", "P", "S", "Z"])
+    ),
+)
+def test_craft_environment_handler(craft_environment_handler, item: str, content: str):
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv(f"CRAFT_{item.upper()}", content)
+
+        assert craft_environment_handler.get_raw(item) == content
+
+
+@given(
+    item=strategies.text(alphabet=string.ascii_letters + "_", min_size=1),
+    content=strategies.text(
+        alphabet=strategies.characters(categories=["L", "M", "N", "P", "S", "Z"])
+    ),
+)
+def test_snap_config_handler(snap_config_handler, item: str, content: str):
+    with pytest_subprocess.FakeProcess.context() as fp, pytest.MonkeyPatch.context() as mp:
+        mp.setattr("snaphelpers._ctl.Popen", subprocess.Popen)
+        fp.register(
+            ["/usr/bin/snapctl", "get", "-d", item],
+            stdout=json.dumps({item: content})
+        )
+        assert snap_config_handler.get_raw(item) == content
+
+
+
+@pytest.mark.parametrize(
+    ("item", "expected"),
+    [
+        ("verbosity_level", craft_cli.EmitterMode.BRIEF),
+        ("debug", False),
+        ("lxd_remote", "local"),
+        ("launchpad_instance", "production"),
+        # Application model items with defaults
+        ("my_default_str", "default"),
+        ("my_default_int", -1),
+        ("my_default_bool", True),
+        ("my_default_factory", {"dict": "yes"})
+    ]
+)
+def test_default_config_handler_success(default_config_handler, item, expected):
+    assert default_config_handler.get_raw(item) == expected
+
+
+@pytest.mark.parametrize(
+    ("item", "environment_variables", "expected"),
+    [
+        ("verbosity_level", {}, craft_cli.EmitterMode.BRIEF),
+        *(
+            ("verbosity_level", {"TESTCRAFT_VERBOSITY_LEVEL": mode.name}, mode)
+            for mode in craft_cli.EmitterMode
+        ),
+        *(
+            ("verbosity_level", {"TESTCRAFT_VERBOSITY_LEVEL": mode.name.lower()}, mode)
+            for mode in craft_cli.EmitterMode
+        ),
+        *(
+            ("verbosity_level", {"CRAFT_VERBOSITY_LEVEL": mode.name}, mode)
+            for mode in craft_cli.EmitterMode
+        ),
+        *(
+            ("verbosity_level", {"CRAFT_VERBOSITY_LEVEL": mode.name.lower()}, mode)
+            for mode in craft_cli.EmitterMode
+        ),
+        *(
+            ("debug", {var: value}, True)
+            for var, value in itertools.product(
+                ["CRAFT_DEBUG", "TESTCRAFT_DEBUG"],
+                ["true", "1", "yes", "Y"]
+            )
+        ),
+        *(
+            ("debug", {var: value}, False)
+            for var, value in itertools.product(
+                ["CRAFT_DEBUG", "TESTCRAFT_DEBUG"],
+                ["false", "0", "no", "N"]
+            )
+        ),
+        *(
+            ("parallel_build_count", {var: str(value)}, value)
+            for var, value in itertools.product(["CRAFT_PARALLEL_BUILD_COUNT", "TESTCRAFT_PARALLEL_BUILD_COUNT"], range(10))
+        )
+    ]
+)
+def test_config_service_converts_type(
+    monkeypatch: pytest.MonkeyPatch, fake_process: pytest_subprocess.FakeProcess,
+    fake_services, item: str, environment_variables: dict[str, str], expected
+):
+    monkeypatch.setattr("snaphelpers._ctl.Popen", subprocess.Popen)
+    for key, value in environment_variables.items():
+        monkeypatch.setenv(key, value)
+    fake_process.register(["/usr/bin/snapctl", fake_process.any()], stdout="{}")
+    assert fake_services.config.get(item) == expected

--- a/tests/unit/services/test_config.py
+++ b/tests/unit/services/test_config.py
@@ -141,10 +141,11 @@ def test_craft_environment_handler_error(
     ),
 )
 def test_snap_config_handler(snap_config_handler, item: str, content: str):
+    snap_item = item.replace("_", "-")
     with pytest_subprocess.FakeProcess.context() as fp, pytest.MonkeyPatch.context() as mp:
         mp.setattr("snaphelpers._ctl.Popen", subprocess.Popen)
         fp.register(
-            ["/usr/bin/snapctl", "get", "-d", item], stdout=json.dumps({item: content})
+            ["/usr/bin/snapctl", "get", "-d", snap_item], stdout=json.dumps({snap_item: content})
         )
         assert snap_config_handler.get_raw(item) == content
 

--- a/tests/unit/services/test_config.py
+++ b/tests/unit/services/test_config.py
@@ -25,6 +25,7 @@ import craft_application
 import craft_cli
 import pytest
 import pytest_subprocess
+from craft_application import launchpad
 from craft_application.services import config
 from hypothesis import given, strategies
 
@@ -54,6 +55,7 @@ APP_SPECIFIC_TEST_ENTRY_VALUES = [
     ("my_default_str", "something", "something"),
     ("my_default_int", "4294967296", 2**32),
     ("my_bool", "1", True),
+    ("my_arch", "riscv64", launchpad.Architecture.RISCV64),
 ]
 TEST_ENTRY_VALUES = CRAFT_APPLICATION_TEST_ENTRY_VALUES + APP_SPECIFIC_TEST_ENTRY_VALUES
 

--- a/tests/unit/services/test_config.py
+++ b/tests/unit/services/test_config.py
@@ -19,26 +19,20 @@ import itertools
 import json
 import string
 import subprocess
-from typing import Iterator
+from collections.abc import Iterator
 
-from hypothesis import given, strategies
 import craft_cli
 import pytest
 import pytest_subprocess
-
-from craft_application import ConfigModel
 from craft_application.services import config
-
+from hypothesis import given, strategies
 
 CRAFT_APPLICATION_TEST_ENTRY_VALUES = [
     *(
         ("verbosity_level", mode.name.lower(), mode)
         for mode in craft_cli.messages.EmitterMode
     ),
-    *(
-        ("verbosity_level", mode.name, mode)
-        for mode in craft_cli.messages.EmitterMode
-    ),
+    *(("verbosity_level", mode.name, mode) for mode in craft_cli.messages.EmitterMode),
     ("debug", "true", True),
     ("debug", "false", False),
     ("build_environment", "host", "host"),
@@ -128,11 +122,9 @@ def test_snap_config_handler(snap_config_handler, item: str, content: str):
     with pytest_subprocess.FakeProcess.context() as fp, pytest.MonkeyPatch.context() as mp:
         mp.setattr("snaphelpers._ctl.Popen", subprocess.Popen)
         fp.register(
-            ["/usr/bin/snapctl", "get", "-d", item],
-            stdout=json.dumps({item: content})
+            ["/usr/bin/snapctl", "get", "-d", item], stdout=json.dumps({item: content})
         )
         assert snap_config_handler.get_raw(item) == content
-
 
 
 @pytest.mark.parametrize(
@@ -146,8 +138,8 @@ def test_snap_config_handler(snap_config_handler, item: str, content: str):
         ("my_default_str", "default"),
         ("my_default_int", -1),
         ("my_default_bool", True),
-        ("my_default_factory", {"dict": "yes"})
-    ]
+        ("my_default_factory", {"dict": "yes"}),
+    ],
 )
 def test_default_config_handler_success(default_config_handler, item, expected):
     assert default_config_handler.get_raw(item) == expected
@@ -176,26 +168,31 @@ def test_default_config_handler_success(default_config_handler, item, expected):
         *(
             ("debug", {var: value}, True)
             for var, value in itertools.product(
-                ["CRAFT_DEBUG", "TESTCRAFT_DEBUG"],
-                ["true", "1", "yes", "Y"]
+                ["CRAFT_DEBUG", "TESTCRAFT_DEBUG"], ["true", "1", "yes", "Y"]
             )
         ),
         *(
             ("debug", {var: value}, False)
             for var, value in itertools.product(
-                ["CRAFT_DEBUG", "TESTCRAFT_DEBUG"],
-                ["false", "0", "no", "N"]
+                ["CRAFT_DEBUG", "TESTCRAFT_DEBUG"], ["false", "0", "no", "N"]
             )
         ),
         *(
             ("parallel_build_count", {var: str(value)}, value)
-            for var, value in itertools.product(["CRAFT_PARALLEL_BUILD_COUNT", "TESTCRAFT_PARALLEL_BUILD_COUNT"], range(10))
-        )
-    ]
+            for var, value in itertools.product(
+                ["CRAFT_PARALLEL_BUILD_COUNT", "TESTCRAFT_PARALLEL_BUILD_COUNT"],
+                range(10),
+            )
+        ),
+    ],
 )
 def test_config_service_converts_type(
-    monkeypatch: pytest.MonkeyPatch, fake_process: pytest_subprocess.FakeProcess,
-    fake_services, item: str, environment_variables: dict[str, str], expected
+    monkeypatch: pytest.MonkeyPatch,
+    fake_process: pytest_subprocess.FakeProcess,
+    fake_services,
+    item: str,
+    environment_variables: dict[str, str],
+    expected,
 ):
     monkeypatch.setattr("snaphelpers._ctl.Popen", subprocess.Popen)
     for key, value in environment_variables.items():

--- a/tests/unit/services/test_config.py
+++ b/tests/unit/services/test_config.py
@@ -147,7 +147,8 @@ def test_snap_config_handler(snap_config_handler, item: str, content: str):
     with pytest_subprocess.FakeProcess.context() as fp, pytest.MonkeyPatch.context() as mp:
         mp.setattr("snaphelpers._ctl.Popen", subprocess.Popen)
         fp.register(
-            ["/usr/bin/snapctl", "get", "-d", snap_item], stdout=json.dumps({snap_item: content})
+            ["/usr/bin/snapctl", "get", "-d", snap_item],
+            stdout=json.dumps({snap_item: content}),
         )
         assert snap_config_handler.get_raw(item) == content
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -620,6 +620,7 @@ def test_run_managed_specified_platform(app, fake_project):
         ),
     ],
 )
+@pytest.mark.usefixtures("emitter")
 def test_get_dispatcher_error(
     monkeypatch, check, capsys, app, mock_dispatcher, managed, error, exit_code, message
 ):
@@ -911,6 +912,7 @@ def test_run_success_managed_inside_managed(
         ),
     ],
 )
+@pytest.mark.usefixtures("emitter")
 def test_run_error(
     monkeypatch,
     capsys,
@@ -980,6 +982,7 @@ def test_run_error_with_docs_url(
 
 
 @pytest.mark.parametrize("error", [KeyError(), ValueError(), Exception()])
+@pytest.mark.usefixtures("emitter")
 def test_run_error_debug(monkeypatch, mock_dispatcher, app, fake_project, error):
     app.set_project(fake_project)
     mock_dispatcher.load_command.side_effect = error


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Adds a service for handling application configuration. This service works as follows:

1. Uses application-specific environment variables
2. Uses general `CRAFT_*` environment variables
3. Uses application-provided configuration handlers
4. Uses snap configuration (if the app is installed as a snap)
5. Falls back to the default or errors if no default is set.