### PR TITLE
Rocks 1457 / Rocks 1458 - Add Ubuntu Pro argument to craft-applications

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -544,7 +544,9 @@ class Application:
                 craft_cli.emit.debug(
                     f"Validating requested Ubuntu Pro attachment on host: {pro_services}"
                 )
-                pro_services.validate(options=ValidatorOptions.ATTACHMENT | ValidatorOptions.SUPPORT)
+                pro_services.validate(
+                    options=ValidatorOptions.ATTACHMENT | ValidatorOptions.SUPPORT
+                )
 
             if run_managed or command.needs_project(dispatcher.parsed_args()):
                 self.services.project = self.get_project(

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -38,6 +38,7 @@ from platformdirs import user_cache_path
 from craft_application import commands, errors, grammar, models, secrets, util
 from craft_application.errors import PathInvalidError
 from craft_application.models import BuildInfo, GrammarAwareProject
+from craft_application.commands.lifecycle import ProServices
 
 if TYPE_CHECKING:
     from craft_application.services import service_factory
@@ -471,7 +472,9 @@ class Application:
         """Register per application plugins when initializing."""
         self.register_plugins(self._get_app_plugins())
 
-    def _pre_run(self, dispatcher: craft_cli.Dispatcher) -> None:
+    def _pre_run(
+        self, dispatcher: craft_cli.Dispatcher, dispatcher: craft_cli.Dispatcher
+    ) -> None:
         """Do any final setup before running the command.
 
         At the time this is run, the command is loaded in the dispatcher, but
@@ -480,6 +483,11 @@ class Application:
         # Some commands might have a project_dir parameter. Those commands and
         # only those commands should get a project directory, but only when
         # not managed.
+
+        # Check that pro services are correctly attached.
+        pro_services = getattr(dispatcher.parsed_args(), "pro", ProServices())
+        pro_services.validate()
+
         if self.is_managed():
             self.project_dir = pathlib.Path("/root/project")
         elif project_dir := getattr(dispatcher.parsed_args(), "project_dir", None):

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -528,16 +528,14 @@ class Application:
 
             provider_name = command.provider_name(dispatcher.parsed_args())
 
-            # Check that pro services are correctly configured
-            # only validate requested pro services if we are inside a managed execution
-            # or outside an unmanaged execution
-
+            # Check that pro services are correctly configured:
+            # Validate requested pro services if we are running in destructive mode ...
             if not run_managed and not is_managed:
                 craft_cli.emit.debug(
                     f"Validating requested Ubuntu Pro status on host: {pro_services}"
                 )
                 pro_services.validate()
-
+            # .. or validate pro attachment if running in a managed instance
             elif run_managed and not is_managed:
                 craft_cli.emit.debug(
                     f"Validating requested Ubuntu Pro attachment on host: {pro_services}"

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -29,6 +29,7 @@ from functools import cached_property
 from importlib import metadata
 from typing import TYPE_CHECKING, Any, cast, final
 
+
 import craft_cli
 import craft_parts
 import craft_providers
@@ -532,6 +533,9 @@ class Application:
             # or outside an unmanaged execution
 
             if (managed_mode and is_managed) or not (managed_mode or is_managed):
+                craft_cli.emit.debug(
+                    f"Validating Requested Ubuntu Pro Services: {pro_services}"
+                )
                 pro_services.validate()
 
             if managed_mode or command.needs_project(dispatcher.parsed_args()):

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -38,7 +38,7 @@ from platformdirs import user_cache_path
 from craft_application import commands, errors, grammar, models, secrets, util
 from craft_application.errors import PathInvalidError
 from craft_application.models import BuildInfo, GrammarAwareProject
-from craft_application.util.pro_services import ValidatorOptions
+from craft_application.util import ValidatorOptions
 
 if TYPE_CHECKING:
     from craft_application.services import service_factory

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -29,7 +29,6 @@ from functools import cached_property
 from importlib import metadata
 from typing import TYPE_CHECKING, Any, cast, final
 
-
 import craft_cli
 import craft_parts
 import craft_providers
@@ -39,7 +38,7 @@ from platformdirs import user_cache_path
 from craft_application import commands, errors, grammar, models, secrets, util
 from craft_application.errors import PathInvalidError
 from craft_application.models import BuildInfo, GrammarAwareProject
-from craft_application.commands.lifecycle import ProServices
+from craft_application.util.pro_services import ProServices, ValidatorOptions
 
 if TYPE_CHECKING:
     from craft_application.services import service_factory
@@ -540,7 +539,7 @@ class Application:
                 craft_cli.emit.debug(
                     f"Validating requested Ubuntu Pro attachment on host: {pro_services}"
                 )
-                pro_services.validate(service_support=False, service_enablement=False)
+                pro_services.validate(options=ValidatorOptions.ATTACHMENT)
 
             if run_managed or command.needs_project(dispatcher.parsed_args()):
                 self.services.project = self.get_project(

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -508,6 +508,8 @@ class Application:
                 commands.AppCommand,
                 dispatcher.load_command(self.app_config),
             )
+
+            # TODO: do we need default kwargs here? our argparse was already passed defaults.
             platform = getattr(dispatcher.parsed_args(), "platform", None)
             build_for = getattr(dispatcher.parsed_args(), "build_for", None)
             pro_services = getattr(dispatcher.parsed_args(), "pro", ProServices())
@@ -525,21 +527,22 @@ class Application:
 
             provider_name = command.provider_name(dispatcher.parsed_args())
 
-            craft_cli.emit.debug(
-                f"Build plan: platform={platform}, build_for={build_for}"
-            )
-            self._pre_run(dispatcher)
-
-            # Check that pro services are correctly attached...
+            # Check that pro services are correctly configured
             # only validate requested pro services if we are inside a managed execution
             # or outside an unmanaged execution
-            if not (managed_mode ^ is_managed):
+
+            if (managed_mode and is_managed) or not (managed_mode or is_managed):
                 pro_services.validate()
 
             if managed_mode or command.needs_project(dispatcher.parsed_args()):
                 self.services.project = self.get_project(
                     platform=platform, build_for=build_for
                 )
+
+            craft_cli.emit.debug(
+                f"Build plan: platform={platform}, build_for={build_for}"
+            )
+            self._pre_run(dispatcher)
 
             self._configure_services(provider_name)
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -26,7 +26,7 @@ from craft_parts.features import Features
 from typing_extensions import override
 
 from craft_application.commands import base
-from craft_application.util.pro_services import ProServices
+from craft_application.util import ProServices
 
 
 def get_lifecycle_command_group() -> CommandGroup:

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -50,6 +50,21 @@ def get_lifecycle_command_group() -> CommandGroup:
     )
 
 
+class ProServices(set):
+    """Class for managing pro-services within the lifecycle"""
+
+    separator: str = ","
+
+    @classmethod
+    def from_csv(cls, services: str) -> ProServices:
+        """Return a set of ProServices from a csv string."""
+
+        split = [service.strip() for service in services.split(cls.separator)]
+        result = cls(split)
+
+        return result
+
+
 class _BaseLifecycleCommand(base.ExtensibleCommand):
     """Base class for lifecycle-related commands.
 
@@ -75,6 +90,13 @@ class _BaseLifecycleCommand(base.ExtensibleCommand):
             "--use-lxd",
             action="store_true",
             help="Build in a LXD container.",
+        )
+
+        parser.add_argument(
+            "--pro",
+            type=ProServices.from_csv,
+            metavar="<pro-services>",
+            help="Enable Ubuntu Pro service by name. Each service should be separated by a comma.",
         )
 
     @override

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -29,8 +29,7 @@ from craft_application.commands import base
 from craft_application.util.pro_services import ProServices
 
 
