### PR TITLE
fix(platform): automatically vectorise architectures

### DIFF
--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -93,6 +93,14 @@ class Platform(base.CraftBaseModel):
     build_on: UniqueList[str] | None = pydantic.Field(min_length=1)
     build_for: SingleEntryList[str] | None = None
 
+    @pydantic.field_validator("build_on", "build_for", mode="before")
+    @classmethod
+    def _vectorise_architectures(cls, values: str | list[str]) -> list[str]:
+        """Convert string build-on and build-for to lists."""
+        if isinstance(values, str):
+            return [values]
+        return values
+
     @pydantic.field_validator("build_on", "build_for", mode="after")
     @classmethod
     def _validate_architectures(cls, values: list[str]) -> list[str]:


### PR DESCRIPTION
This is a fix for https://github.com/canonical/charmcraft/issues/1874

The spec (ST105) allows `<list-of-arch> | <arch>` in both build-on and build-for on all craft apps. This change makes the Platform model accept a string value, but doesn't specify that in the schema. This means text editors using the schema will still suggest converting the build-on and build-for values to lists.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
