### PR TITLE
fix: inject aliased snaps into build environment

### DIFF
--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -98,12 +98,16 @@ class ProviderService(base.ProjectService):
             self.environment[f"{scheme.upper()}_PROXY"] = value
 
         if self._install_snap:
-            channel = (
-                None
-                if util.is_running_from_snap(self._app.name)
-                else os.getenv("CRAFT_SNAP_CHANNEL", "latest/stable")
-            )
-            self.snaps.append(Snap(name=self._app.name, channel=channel, classic=True))
+            if util.is_running_from_snap(self._app.name):
+                # use the aliased name of the snap when injecting
+                name = os.getenv("SNAP_INSTANCE_NAME", self._app.name)
+                channel = None
+            else:
+                # use the snap name when installing from the store
+                name = self._app.name
+                channel = os.getenv("CRAFT_SNAP_CHANNEL", "latest/stable")
+
+            self.snaps.append(Snap(name=name, channel=channel, classic=True))
 
     @contextlib.contextmanager
     def instance(

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -116,14 +116,24 @@ def test_setup_proxy_environment(
             id="inject-from-host-ignore-channel",
         ),
         pytest.param(
-            # SNAP_INSTANCE_NAME may not exist if snapd < 2.43
+            # SNAP_INSTANCE_NAME may not exist if snapd < 2.43 or feature is disabled
             {
                 "SNAP_NAME": "testcraft",
                 "SNAP": "/snap/testcraft/x1",
-                "CRAFT_SNAP_CHANNEL": "something",
             },
             [Snap(name="testcraft", channel=None, classic=True)],
             id="missing-snap-instance-name",
+        ),
+        pytest.param(
+            # SNAP_INSTANCE_NAME may not exist if snapd < 2.43 or feature is disabled
+            {
+                "SNAP_NAME": "testcraft",
+                "SNAP": "/snap/testcraft/x1",
+                # CRAFT_SNAP_CHANNEL should be ignored
+                "CRAFT_SNAP_CHANNEL": "something",
+            },
+            [Snap(name="testcraft", channel=None, classic=True)],
+            id="missing-snap-instance-name-ignore-snap-channel",
         ),
         pytest.param(
             # this can happen when running testcraft from a venv in a snapped terminal

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -84,41 +84,60 @@ def test_setup_proxy_environment(
 
 
 @pytest.mark.parametrize(
-    ("install_snap", "environment", "snaps"),
+    ("environment", "snaps"),
     [
-        (True, {}, [Snap(name="testcraft", channel="latest/stable", classic=True)]),
-        (
-            True,
+        pytest.param(
+            {},
+            [Snap(name="testcraft", channel="latest/stable", classic=True)],
+            id="install-from-store-default-channel",
+        ),
+        pytest.param(
             {"CRAFT_SNAP_CHANNEL": "something"},
             [Snap(name="testcraft", channel="something", classic=True)],
+            id="install-from-store-with-channel",
         ),
-        (
-            True,
-            {"SNAP_NAME": "testcraft", "SNAP": "/snap/testcraft/x1"},
-            [Snap(name="testcraft", channel=None, classic=True)],
+        pytest.param(
+            {
+                "SNAP_NAME": "testcraft",
+                "SNAP_INSTANCE_NAME": "testcraft_1",
+                "SNAP": "/snap/testcraft/x1",
+            },
+            [Snap(name="testcraft_1", channel=None, classic=True)],
+            id="inject-from-host",
         ),
-        (
-            True,
+        pytest.param(
+            {
+                "SNAP_NAME": "testcraft",
+                "SNAP_INSTANCE_NAME": "testcraft_1",
+                "SNAP": "/snap/testcraft/x1",
+                "CRAFT_SNAP_CHANNEL": "something",
+            },
+            [Snap(name="testcraft_1", channel=None, classic=True)],
+            id="inject-from-host-ignore-channel",
+        ),
+        pytest.param(
+            # SNAP_INSTANCE_NAME may not exist if snapd < 2.43
             {
                 "SNAP_NAME": "testcraft",
                 "SNAP": "/snap/testcraft/x1",
                 "CRAFT_SNAP_CHANNEL": "something",
             },
             [Snap(name="testcraft", channel=None, classic=True)],
+            id="missing-snap-instance-name",
         ),
-        (False, {}, []),
-        (False, {"CRAFT_SNAP_CHANNEL": "something"}, []),
-        (
-            False,
+        pytest.param(
+            # this can happen when running testcraft from a venv in a snapped terminal
             {
-                "SNAP_NAME": "testcraft",
-                "SNAP": "/snap/testcraft/x1",
-                "CRAFT_SNAP_CHANNEL": "something",
+                "SNAP_NAME": "kitty",
+                "SNAP_INSTANCE_NAME": "kitty",
+                "SNAP": "/snap/kitty/x1",
             },
-            [],
+            [Snap(name="testcraft", channel="latest/stable", classic=True)],
+            id="running-inside-another-snap",
         ),
     ],
 )
+@pytest.mark.parametrize("install_snap", [True, False])
 def test_install_snap(
     monkeypatch,
     app_metadata,
@@ -143,7 +162,10 @@ def test_install_snap(
     )
     service.setup()
 
-    assert service.snaps == snaps
+    if install_snap:
+        assert service.snaps == snaps
+    else:
+        assert service.snaps == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Inject snaps into the build environment using their aliased name.

I tested and confirmed this works with the reproducer in https://github.com/canonical/snapcraft/issues/4683.

However, I tested with a locally built snap, so it had no assertions.  The secondary failure in craft-providers with [`snap ack`](https://github.com/canonical/snapcraft/issues/4683#issuecomment-2344242230) will probably start occurring when testing with a signed snap from the store.

The craft-providers fix is probably changing [this line](https://github.com/canonical/craft-providers/blob/262978901d49e5c16668d8f0bc251b185837cee9/craft_providers/actions/snap_installer.py#L262) to `snap_name.split('_')[0]`.  

Fixes #411