### PR TITLE
feat: support shell/shell-after and debug in 'pack'

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -372,6 +372,7 @@ class PackCommand(LifecycleCommand):
         shell_after = getattr(parsed_args, "shell_after", False)
         debug = getattr(parsed_args, "debug", False)
 
+        # Prevent the steps in the prime command from using `--shell` or `--shell-after`
         parsed_args.shell = False
         parsed_args.shell_after = False
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -367,13 +367,31 @@ class PackCommand(LifecycleCommand):
         """Run the pack command."""
         if step_name not in ("pack", None):
             raise RuntimeError(f"Step name {step_name} passed to pack command.")
+
+        shell = getattr(parsed_args, "shell", False)
+        shell_after = getattr(parsed_args, "shell_after", False)
+        debug = getattr(parsed_args, "debug", False)
+
+        parsed_args.shell = False
+        parsed_args.shell_after = False
+
         super()._run(parsed_args, step_name="prime")
         self._run_post_prime_steps()
 
+        if shell:
+            _launch_shell()
+            return
+
         emit.progress("Packing...")
-        packages = self._services.package.pack(
-            self._services.lifecycle.prime_dir, parsed_args.output
-        )
+        try:
+            packages = self._services.package.pack(
+                self._services.lifecycle.prime_dir, parsed_args.output
+            )
+        except Exception as err:
+            if debug:
+                emit.progress(str(err), permanent=True)
+                _launch_shell()
+            raise
 
         if not packages:
             emit.progress("No packages created.", permanent=True)
@@ -383,10 +401,8 @@ class PackCommand(LifecycleCommand):
             package_names = ", ".join(pkg.name for pkg in packages)
             emit.progress(f"Packed: {package_names}", permanent=True)
 
-    @staticmethod
-    @override
-    def _should_add_shell_args() -> bool:
-        return False
+        if shell_after:
+            _launch_shell()
 
 
 class CleanCommand(_BaseLifecycleCommand):

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -414,6 +414,7 @@ def test_clean_run_managed(
 
 
 @pytest.mark.parametrize(("build_env_dict", "build_env_args"), BUILD_ENV_COMMANDS)
+@pytest.mark.parametrize(("shell_dict", "shell_args"), SHELL_PARAMS)
 @pytest.mark.parametrize(("debug_dict", "debug_args"), DEBUG_PARAMS)
 @pytest.mark.parametrize("output_arg", [".", "/"])
 def test_pack_fill_parser(
@@ -421,6 +422,8 @@ def test_pack_fill_parser(
     mock_services,
     build_env_dict,
     build_env_args,
+    shell_dict,
+    shell_args,
     debug_dict,
     debug_args,
     output_arg,
@@ -430,6 +433,7 @@ def test_pack_fill_parser(
         "platform": None,
         "build_for": None,
         "output": pathlib.Path(output_arg),
+        **shell_dict,
         **debug_dict,
         **build_env_dict,
     }
@@ -438,7 +442,9 @@ def test_pack_fill_parser(
     command.fill_parser(parser)
 
     args_dict = vars(
-        parser.parse_args([*build_env_args, *debug_args, f"--output={output_arg}"])
+        parser.parse_args(
+            [*build_env_args, *shell_args, *debug_args, f"--output={output_arg}"]
+        )
     )
     assert args_dict == expected
 
@@ -531,6 +537,34 @@ def test_shell(
     mock_subprocess_run.assert_called_once_with(["bash"], check=False)
 
 
+def test_shell_pack(
+    app_metadata,
+    fake_services,
+    mocker,
+    mock_subprocess_run,
+):
+    parsed_args = argparse.Namespace(shell=True)
+    mock_lifecycle_run = mocker.patch.object(fake_services.lifecycle, "run")
+    mock_pack = mocker.patch.object(fake_services.package, "pack")
+    mocker.patch.object(
+        fake_services.lifecycle.project_info, "execution_finished", return_value=True
+    )
+    command = PackCommand(
+        {
+            "app": app_metadata,
+            "services": fake_services,
+        }
+    )
+    command.run(parsed_args)
+
+    # Must run the lifecycle
+    mock_lifecycle_run.assert_called_once_with(step_name="prime")
+
+    # Must call the shell instead of packing
+    mock_subprocess_run.assert_called_once_with(["bash"], check=False)
+    assert not mock_pack.called
+
+
 @pytest.mark.parametrize("command_cls", MANAGED_LIFECYCLE_COMMANDS)
 def test_shell_after(
     app_metadata, fake_services, mocker, mock_subprocess_run, command_cls
@@ -554,6 +588,33 @@ def test_shell_after(
     mock_subprocess_run.assert_called_once_with(["bash"], check=False)
 
 
+def test_shell_after_pack(
+    app_metadata,
+    fake_services,
+    mocker,
+    mock_subprocess_run,
+):
+    parsed_args = argparse.Namespace(shell_after=True, output=pathlib.Path())
+    mock_lifecycle_run = mocker.patch.object(fake_services.lifecycle, "run")
+    mock_pack = mocker.patch.object(fake_services.package, "pack")
+    mocker.patch.object(
+        fake_services.lifecycle.project_info, "execution_finished", return_value=True
+    )
+    command = PackCommand(
+        {
+            "app": app_metadata,
+            "services": fake_services,
+        }
+    )
+    command.run(parsed_args)
+
+    # Must run the lifecycle
+    mock_lifecycle_run.assert_called_once_with(step_name="prime")
+    # Must pack, and then shell
+    mock_pack.assert_called_once_with(fake_services.lifecycle.prime_dir, pathlib.Path())
+    mock_subprocess_run.assert_called_once_with(["bash"], check=False)
+
+
 @pytest.mark.parametrize("command_cls", [*MANAGED_LIFECYCLE_COMMANDS, PackCommand])
 def test_debug(app_metadata, fake_services, mocker, mock_subprocess_run, command_cls):
     parsed_args = argparse.Namespace(parts=None, debug=True)
@@ -564,6 +625,36 @@ def test_debug(app_metadata, fake_services, mocker, mock_subprocess_run, command
         fake_services.lifecycle, "run", side_effect=RuntimeError(error_message)
     )
     command = command_cls(
+        {
+            "app": app_metadata,
+            "services": fake_services,
+        }
+    )
+
+    with pytest.raises(RuntimeError, match=error_message):
+        command.run(parsed_args)
+
+    mock_subprocess_run.assert_called_once_with(["bash"], check=False)
+
+
+def test_debug_pack(
+    app_metadata,
+    fake_services,
+    mocker,
+    mock_subprocess_run,
+):
+    """Same as test_debug(), but checking when the error happens when packing."""
+    parsed_args = argparse.Namespace(debug=True, output=pathlib.Path())
+    error_message = "Packing failed!"
+
+    # Lifecycle.run() should work
+    mocker.patch.object(fake_services.lifecycle, "run")
+    # Package.pack() should fail
+    mocker.patch.object(
+        fake_services.package, "pack", side_effect=RuntimeError(error_message)
+    )
+    mocker.patch.object(fake_services.package, "update_project")
+    command = PackCommand(
         {
             "app": app_metadata,
             "services": fake_services,


### PR DESCRIPTION
`--shell` and `--shell-after` are implemented for a) consistency with the other lifecycle commands, and b) because it makes sense to want to inspect the build environment at packing time, considering that there are packing-related steps, like writing the metadata file, that the users don't have a way to inspect otherwise (short of examining the final artefact).

`--debug` is improved to actually shell into the build environment when the packing itself failed, as opposed to the previous behavior of only debugging failures that happen during the lifecycle steps.

Fixes #430

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