-if TYPE_CHECKING:  # pragma: no cover
-    import argparse
+import argparse
 
 
 def get_lifecycle_command_group() -> CommandGroup:

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -117,7 +117,7 @@ class ProServices(set):
 
             service_names = {service.name for service in response.enabled_services}
 
-            # remove any services that arn't relevant to build services
+            # remove any services that aren't relevant to build services
             service_names = service_names.intersection(cls.build_service_scope)
 
             result = cls(service_names)
@@ -156,7 +156,7 @@ class ProServices(set):
             # the services specified in this set
             if (services := self.pro_services()) != self:
                 raise InvalidProStatus(
-                    "The requested pro services do not match the services enabled in the enviroment.\n"
+                    "The requested pro services do not match the services enabled in the environment.\n"
                     f"Enabled Pro Services: {services}\n"
                     f"Specified Pro Services: {self}\n"
                 )

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -80,15 +80,20 @@ class _BaseLifecycleCommand(base.ExtensibleCommand):
         )
 
         # we suppress the help msg from this argument if the pro api is not found
+        pro_help_str = argparse.SUPPRESS
+        if ProServices.pro_client_exists():
+            supported_pro_services = ", ".join(
+                [f"'{name}'" for name in ProServices.supported_services]
+            )
+            pro_help_str = "Enable Ubuntu Pro services for this command. "
+            f"Supported values include: {supported_pro_services}. "
+            "Multiple values can be passed separated by commas."
+
         parser.add_argument(
             "--pro",
             type=ProServices.from_csv,
             metavar="<pro-services>",
-            help=(
-                "Enable Ubuntu Pro service by name. Each service should be separated by a comma."
-                if ProServices.pro_client_exists()
-                else argparse.SUPPRESS
-            ),
+            help=pro_help_str,
             default=ProServices(),
         )
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -14,12 +14,12 @@
 """Basic lifecycle commands for a Craft Application."""
 from __future__ import annotations
 
+import argparse
 import os
 import pathlib
 import subprocess
 import textwrap
-from typing import TYPE_CHECKING, Any
-
+from typing import Any
 
 from craft_cli import CommandGroup, emit
 from craft_parts.features import Features
@@ -27,9 +27,6 @@ from typing_extensions import override
 
 from craft_application.commands import base
 from craft_application.util.pro_services import ProServices
-
-
-import argparse
 
 
 def get_lifecycle_command_group() -> CommandGroup:

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -19,13 +19,14 @@ import pathlib
 import subprocess
 import textwrap
 from typing import TYPE_CHECKING, Any
-import json
+
 
 from craft_cli import CommandGroup, emit
 from craft_parts.features import Features
 from typing_extensions import override
 
 from craft_application.commands import base
+
 
 if TYPE_CHECKING:  # pragma: no cover
     import argparse
@@ -71,11 +72,18 @@ class ProServices(set):
     """Class for managing pro-services within the lifecycle"""
 
     separator: str = ","
-    build_service_scope = {"esm-apps", "esm-infa", "fips-preview", "fips-updates"}
+    build_service_scope: set = {"esm-apps", "esm-infa", "fips-preview", "fips-updates"}
+
+    def __str__(self) -> str:
+        """Convert to string for display to user."""
+
+        result = ", ".join(self)
+
+        return result
 
     @classmethod
     def from_csv(cls, services: str) -> ProServices:
-        """Return a set of ProServices from a csv string."""
+        """Create a new ProServices instance from a csv string."""
 
         split = [service.strip() for service in services.split(cls.separator)]
         result = cls(split)
@@ -84,56 +92,84 @@ class ProServices(set):
 
     @classmethod
     def pro_attached(cls) -> bool:
+        """Returns True if environment is attached to Ubuntu Pro."""
         try:
-            from uaclient.api.u.pro.status.enabled_services.v1 import is_attached
+            import uaclient
 
-            response = is_attached()
+            response = uaclient.api.u.pro.status.is_attached.v1.is_attached()
 
-            is_attached = response.is_attached
+            result = response.is_attached
 
-            return is_attached
+            return result
 
         except ImportError as exc:
             raise UnableToImportProApi() from exc
 
     @classmethod
-    def pro_services(cls) -> set:
-        try:
-            from uaclient.api.u.pro.status.enabled_services.v1 import enabled_services
+    def pro_services(cls) -> ProServices:
+        """Return set of enabled Ubuntu Pro services in the environment.
+        The returned set only includes services relevant to lifecycle commands."""
 
-            response = enabled_services()
+        try:
+            import uaclient
+
+            response = uaclient.api.u.pro.status.enabled_services.v1.enabled_services()
 
             service_names = {service.name for service in response.enabled_services}
 
             # remove any services that arn't relevant to build services
             service_names = service_names.intersection(cls.build_service_scope)
 
-            return service_names
+            result = cls(service_names)
+
+            return result
 
         except ImportError as exc:
             raise UnableToImportProApi() from exc
 
     def validate(self):
+        """Validate the environment against pro services specified in this ProServices instance."""
 
-        attached = self.pro_attached()
+        try:
 
-        # pro services are declared
-        if self:
+            # first, check Ubuntu Pro status
+            # Since we extend the set class, cast ourselves to bool to check if we empty. if we are not
+            # empty, this implies we require pro services.
+            if self.pro_attached() != bool(self):
+                if bool(self):
+                    raise InvalidProStatus(
+                        "This command requires a Ubuntu Pro environment, "
+                        "but no Ubuntu Pro attachment was found."
+                    )
+                else:
+                    raise InvalidProStatus(
+                        "This command requires a non-Ubuntu Pro environment, "
+                        "but Ubuntu Pro attachment was found."
+                    )
 
