### PR TITLE
 feat: wipe existing instances when using the fetch-service

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -371,7 +371,9 @@ class Application:
             instance_path = pathlib.PosixPath("/root/project")
 
             with self.services.provider.instance(
-                build_info, work_dir=self._work_dir
+                build_info,
+                work_dir=self._work_dir,
+                clean_existing=self._use_fetch_service,
             ) as instance:
                 if self._use_fetch_service:
                     session_env = self.services.fetch.create_session(instance)

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -112,6 +112,7 @@ class ProviderService(base.ProjectService):
         *,
         work_dir: pathlib.Path,
         allow_unstable: bool = True,
+        clean_existing: bool = False,
         **kwargs: bool | str | None,
     ) -> Generator[craft_providers.Executor, None, None]:
         """Context manager for getting a provider instance.
@@ -119,6 +120,8 @@ class ProviderService(base.ProjectService):
         :param build_info: Build information for the instance.
         :param work_dir: Local path to mount inside the provider instance.
         :param allow_unstable: Whether to allow the use of unstable images.
+        :param clean_existing: Whether pre-existing instances should be wiped
+          and re-created.
         :returns: a context manager of the provider instance.
         """
         instance_name = self._get_instance_name(work_dir, build_info)
@@ -128,6 +131,9 @@ class ProviderService(base.ProjectService):
         provider = self.get_provider(name=self.__provider_name)
 
         provider.ensure_provider_is_available()
