### PR TITLE
ci: use the default version of lxd for integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,10 +60,6 @@ jobs:
             3.10
             3.12
           cache: 'pip'
-      - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.1
-        with:
-          channel: latest/stable
       - name: Configure environment
         run: |
           echo "::group::apt-get"
@@ -111,8 +107,6 @@ jobs:
           cache: 'pip'
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
-        with:
-          channel: latest/stable
       - name: Configure environment
         run: |
           echo "::group::Begin snap install"


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Related: https://github.com/canonical/charmcraft/pull/1888#discussion_r1754963336