-            # first check that we are attached
-            if attached:
-                raise InvalidProStatus("Host is not attached")
+            # TODO:
+            # - Optimization: could we just check if the services we need are available and skip
+            #   checking if we are attached? or could we return early here if we are detached and did not request pro services?
+            # - What if pro services are attached, but no services within the build_service_scope are used?
 
-            services = self.pro_services()
-
-            if services != self:
+            # second, check that the set of enabled pro services in the environment matches
+            # the services specified in this set
+            if (services := self.pro_services()) != self:
                 raise InvalidProStatus(
-                    "Host pro service enablement does not match build requirements"
+                    "The requested pro services do not match the services enabled in the enviroment.\n"
+                    f"Enabled Pro Services: {services}\n"
+                    f"Specified Pro Services: {self}\n"
                 )
 
-        else:
-            if attached:
-                raise InvalidProStatus("Host is attached")
+        except UnableToImportProApi as exc:
+            # TODO: if we ever run in environments where the uaclient module
+            # is not available we may need to add it to the path, or suppress this
+            # exception on platforms that do not support uaclient.
+            #
+            # If we have difficulty importing uaclient, we may want to
+            # revert back to calling the command directly via subprocess
+
+            raise exc
 
 
 class _BaseLifecycleCommand(base.ExtensibleCommand):
@@ -168,6 +204,7 @@ class _BaseLifecycleCommand(base.ExtensibleCommand):
             type=ProServices.from_csv,
             metavar="<pro-services>",
             help="Enable Ubuntu Pro service by name. Each service should be separated by a comma.",
+            default=ProServices(),
         )
 
     @override

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -53,23 +53,25 @@ def get_lifecycle_command_group() -> CommandGroup:
 
 
 class ProException(Exception):
+    """Base Exception class for ProServices."""
+
     pass
 
 
 class InvalidProStatus(ProException):
+    """Raised when ProServices does not environment Ubuntu Pro configuration."""
+
     pass
 
 
-class ProApiException(ProException):
-    pass
+class UnableToImportProApi(ProException):
+    """Raised when uaclient module is not found."""
 
-
-class UnableToImportProApi(ProApiException):
     pass
 
 
 class ProServices(set[str]):
