### PR TITLE
docs(changelog): update 4.1.2 release notes

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -8,13 +8,20 @@ Changelog
 Application
 ===========
 
-- Managed runs now fail if the build plan is empty.
-- Error message tweaks for invalid YAML files.
+* Managed runs now fail if the build plan is empty.
+* Error message tweaks for invalid YAML files.
+
+Commands
+========
+
+* The ``pack`` command now accepts ``--shell`` and ``--shell-after``.
+* Using ``--debug`` for lifecycle commands will shell into the build
+  environment if the packing itself fails.
 
 Models
 ======
 
-- Platform models now correctly accept non-vectorised architectures.
+* Platform models now correctly accept non-vectorised architectures.
 
 For a complete list of commits, check out the `4.1.2`_ release on GitHub.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

@tigarmo noticed a missing entry in https://github.com/canonical/snapcraft/pull/5027.

Also changed bullet points `*` to match previous changelog entries.