+
+        if clean_existing:
+            self._clean_instance(provider, work_dir, build_info)
 
         emit.progress(f"Launching managed {base_name[0]} {base_name[1]} instance...")
         with provider.launched_environment(
@@ -263,9 +269,7 @@ class ProviderService(base.ProjectService):
             emit.progress(f"Cleaning build {target}")
 
         for info in build_plan:
-            instance_name = self._get_instance_name(self._work_dir, info)
-            emit.debug(f"Cleaning instance {instance_name}")
-            provider.clean_project_environments(instance_name=instance_name)
+            self._clean_instance(provider, self._work_dir, info)
 
     def _get_instance_name(
         self, work_dir: pathlib.Path, build_info: models.BuildInfo
@@ -328,3 +332,14 @@ class ProviderService(base.ProjectService):
             content=io.BytesIO(bashrc),
             file_mode="644",
         )
+
+    def _clean_instance(
+        self,
+        provider: craft_providers.Provider,
+        work_dir: pathlib.Path,
+        info: models.BuildInfo,
+    ) -> None:
+        """Clean an instance, if it exists."""
+        instance_name = self._get_instance_name(work_dir, info)
+        emit.debug(f"Cleaning instance {instance_name}")
+        provider.clean_project_environments(instance_name=instance_name)

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -30,6 +30,18 @@ from craft_providers import bases, lxd, multipass
 from craft_providers.actions.snap_installer import Snap
 
 
+@pytest.fixture
+def mock_provider(monkeypatch, provider_service):
+    mocked_provider = mock.MagicMock(spec=craft_providers.Provider)
+    monkeypatch.setattr(
+        provider_service,
+        "get_provider",
+        lambda name: mocked_provider,  # noqa: ARG005 (unused argument)
+    )
+
+    return mocked_provider
+
+
 @pytest.mark.parametrize(
     ("given_environment", "expected_environment"),
     [
@@ -384,7 +396,6 @@ def test_get_base_packages(provider_service):
     ],
 )
 def test_instance(
-    monkeypatch,
     check,
     emitter,
     tmp_path,
@@ -393,13 +404,8 @@ def test_instance(
     provider_service,
     base_name,
     allow_unstable,
+    mock_provider,
 ):
-    mock_provider = mock.MagicMock(spec=craft_providers.Provider)
-    monkeypatch.setattr(
-        provider_service,
-        "get_provider",
-        lambda name: mock_provider,  # noqa: ARG005 (unused argument)
-    )
     arch = util.get_host_architecture()
     build_info = models.BuildInfo("foo", arch, arch, base_name)
 
@@ -427,6 +433,33 @@ def test_instance(
         )
     with check:
         emitter.assert_progress("Launching managed .+ instance...", regex=True)
+
+
+@pytest.mark.parametrize("clean_existing", [True, False])
+def test_instance_clean_existing(
+    tmp_path,
+    provider_service,
+    mock_provider,
+    clean_existing,
+):
+    arch = util.get_host_architecture()
+    base_name = bases.BaseName("ubuntu", "24.04")
+    build_info = models.BuildInfo("foo", arch, arch, base_name)
+
+    with provider_service.instance(
+        build_info, work_dir=tmp_path, clean_existing=clean_existing
+    ) as _instance:
+        pass
+
+    clean_called = mock_provider.clean_project_environments.called
+    assert clean_called == clean_existing
+
+    if clean_existing:
+        work_dir_inode = tmp_path.stat().st_ino
+        expected_name = f"testcraft-full-project-on-{arch}-for-{arch}-{work_dir_inode}"
+        mock_provider.clean_project_environments.assert_called_once_with(
+            instance_name=expected_name
+        )
 
 
 def test_load_bashrc(emitter):

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -485,6 +485,7 @@ def test_run_managed_success(mocker, app, fake_project, fake_build_plan):
         mock.call(
             fake_build_plan[0],
             work_dir=mock.ANY,
+            clean_existing=False,
         )
         in mock_provider.instance.mock_calls
     )
@@ -543,8 +544,12 @@ def test_run_managed_multiple(app, fake_project):
 
     app.run_managed(None, None)
 
-    assert mock.call(info2, work_dir=mock.ANY) in mock_provider.instance.mock_calls
-    assert mock.call(info1, work_dir=mock.ANY) in mock_provider.instance.mock_calls
+    extra_args = {
+        "work_dir": mock.ANY,
+        "clean_existing": False,
+    }
+    assert mock.call(info2, **extra_args) in mock_provider.instance.mock_calls
+    assert mock.call(info1, **extra_args) in mock_provider.instance.mock_calls
 
 
 def test_run_managed_specified_arch(app, fake_project):
@@ -559,8 +564,12 @@ def test_run_managed_specified_arch(app, fake_project):
 
     app.run_managed(None, "arch2")
 
-    assert mock.call(info2, work_dir=mock.ANY) in mock_provider.instance.mock_calls
-    assert mock.call(info1, work_dir=mock.ANY) not in mock_provider.instance.mock_calls
+    extra_args = {
+        "work_dir": mock.ANY,
+        "clean_existing": False,
+    }
+    assert mock.call(info2, **extra_args) in mock_provider.instance.mock_calls
+    assert mock.call(info1, **extra_args) not in mock_provider.instance.mock_calls
 
 
 def test_run_managed_specified_platform(app, fake_project):
@@ -575,8 +584,12 @@ def test_run_managed_specified_platform(app, fake_project):
 
     app.run_managed("a2", None)
 
-    assert mock.call(info2, work_dir=mock.ANY) in mock_provider.instance.mock_calls
-    assert mock.call(info1, work_dir=mock.ANY) not in mock_provider.instance.mock_calls
+    extra_args = {
+        "work_dir": mock.ANY,
+        "clean_existing": False,
+    }
+    assert mock.call(info2, **extra_args) in mock_provider.instance.mock_calls
+    assert mock.call(info1, **extra_args) not in mock_provider.instance.mock_calls
 
 
 def test_run_managed_empty_plan(app, fake_project):


### PR DESCRIPTION
This is necessary because the fetch-service needs visibility on *all* assets
downloaded during a build, so pre-existing instances that might already have
existing items cannot be re-used.

There are two commits: the first one adds the feature to wipe existing instances,
and the second one uses said feature when the fetch-service integration is enabled.

Fixes #40