-    """Class for managing pro-services within the lifecycle"""
+    """Class for managing pro-services within the lifecycle."""
 
     separator: str = ","
     build_service_scope: set[str] = {

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -68,11 +68,16 @@ class UnableToImportProApi(ProApiException):
     pass
 
 
-class ProServices(set):
+class ProServices(set[str]):
     """Class for managing pro-services within the lifecycle"""
 
     separator: str = ","
-    build_service_scope: set = {"esm-apps", "esm-infa", "fips-preview", "fips-updates"}
+    build_service_scope: set[str] = {
+        "esm-apps",
+        "esm-infa",
+        "fips-preview",
+        "fips-updates",
+    }
 
     def __str__(self) -> str:
         """Convert to string for display to user."""
@@ -93,14 +98,18 @@ class ProServices(set):
     @classmethod
     def pro_attached(cls) -> bool:
         """Returns True if environment is attached to Ubuntu Pro."""
+
+        # TODO: fix pyright when uaclient module is not available
         try:
-            import uaclient
+            import uaclient  # pyright: ignore
 
-            response = uaclient.api.u.pro.status.is_attached.v1.is_attached()
+            response = (  # pyright: ignore
+                uaclient.api.u.pro.status.is_attached.v1.is_attached()  # pyright: ignore
+            )
 
-            result = response.is_attached
+            result = response.is_attached  # pyright: ignore
 
-            return result
+            return result  # pyright: ignore
 
         except ImportError as exc:
             raise UnableToImportProApi() from exc
@@ -111,16 +120,22 @@ class ProServices(set):
         The returned set only includes services relevant to lifecycle commands."""
 
         try:
-            import uaclient
+            import uaclient  # pyright: ignore
 
-            response = uaclient.api.u.pro.status.enabled_services.v1.enabled_services()
+            response = (  # pyright: ignore
+                uaclient.api.u.pro.status.enabled_services.v1.enabled_services()  # pyright: ignore
+            )
 
-            service_names = {service.name for service in response.enabled_services}
+            service_names = {  # pyright: ignore
+                service.name for service in response.enabled_services  # pyright: ignore
+            }
 
             # remove any services that aren't relevant to build services
-            service_names = service_names.intersection(cls.build_service_scope)
+            service_names = service_names.intersection(  # pyright: ignore
+                cls.build_service_scope  # pyright: ignore
+            )
 
-            result = cls(service_names)
+            result = cls(service_names)  # pyright: ignore
 
             return result
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -85,9 +85,11 @@ class _BaseLifecycleCommand(base.ExtensibleCommand):
             supported_pro_services = ", ".join(
                 [f"'{name}'" for name in ProServices.supported_services]
             )
-            pro_help_str = "Enable Ubuntu Pro services for this command. "
-            f"Supported values include: {supported_pro_services}. "
-            "Multiple values can be passed separated by commas."
+            pro_help_str = (
+                "Enable Ubuntu Pro services for this command. "
+                f"Supported values include: {supported_pro_services}. "
+                "Multiple values can be passed separated by commas."
+            )
 
         parser.add_argument(
             "--pro",

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -76,23 +76,20 @@ class _BaseLifecycleCommand(base.ExtensibleCommand):
             help="Build in a LXD container.",
         )
 
-        # we suppress the help msg from this argument if the pro api is not found
-        pro_help_str = argparse.SUPPRESS
-        if ProServices.pro_client_exists():
-            supported_pro_services = ", ".join(
-                [f"'{name}'" for name in ProServices.supported_services]
-            )
-            pro_help_str = (
-                "Enable Ubuntu Pro services for this command. "
-                f"Supported values include: {supported_pro_services}. "
-                "Multiple values can be passed separated by commas."
-            )
+        supported_pro_services = ", ".join(
+            [f"'{name}'" for name in ProServices.supported_services]
+        )
 
         parser.add_argument(
             "--pro",
             type=ProServices.from_csv,
             metavar="<pro-services>",
-            help=pro_help_str,
+            help=(
+                "Enable Ubuntu Pro services for this command. "
+                f"Supported values include: {supported_pro_services}. "
+                "Multiple values can be passed separated by commas. "
+                "Note: This feature requires an Ubuntu Pro compatible host and build base."
+            ),
             default=ProServices(),
         )
 

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -239,22 +239,22 @@ class CancelFailedError(RemoteBuildError):
         )
 
 
-class UbuntuProException(CraftError):
+class UbuntuProError(CraftError):
     """Base Exception class for ProServices."""
 
 
-class UbuntuProApiException(UbuntuProException):
-    """Base class for exceptions raised during Ubuntu Pro Api calls"""
+class UbuntuProApiError(UbuntuProError):
+    """Base class for exceptions raised during Ubuntu Pro Api calls."""
 
 
-class InvalidUbuntuProState(UbuntuProException):
-    """Base class for exceptions raised during Ubuntu Pro validation"""
+class InvalidUbuntuProStateError(UbuntuProError):
+    """Base class for exceptions raised during Ubuntu Pro validation."""
 
     # TODO: some of the resolution strings may not sense in a managed
     # environment. What is the best way to get the is_managed method here?
 
 
-class UbuntuProClientNotFound(UbuntuProApiException):
+class UbuntuProClientNotFoundError(UbuntuProApiError):
     """Raised when Ubuntu Pro client was not found on the system."""
 
     def __init__(self, path: str) -> None:
@@ -264,7 +264,7 @@ class UbuntuProClientNotFound(UbuntuProApiException):
         super().__init__(message=message)
 
 
-class UbuntuProDetached(InvalidUbuntuProState):
+class UbuntuProDetachedError(InvalidUbuntuProStateError):
     """Raised when Ubuntu Pro is not attached, but Pro services were requested."""
 
     def __init__(self) -> None:
@@ -275,7 +275,7 @@ class UbuntuProDetached(InvalidUbuntuProState):
         super().__init__(message=message, resolution=resolution)
 
 
-class UbuntuProAttached(InvalidUbuntuProState):
+class UbuntuProAttachedError(InvalidUbuntuProStateError):
     """Raised when Ubuntu Pro is attached, but Pro services were not requested."""
 
     def __init__(self) -> None:
@@ -286,9 +286,8 @@ class UbuntuProAttached(InvalidUbuntuProState):
         super().__init__(message=message, resolution=resolution)
 
 
-class InvalidUbuntuProService(InvalidUbuntuProState):
-    """Raised when the requested Ubuntu Pro service is not supported in
-    Craft Application or is an invalid Ubuntu Pro Service."""
+class InvalidUbuntuProServiceError(InvalidUbuntuProStateError):
+    """Raised when the requested Ubuntu Pro service is not supported or invalid."""
 
     # TODO: Should there be separate exceptions for services that not supported vs. invalid?
     # if so where is the list of supported service names?
@@ -308,7 +307,7 @@ class InvalidUbuntuProService(InvalidUbuntuProState):
         super().__init__(message=message, resolution=resolution)
 
 
-class InvalidUbuntuProStatus(InvalidUbuntuProState):
+class InvalidUbuntuProStatusError(InvalidUbuntuProStateError):
     """Raised when the incorrect set of Pro Services are enabled."""
 
     def __init__(

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -250,6 +250,9 @@ class UbuntuProApiException(UbuntuProException):
 class InvalidUbuntuProState(UbuntuProException):
     """Base class for exceptions raised during Ubuntu Pro validation"""
 
+    # TODO: some of the resolution strings may not sense in a managed
+    # environment. What is the best way to get the is_managed method here?
+
 
 class UbuntuProClientNotFound(UbuntuProApiException):
     """Raised when Ubuntu Pro client was not found on the system."""
@@ -283,29 +286,44 @@ class UbuntuProAttached(InvalidUbuntuProState):
         super().__init__(message=message, resolution=resolution)
 
 
-class InvalidUbuntuProServices(InvalidUbuntuProState):
+class InvalidUbuntuProService(InvalidUbuntuProState):
+    """Raised when the requested Ubuntu Pro service is not supported in
+    Craft Application or is an invalid Ubuntu Pro Service."""
+
+    # TODO: Should there be separate exceptions for services that not supported vs. invalid?
+    # if so where is the list of supported service names?
+
+    def __init__(self, invalid_services: set[str]) -> None:
+
+        invalid_services_str = "".join(invalid_services)
+
+        message = "Invalid Ubuntu Pro Services were requested."
+        resolution = (
+            "The services listed are either not supported by this application "
+            "or are invalid Ubuntu Pro Services.\n"
+            f"Invalid Services: {invalid_services_str}\n"
+            'See "--pro" argument details for supported services.'
+        )
+
+        super().__init__(message=message, resolution=resolution)
+
+
+class InvalidUbuntuProStatus(InvalidUbuntuProState):
     """Raised when the incorrect set of Pro Services are enabled."""
 
     def __init__(
         self, requested_services: set[str], available_services: set[str]
     ) -> None:
 
-        line_fmt = "\t{}\n"
-        enable_services = "".join(
-            line_fmt.format(service)
-            for service in requested_services - available_services
-        )
-        disable_services = "".join(
-            line_fmt.format(service)
-            for service in available_services - requested_services
-        )
+        enable_services_str = " ".join(requested_services - available_services)
+        disable_services_str = " ".join(available_services - requested_services)
 
         message = "Incorrect Ubuntu Pro Services were enabled."
         resolution = (
             "Please enable or disable the following services.\n"
-            f"Enable:\n{enable_services}\n"
-            f"Disable:\n{disable_services}\n"
-            ' See "pro" command for details.'
+            f"Enable: {enable_services_str}\n"
+            f"Disable: {disable_services_str}\n"
+            'See "pro" command for details.'
         )
 
         super().__init__(message=message, resolution=resolution)

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -237,3 +237,75 @@ class CancelFailedError(RemoteBuildError):
             reportable=reportable,
             retcode=retcode,
         )
+
+
+class UbuntuProException(CraftError):
+    """Base Exception class for ProServices."""
+
+
+class UbuntuProApiException(UbuntuProException):
+    """Base class for exceptions raised during Ubuntu Pro Api calls"""
+
+
+class InvalidUbuntuProState(UbuntuProException):
+    """Base class for exceptions raised during Ubuntu Pro validation"""
+
+
+class UbuntuProClientNotFound(UbuntuProApiException):
+    """Raised when Ubuntu Pro client was not found on the system."""
+
+    def __init__(self, path: str) -> None:
+
+        message = f'The Ubuntu Pro client was not found on the system at "{path}"'
+
+        super().__init__(message=message)
+
+
+class UbuntuProDetached(InvalidUbuntuProState):
+    """Raised when Ubuntu Pro is not attached, but Pro services were requested."""
+
+    def __init__(self) -> None:
+
+        message = "Ubuntu Pro is requested, but was found detached."
+        resolution = 'Attach Ubuntu Pro to continue. See "pro" command for details.'
+
+        super().__init__(message=message, resolution=resolution)
+
+
+class UbuntuProAttached(InvalidUbuntuProState):
+    """Raised when Ubuntu Pro is attached, but Pro services were not requested."""
+
+    def __init__(self) -> None:
+
+        message = "Ubuntu Pro is not requested, but was found attached."
+        resolution = 'Detach Ubuntu Pro to continue. See "pro" command for details.'
+
+        super().__init__(message=message, resolution=resolution)
+
+
+class InvalidUbuntuProServices(InvalidUbuntuProState):
+    """Raised when the incorrect set of Pro Services are enabled."""
+
+    def __init__(
+        self, requested_services: set[str], available_services: set[str]
+    ) -> None:
+
+        line_fmt = "\t{}\n"
+        enable_services = "".join(
+            line_fmt.format(service)
+            for service in requested_services - available_services
+        )
+        disable_services = "".join(
+            line_fmt.format(service)
+            for service in available_services - requested_services
+        )
+
+        message = "Incorrect Ubuntu Pro Services were enabled."
+        resolution = (
+            "Please enable or disable the following services.\n"
+            f"Enable:\n{enable_services}\n"
+            f"Disable:\n{disable_services}\n"
+            ' See "pro" command for details.'
+        )
+
+        super().__init__(message=message, resolution=resolution)

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -33,6 +33,7 @@ from craft_application.util.snap_config import (
 )
 from craft_application.util.string import humanize_list, strtobool
 from craft_application.util.yaml import dump_yaml, safe_yaml_load
+from craft_application.util.pro_services import ProServices, ValidatorOptions
 
 __all__ = [
     "get_unique_callbacks",
@@ -52,4 +53,6 @@ __all__ = [
     "dump_yaml",
     "safe_yaml_load",
     "retry",
+    "ProServices", 
+    "ValidatorOptions",
 ]

--- a/craft_application/util/__init__.py
+++ b/craft_application/util/__init__.py
@@ -53,6 +53,6 @@ __all__ = [
     "dump_yaml",
     "safe_yaml_load",
     "retry",
-    "ProServices", 
+    "ProServices",
     "ValidatorOptions",
 ]

--- a/craft_application/util/pro_services.py
+++ b/craft_application/util/pro_services.py
@@ -1,0 +1,195 @@
+# This file is part of craft_application.
+#
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Handling of Ubuntu Pro Services"""
+from __future__ import annotations
+from typing import Any
+
+from craft_application.errors import (
+    UbuntuProClientNotFound,
+    UbuntuProApiException,
+    UbuntuProDetached,
+    UbuntuProAttached,
+    InvalidUbuntuProServices,
+)
+import logging
+import subprocess as sub
+import json
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# list of locations to search for paths
+PRO_CLIENT_PATHS = [
+    Path("/usr/bin/ubuntu-advantage"),
+    Path("/usr/bin/ua"),
+    Path("/usr/bin/pro"),
+]
+
+
+class ProServices(set[str]):
+    """Class for managing pro-services within the lifecycle."""
+
+    # pro binary to use for calls
+    # TODO: will we support this executable long term?
+
+    # placeholder for empty sets
+    empty_placeholder = "none"
+
+    # ignore services outside of this scope
+    build_service_scope: set[str] = {
+        "esm-apps",
+        "esm-infa",
+        "fips-preview",
+        "fips-updates",
+    }
+
+    # location of pro client
+    pro_executable: Path | None = next(
+        (path for path in PRO_CLIENT_PATHS if path.exists()), None
+    )
+    # locations to check for pro client
+
+    def __str__(self) -> str:
+        """Convert to string for display to user."""
+
+        result = ", ".join(self) if self else self.empty_placeholder
+
+        return result
+
+    @classmethod
+    def from_csv(cls, services: str) -> ProServices:
+        """Create a new ProServices instance from a csv string."""
+
+        split = [service.strip() for service in services.split(",")]
+        result = cls(split)
+
+        return result
+
+    @classmethod
+    def pro_client_exists(cls) -> bool:
+        """Check if Ubuntu Pro executable exists or not."""
+        result = cls.pro_executable is not None and cls.pro_executable.exists()
+
+        return result
+
+    @classmethod
+    def _log_processes(cls, process: sub.CompletedProcess) -> None:  # pyright: ignore
+        # TODO: Fix pyright warnings
+        logger.error(
+            "Ubuntu Pro Client Response: \n"
+            f"Return Code: {process.returncode}\n"
+            f"StdOut:\n{process.stdout}\n\n"  # pyright: ignore
+            f"StdErr:\n{process.stderr}\n\n"  # pyright: ignore
+        )
+
+    @classmethod
+    def _pro_api_call(cls, endpoint: str) -> dict[str, Any]:
+        """Call Ubuntu Pro executable and parse response"""
+
+        if not cls.pro_client_exists():
+            raise UbuntuProClientNotFound(str(cls.pro_executable))
+
+        try:
+            proc = sub.run(
+                [str(cls.pro_executable), "api", endpoint],
+                capture_output=True,
+                text=True,
+            )
+        except Exception as exc:
+            raise UbuntuProApiException(
+                f'An error occurred while executing "{cls.pro_executable}"'
+            ) from exc
+
+        if proc.returncode != 0:
+            cls._log_processes(proc)  # pyright: ignore
+            raise UbuntuProApiException(
+                f"The Pro Client returned a non-zero status: {proc.returncode}. "
+                "See log for more details"
+            )
+
+        try:
+            result = json.loads(proc.stdout)
+
+        except json.decoder.JSONDecodeError as exc:
+            cls._log_processes(proc)  # pyright: ignore
+            raise UbuntuProApiException(
+                f"Could not parse JSON response from Ubuntu Pro client. "
+                "See log for more details"
+            )
+
+        if result["result"] != "success":
+            cls._log_processes(proc)  # pyright: ignore
+            raise UbuntuProApiException(
+                f"Ubuntu Pro API returned an error response. See log for more details"
+            )
+
+        return result
+
+    @classmethod
+    def pro_attached(cls) -> bool:
+        """Returns True if environment is attached to Ubuntu Pro."""
+
+        response = cls._pro_api_call("u.pro.status.is_attached.v1")
+        result = response["data"]["attributes"]["is_attached"]
+
+        return result  # pyright: ignore
+
+    @classmethod
+    def pro_services(cls) -> ProServices:
+        """Return set of enabled Ubuntu Pro services in the environment.
+        The returned set only includes services relevant to lifecycle commands."""
+
+        response = cls._pro_api_call("u.pro.status.enabled_services.v1")
+        enabled_services = response["data"]["attributes"]["enabled_services"]
+
+        service_names = {service["name"] for service in enabled_services}
+
+        # remove any services that aren't relevant to build services
+        service_names = service_names.intersection(cls.build_service_scope)
+
+        result = cls(service_names)
+
+        return result
+
+    def validate(self):
+        """Validate the environment against pro services specified in this ProServices instance."""
+
+        # TODO: add logging
+        try:
+            # first, check Ubuntu Pro status
+            # Since we extend the set class, cast ourselves to bool to check if we empty. if we are not
+            # empty, this implies we require pro services.
+            if self.pro_attached() != bool(self):
+                if self:
+                    raise UbuntuProDetached()
+                else:
+                    raise UbuntuProAttached()
+
+            # If we are not attached, we can infer that services are disabled
+            if not self:
+                return
+
+            # second, check that the set of enabled pro services in the environment matches
+            # the services specified in this set
+            if (available_services := self.pro_services()) != self:
+                raise InvalidUbuntuProServices(self, available_services)
+
+        except UbuntuProClientNotFound as exc:
+
+            # If The pro client was not found, we may be on a non Ubuntu
+            # system, but if Pro services were requested, re-raise error
+            if self and not self.pro_client_exists():
+                raise exc

--- a/craft_application/util/pro_services.py
+++ b/craft_application/util/pro_services.py
@@ -51,6 +51,7 @@ class ProServices(set[str]):
     supported_services: set[str] = {
         "esm-apps",
         "esm-infra",
+        "fips",
         "fips-preview",
         "fips-updates",
     }

--- a/craft_application/util/pro_services.py
+++ b/craft_application/util/pro_services.py
@@ -51,7 +51,7 @@ class ProServices(set[str]):
     # ignore services outside of this scope
     build_service_scope: set[str] = {
         "esm-apps",
-        "esm-infa",
+        "esm-infra",
         "fips-preview",
         "fips-updates",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import pathlib
 import shutil
 from importlib import metadata
@@ -301,7 +300,7 @@ def mock_pro_api_call(mocker):
         },
     }
 
