### PR TITLE
fix(models): coerce numbers to strings by default

### DIFF
--- a/craft_application/models/base.py
+++ b/craft_application/models/base.py
@@ -38,6 +38,7 @@ class CraftBaseModel(pydantic.BaseModel):
         extra="forbid",
         populate_by_name=True,
         alias_generator=alias_generator,
+        coerce_numbers_to_str=True,
     )
 
     def marshal(self) -> dict[str, str | list[str] | dict[str, Any]]:

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pydantic
 import pytest
 from craft_application import errors, models
+from hypothesis import given, strategies
 from overrides import override
 
 
@@ -58,3 +59,22 @@ def test_model_reference_slug_errors():
     )
     assert str(err.value) == expected
     assert err.value.doc_slug == "/mymodel.html"
+
+
+class CoerceModel(models.CraftBaseModel):
+
+    stringy: str
+
+
+@given(
+    strategies.one_of(
+        strategies.integers(),
+        strategies.floats(),
+        strategies.decimals(),
+        strategies.text(),
+    )
+)
+def test_model_coerces_to_strings(value):
+    result = CoerceModel.model_validate({"stringy": value})
+
+    assert result.stringy == str(value)


### PR DESCRIPTION
As seen in:

https://github.com/canonical/snapcraft/issues/4978 https://github.com/canonical/snapcraft/issues/5017

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
