### PR TITLE
feat: set the fetch-service to idle shutdown

### DIFF
--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -184,6 +184,9 @@ def start_service() -> subprocess.Popen[str] | None:
     # Accept permissive sessions
     cmd.append("--permissive-mode")
 
+    # Shutdown after 5 minutes with no live sessions
+    cmd.append("--idle-shutdown=300")
+
     log_filepath = _get_log_filepath()
     log_filepath.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -136,6 +136,7 @@ def test_start_service(mocker, tmp_path):
                     f"--cert={fake_cert}",
                     f"--key={fake_key}",
                     "--permissive-mode",
+                    "--idle-shutdown=300",
                 ]
             )
             + f" > {fetch._get_log_filepath()}",


### PR DESCRIPTION
Set it to shutdown after 5 minutes of no live sessions.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