-    def set_is_attached(value: bool):
+    def set_is_attached(value: bool):  # noqa: FBT001
         response = mock_responses["u.pro.status.is_attached.v1"]
         response["data"]["attributes"]["is_attached"] = value
 
@@ -316,8 +315,7 @@ def mock_pro_api_call(mocker):
         response["data"]["attributes"]["enabled_services"] = enabled_services
 
     def mock_pro_api_call(endpoint: str):
-        result = mock_responses[endpoint]
-        return result
+        return mock_responses[endpoint]
 
     mocker.patch(
         "craft_application.util.pro_services.ProServices._pro_api_call",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,7 +318,7 @@ def mock_pro_api_call(mocker):
         return mock_responses[endpoint]
 
     mocker.patch(
-        "craft_application.util.pro_services.ProServices._pro_api_call",
+        "craft_application.util.ProServices._pro_api_call",
         new=mock_pro_api_call,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,7 +304,7 @@ def uaclient_mock(monkeypatch, mocker):
             mock_isattachedresult
         )
 
-        # similarily mock empty enabled services list
+        # similarly mock empty enabled services list
 
         mock_enabledservice_list = list()
         for service in services:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import pathlib
 import shutil
 from importlib import metadata
@@ -282,3 +283,31 @@ def fake_services(
         PackageClass=fake_package_service_class,
         LifecycleClass=fake_lifecycle_service_class,
     )
+
+
+@pytest.fixture
+def uaclient_mock(monkeypatch, mocker):
+
+    # create mock for UA client
+    mock_uaclient = mocker.Mock()
+
+    # mock is_attached calls to return false
+    mock_isattachedresult = mocker.Mock()
+    type(mock_isattachedresult).is_attached = mocker.PropertyMock(return_value=False)
+    mock_uaclient.api.u.pro.status.is_attached.v1.is_attached.return_value = (
+        mock_isattachedresult
+    )
+
+    # similarily mock empty enabled services list
+    mock_enabledserviceresult = mocker.Mock()
+    type(mock_enabledserviceresult).enabled_services = mocker.PropertyMock(
+        return_value=list()
+    )
+    mock_uaclient.api.u.pro.status.enabled_services.v1.enabled_services.return_value = (
+        mock_enabledserviceresult
+    )
+
+    # patch imports of uaclient
+    monkeypatch.setitem(sys.modules, "uaclient", mock_uaclient)
+
+    return mock_uaclient

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -29,7 +29,6 @@ from craft_application.commands.lifecycle import (
     OverlayCommand,
     PackCommand,
     PrimeCommand,
-    ProServices,
     PullCommand,
     StageCommand,
     get_lifecycle_command_group,
@@ -40,6 +39,7 @@ from craft_application.errors import (
     UbuntuProAttachedError,
     UbuntuProDetachedError,
 )
+from craft_application.util import ProServices
 from craft_cli import emit
 from craft_parts import Features
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -34,7 +34,8 @@ from craft_application.commands.lifecycle import (
     ProServices,
 )
 from craft_application.errors import (
-    InvalidUbuntuProServices,
+    InvalidUbuntuProStatus,
+    InvalidUbuntuProService,
     UbuntuProAttached,
     UbuntuProDetached,
 )
@@ -77,9 +78,9 @@ PRO_SERVICE_CONFIGS = [
     (True,                  ["esm-apps", "fips-updates"],["esm-apps", "fips-updates"],      None),
     (True,                  ["esm-apps"],                [],                                UbuntuProAttached),
     (False,                 [],                          ["esm-apps"],                      UbuntuProDetached),
-    (True,                  ["esm-apps", "fips-updates"],["fips-updates"],                  InvalidUbuntuProServices),
-    (True,                  ["esm-apps",],               ["fips-updates", "fips-updates"],  InvalidUbuntuProServices),
-
+    (True,                  ["esm-apps", "fips-updates"],["fips-updates"],                  InvalidUbuntuProStatus),
+    (True,                  ["esm-apps",],               ["fips-updates", "fips-updates"],  InvalidUbuntuProStatus),
+    (True,                  ["esm-apps"],                ["esm-apps", "invalid-service"],   InvalidUbuntuProService),
 ]
 
 STEP_NAMES = [step.name.lower() for step in craft_parts.Step]

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -28,16 +28,16 @@ from craft_application.commands.lifecycle import (
     OverlayCommand,
     PackCommand,
     PrimeCommand,
+    ProServices,
     PullCommand,
     StageCommand,
     get_lifecycle_command_group,
-    ProServices,
 )
 from craft_application.errors import (
-    InvalidUbuntuProStatus,
-    InvalidUbuntuProService,
-    UbuntuProAttached,
-    UbuntuProDetached,
+    InvalidUbuntuProServiceError,
+    InvalidUbuntuProStatusError,
+    UbuntuProAttachedError,
+    UbuntuProDetachedError,
 )
 from craft_cli import emit
 from craft_parts import Features
@@ -76,11 +76,11 @@ PRO_SERVICE_CONFIGS = [
     (False,                 [],                          [],                                None),
     (True,                  ["esm-apps"],                ["esm-apps"],                      None),
     (True,                  ["esm-apps", "fips-updates"],["esm-apps", "fips-updates"],      None),
-    (True,                  ["esm-apps"],                [],                                UbuntuProAttached),
-    (False,                 [],                          ["esm-apps"],                      UbuntuProDetached),
-    (True,                  ["esm-apps", "fips-updates"],["fips-updates"],                  InvalidUbuntuProStatus),
-    (True,                  ["esm-apps",],               ["fips-updates", "fips-updates"],  InvalidUbuntuProStatus),
-    (True,                  ["esm-apps"],                ["esm-apps", "invalid-service"],   InvalidUbuntuProService),
+    (True,                  ["esm-apps"],                [],                                UbuntuProAttachedError),
+    (False,                 [],                          ["esm-apps"],                      UbuntuProDetachedError),
+    (True,                  ["esm-apps", "fips-updates"],["fips-updates"],                  InvalidUbuntuProStatusError),
+    (True,                  ["esm-apps",],               ["fips-updates", "fips-updates"],  InvalidUbuntuProStatusError),
+    (True,                  ["esm-apps"],                ["esm-apps", "invalid-service"],   InvalidUbuntuProServiceError),
 ]
 
 STEP_NAMES = [step.name.lower() for step in craft_parts.Step]

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -131,7 +131,9 @@ def test_validate_pro_services(
     set_is_attached(is_attached)
     set_enabled_service(enabled_services)
 
-    exception_context = pytest.raises(expected_exception) if expected_exception else nullcontext()
+    exception_context = (
+        pytest.raises(expected_exception) if expected_exception else nullcontext()
+    )
 
     with exception_context:
         # create and validate pro services

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -17,6 +17,7 @@
 import argparse
 import pathlib
 import subprocess
+from contextlib import nullcontext
 
 import craft_parts
 import pytest
@@ -72,7 +73,7 @@ PRO_SERVICE_COMMANDS = [
 ]
 
 PRO_SERVICE_CONFIGS = [
-    # is_attached,           enabled_services,           proservices_args,                  expected_exception
+    # is_attached,           enabled_services,           pro_services_args,                  expected_exception
     (False,                 [],                          [],                                None),
     (True,                  ["esm-apps"],                ["esm-apps"],                      None),
     (True,                  ["esm-apps", "fips-updates"],["esm-apps", "fips-updates"],      None),
@@ -114,14 +115,14 @@ def get_fake_command_class(parent_cls, managed):
 
 
 @pytest.mark.parametrize(
-    ("is_attached", "enabled_services", "proservices_args", "expected_exception"),
+    ("is_attached", "enabled_services", "pro_services_args", "expected_exception"),
     PRO_SERVICE_CONFIGS,
 )
 def test_validate_pro_services(
     mock_pro_api_call,
     is_attached,
     enabled_services,
-    proservices_args,
+    pro_services_args,
     expected_exception,
 ):
 
@@ -130,13 +131,12 @@ def test_validate_pro_services(
     set_is_attached(is_attached)
     set_enabled_service(enabled_services)
 
-    try:
-        # create and validate pro services
-        proservices = ProServices(proservices_args)
-        proservices.validate()
+    exception_context = pytest.raises(expected_exception) if expected_exception else nullcontext()
 
-    except Exception as exc:
-        assert type(exc) is expected_exception
+    with exception_context:
+        # create and validate pro services
+        pro_services = ProServices(pro_services_args)
+        pro_services.validate()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -55,7 +55,7 @@ BUILD_ENV_COMMANDS = [
 
 # test paring --pro argument with various pro services, and whitespace
 PRO_SERVICE_COMMANDS = [
-    ({"pro": None}, []),
+    ({"pro": ProServices()}, []),
     ({"pro": ProServices(["fips-updates"])}, ["--pro", "fips-updates"]),
     (
         {"pro": ProServices(["fips-updates", "esm-infra"])},

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -41,7 +41,7 @@ from craft_application.errors import (
 from craft_cli import emit
 from craft_parts import Features
 
-# disable black reformat for improve readability on long paramterisations
+# disable black reformat for improve readability on long parameterisations
 # fmt: off
 
 PARTS_LISTS = [[], ["my-part"], ["my-part", "your-part"]]

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -677,7 +677,7 @@ def test_gets_project(
 
 
 def test_fails_without_project(
-    monkeypatch, capsys, tmp_path, app_metadata, fake_services
+    monkeypatch, capsys, tmp_path, app_metadata, fake_services, mock_pro_api_call
 ):
     monkeypatch.setattr(sys, "argv", ["testcraft", "prime"])
 
@@ -766,7 +766,11 @@ def test_pre_run_project_dir_success_unmanaged(app, fs, project_dir):
 
 
 @pytest.mark.parametrize("project_dir", ["relative/file", "/absolute/file"])
-def test_pre_run_project_dir_not_a_directory(app, fs, project_dir):
+def test_pre_run_project_dir_not_a_directory(
+    app,
+    fs,
+    project_dir,
+):
     fs.create_file(project_dir)
     dispatcher = mock.Mock(spec_set=craft_cli.Dispatcher)
     dispatcher.parsed_args.return_value.project_dir = project_dir
@@ -808,7 +812,7 @@ def test_run_success_unmanaged(
         emitter.assert_debug("Running testcraft pass on host")
 
 
-def test_run_success_managed(monkeypatch, app, fake_project, mocker):
+def test_run_success_managed(monkeypatch, app, fake_project, mocker, mock_pro_api_call):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
@@ -818,7 +822,9 @@ def test_run_success_managed(monkeypatch, app, fake_project, mocker):
     app.run_managed.assert_called_once_with(None, None)  # --build-for not used
 
 
-def test_run_success_managed_with_arch(monkeypatch, app, fake_project, mocker):
+def test_run_success_managed_with_arch(
+    monkeypatch, app, fake_project, mocker, mock_pro_api_call
+):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
     arch = get_host_architecture()
@@ -829,7 +835,9 @@ def test_run_success_managed_with_arch(monkeypatch, app, fake_project, mocker):
     app.run_managed.assert_called_once()
 
 
-def test_run_success_managed_with_platform(monkeypatch, app, fake_project, mocker):
+def test_run_success_managed_with_platform(
+    monkeypatch, app, fake_project, mocker, mock_pro_api_call
+):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull", "--platform=foo"])
@@ -858,7 +866,7 @@ def test_run_success_managed_with_platform(monkeypatch, app, fake_project, mocke
     ],
 )
 def test_run_passes_platforms(
-    monkeypatch, app, fake_project, mocker, params, expected_call
+    monkeypatch, app, fake_project, mocker, params, expected_call, mock_pro_api_call
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock(return_value=False)
@@ -878,7 +886,7 @@ def test_run_success_managed_inside_managed(
     mock_dispatcher,
     return_code,
     mocker,
-    mock_pro_api_call, 
+    mock_pro_api_call,
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     mocker.patch.object(

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -658,7 +658,9 @@ def test_craft_lib_log_level(app_metadata, fake_services):
         assert logger.level == logging.DEBUG
 
 
-def test_gets_project(monkeypatch, tmp_path, app_metadata, fake_services):
+def test_gets_project(
+    monkeypatch, tmp_path, app_metadata, fake_services, uaclient_mock
+):
     project_file = tmp_path / "testcraft.yaml"
     project_file.write_text(BASIC_PROJECT_YAML)
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull", "--destructive-mode"])
@@ -776,7 +778,14 @@ def test_pre_run_project_dir_not_a_directory(app, fs, project_dir):
 @pytest.mark.parametrize("load_project", [True, False])
 @pytest.mark.parametrize("return_code", [None, 0, 1])
 def test_run_success_unmanaged(
-    monkeypatch, emitter, check, app, fake_project, return_code, load_project
+    monkeypatch,
+    emitter,
+    check,
+    app,
+    fake_project,
+    return_code,
+    load_project,
+    uaclient_mock,
 ):
     class UnmanagedCommand(commands.AppCommand):
         name = "pass"
@@ -862,7 +871,14 @@ def test_run_passes_platforms(
 
 @pytest.mark.parametrize("return_code", [None, 0, 1])
 def test_run_success_managed_inside_managed(
-    monkeypatch, check, app, fake_project, mock_dispatcher, return_code, mocker
+    monkeypatch,
+    check,
+    app,
+    fake_project,
+    mock_dispatcher,
+    return_code,
+    mocker,
+    uaclient_mock,
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     mocker.patch.object(

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -785,7 +785,7 @@ def test_run_success_unmanaged(
     fake_project,
     return_code,
     load_project,
-    uaclient_mock,
+    uaclient_mock,  # noqa: ARG001
 ):
     class UnmanagedCommand(commands.AppCommand):
         name = "pass"
@@ -878,7 +878,7 @@ def test_run_success_managed_inside_managed(
     mock_dispatcher,
     return_code,
     mocker,
-    uaclient_mock,
+    uaclient_mock,  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     mocker.patch.object(

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -659,7 +659,11 @@ def test_craft_lib_log_level(app_metadata, fake_services):
 
 
 def test_gets_project(
-    monkeypatch, tmp_path, app_metadata, fake_services, mock_pro_api_call
+    monkeypatch,
+    tmp_path,
+    app_metadata,
+    fake_services,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     project_file = tmp_path / "testcraft.yaml"
     project_file.write_text(BASIC_PROJECT_YAML)
@@ -677,7 +681,12 @@ def test_gets_project(
 
 
 def test_fails_without_project(
-    monkeypatch, capsys, tmp_path, app_metadata, fake_services, mock_pro_api_call
+    monkeypatch,
+    capsys,
+    tmp_path,
+    app_metadata,
+    fake_services,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     monkeypatch.setattr(sys, "argv", ["testcraft", "prime"])
 
@@ -789,7 +798,7 @@ def test_run_success_unmanaged(
     fake_project,
     return_code,
     load_project,
-    mock_pro_api_call,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     class UnmanagedCommand(commands.AppCommand):
         name = "pass"
@@ -812,7 +821,9 @@ def test_run_success_unmanaged(
         emitter.assert_debug("Running testcraft pass on host")
 
 
-def test_run_success_managed(monkeypatch, app, fake_project, mocker, mock_pro_api_call):
+def test_run_success_managed(
+    monkeypatch, app, fake_project, mocker, mock_pro_api_call  # noqa: ARG001
+):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
@@ -823,7 +834,7 @@ def test_run_success_managed(monkeypatch, app, fake_project, mocker, mock_pro_ap
 
 
 def test_run_success_managed_with_arch(
-    monkeypatch, app, fake_project, mocker, mock_pro_api_call
+    monkeypatch, app, fake_project, mocker, mock_pro_api_call  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
@@ -836,7 +847,7 @@ def test_run_success_managed_with_arch(
 
 
 def test_run_success_managed_with_platform(
-    monkeypatch, app, fake_project, mocker, mock_pro_api_call
+    monkeypatch, app, fake_project, mocker, mock_pro_api_call  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
@@ -866,7 +877,13 @@ def test_run_success_managed_with_platform(
     ],
 )
 def test_run_passes_platforms(
-    monkeypatch, app, fake_project, mocker, params, expected_call, mock_pro_api_call
+    monkeypatch,
+    app,
+    fake_project,
+    mocker,
+    params,
+    expected_call,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock(return_value=False)
@@ -886,7 +903,7 @@ def test_run_success_managed_inside_managed(
     mock_dispatcher,
     return_code,
     mocker,
-    mock_pro_api_call,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     mocker.patch.object(

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -659,7 +659,7 @@ def test_craft_lib_log_level(app_metadata, fake_services):
 
 
 def test_gets_project(
-    monkeypatch, tmp_path, app_metadata, fake_services, uaclient_mock
+    monkeypatch, tmp_path, app_metadata, fake_services, mock_pro_api_call
 ):
     project_file = tmp_path / "testcraft.yaml"
     project_file.write_text(BASIC_PROJECT_YAML)
@@ -785,7 +785,7 @@ def test_run_success_unmanaged(
     fake_project,
     return_code,
     load_project,
-    uaclient_mock,  # noqa: ARG001
+    mock_pro_api_call,
 ):
     class UnmanagedCommand(commands.AppCommand):
         name = "pass"
@@ -878,7 +878,7 @@ def test_run_success_managed_inside_managed(
     mock_dispatcher,
     return_code,
     mocker,
-    uaclient_mock,  # noqa: ARG001
+    mock_pro_api_call, 
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     mocker.patch.object(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----



This PR contains changes to add Ubuntu Pro argument to craft-applications allowing pro services to be specified for lifecycle commands. Specified pro services are validated at run against uaclient.