### PR TITLE
fix: fail managed runs if the build plan is empty

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -336,8 +336,10 @@ class Application:
 
     def run_managed(self, platform: str | None, build_for: str | None) -> None:
         """Run the application in a managed instance."""
-        extra_args: dict[str, Any] = {}
+        if not self._build_plan:
+            raise errors.EmptyBuildPlanError
 
+        extra_args: dict[str, Any] = {}
         for build_info in self._build_plan:
             if platform and platform != build_info.platform:
                 continue

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -152,8 +152,11 @@ class EmptyBuildPlanError(CraftError):
     """The build plan filtered out all possible builds."""
 
     def __init__(self) -> None:
-        message = "No build matches the current platform."
-        resolution = 'Check the "--platform" and "--build-for" parameters.'
+        message = "No build matches the current execution environment."
+        resolution = (
+            "Check the project's 'platforms' declaration, and the "
+            "'--platform' and '--build-for' parameters."
+        )
 
         super().__init__(message=message, resolution=resolution)
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -606,6 +606,14 @@ def test_run_managed_specified_platform(app, fake_project):
     assert mock.call(info1, work_dir=mock.ANY) not in mock_provider.instance.mock_calls
 
 
+def test_run_managed_empty_plan(app, fake_project):
+    app.set_project(fake_project)
+
+    app._build_plan = []
+    with pytest.raises(errors.EmptyBuildPlanError):
+        app.run_managed(None, None)
+
+
 @pytest.mark.parametrize(
     ("managed", "error", "exit_code", "message"),
     [


### PR DESCRIPTION
This fix addresses cases like, for example, a project that only builds on `amd64` being built on `riscv64`. Previously the call to run_managed() would loop over the (empty) build plan and then finish "successfully". This new version will raise an EmptyBuildPlanError indicating to the user that they should check the project's 'platforms' declaration and the command-line parameters.

Fixes #225

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
