### PR TITLE
refactor: subclass remote-build errors from CraftError

### DIFF
--- a/craft_application/remote/errors.py
+++ b/craft_application/remote/errors.py
@@ -14,63 +14,41 @@
 
 """Remote build errors."""
 
-from dataclasses import dataclass
+import craft_cli.errors
+
+from craft_application.util import humanize_list
 
 
-@dataclass(repr=True)
-class RemoteBuildError(Exception):
-    """Unexpected remote build error.
-
-    :param brief: Brief description of error.
-    :param details: Detailed information.
-    """
-
-    brief: str
-    details: str | None = None
-
-    def __str__(self) -> str:
-        """Return the string representation of the error."""
-        components = [self.brief]
-
-        if self.details:
-            components.append(self.details)
-
-        return "\n".join(components)
+class RemoteBuildError(craft_cli.errors.CraftError):
+    """Error for remote builds."""
 
 
 class RemoteBuildGitError(RemoteBuildError):
-    """Git repository cannot be prepared correctly."""
+    """Git repository cannot be prepared correctly.
+
+    :param message: Git error message.
+    """
 
     def __init__(self, message: str) -> None:
-        self.message = message
-        brief = "Git operation failed"
-        details = message
-
-        super().__init__(brief=brief, details=details)
+        message = f"Git operation failed with: {message}"
+        super().__init__(message=message)
 
 
 class UnsupportedArchitectureError(RemoteBuildError):
-    """Unsupported architecture error."""
+    """Unsupported architecture error.
+
+    :param architectures: List of unsupported architectures.
+    """
 
     def __init__(self, architectures: list[str]) -> None:
-        brief = "Architecture not supported by the remote builder."
-        details = (
+        message = (
             "The following architectures are not supported by the remote builder: "
-            f"{architectures}.\nPlease remove them from the "
-            "architecture list and try again."
+            f"{humanize_list(architectures, 'and')}."
         )
+        resolution = "Remove them from the architecture list and try again."
 
-        super().__init__(brief=brief, details=details)
+        super().__init__(message=message, resolution=resolution)
 
 
 class RemoteBuildInvalidGitRepoError(RemoteBuildError):
-    """The Git repository is invalid for remote build.
-
-    :param brief: Brief description of error.
-    :param details: Detailed information.
-    """
-
-    def __init__(self, details: str) -> None:
-        brief = "The Git repository is invalid for remote build."
-
-        super().__init__(brief=brief, details=details)
+    """The Git repository is invalid for remote build."""

--- a/craft_application/remote/git.py
+++ b/craft_application/remote/git.py
@@ -32,10 +32,12 @@ def check_git_repo_for_remote_build(path: Path) -> None:
 
     if git_type == GitType.INVALID:
         raise RemoteBuildInvalidGitRepoError(
-            f"Could not find a git repository in {str(path)!r}"
+            message=f"Could not find a git repository in {str(path)!r}",
+            resolution="Initialize a git repository in the project directory",
         )
 
     if git_type == GitType.SHALLOW:
         raise RemoteBuildInvalidGitRepoError(
-            "Remote build for shallow cloned git repos are no longer supported"
+            message="Remote builds for shallow cloned git repos are not supported",
+            resolution="Make a non-shallow clone of the repository",
         )

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,16 @@
 Changelog
 *********
 
+4.2.4 (2024-Sep-19)
+-------------------
+
+Remote build
+============
+
+- Remote build errors are now a subclass of ``CraftError``.
+
+For a complete list of commits, check out the `4.2.4`_ release on GitHub.
+
 4.2.3 (2024-Sep-18)
 -------------------
 
@@ -278,3 +288,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _4.2.1: https://github.com/canonical/craft-application/releases/tag/4.2.1
 .. _4.2.2: https://github.com/canonical/craft-application/releases/tag/4.2.2
 .. _4.2.3: https://github.com/canonical/craft-application/releases/tag/4.2.3
+.. _4.2.4: https://github.com/canonical/craft-application/releases/tag/4.2.4

--- a/tests/unit/git/test_git.py
+++ b/tests/unit/git/test_git.py
@@ -894,6 +894,6 @@ def test_check_git_repo_for_remote_build_shallow(empty_working_directory):
 
     with pytest.raises(
         RemoteBuildInvalidGitRepoError,
-        match="Remote build for shallow cloned git repos are no longer supported",
+        match="Remote builds for shallow cloned git repos are not supported",
     ):
         check_git_repo_for_remote_build(git_shallow_path)

--- a/tests/unit/remote/test_errors.py
+++ b/tests/unit/remote/test_errors.py
@@ -15,25 +15,21 @@
 from craft_application.remote import errors
 
 
+def test_git_error():
+    """Test RemoteBuildGitError."""
+    error = errors.RemoteBuildGitError(message="failed to push some refs to 'unknown'")
+
+    assert (
+        str(error) == "Git operation failed with: failed to push some refs to 'unknown'"
+    )
+
+
 def test_unsupported_architecture_error():
     """Test UnsupportedArchitectureError."""
     error = errors.UnsupportedArchitectureError(architectures=["amd64", "arm64"])
 
     assert str(error) == (
-        "Architecture not supported by the remote builder.\nThe following "
-        "architectures are not supported by the remote builder: ['amd64', 'arm64'].\n"
-        "Please remove them from the architecture list and try again."
-    )
-    assert repr(error) == (
-        "UnsupportedArchitectureError(brief='Architecture not supported by the remote "
-        "builder.', details=\"The following architectures are not supported by the "
-        "remote builder: ['amd64', 'arm64'].\\nPlease remove them from the "
-        'architecture list and try again.")'
-    )
-
-    assert error.brief == "Architecture not supported by the remote builder."
-    assert error.details == (
         "The following architectures are not supported by the remote builder: "
-        "['amd64', 'arm64'].\nPlease remove them from the architecture list and "
-        "try again."
+        "'amd64' and 'arm64'."
     )
+    assert error.resolution == "Remove them from the architecture list and try again."

--- a/tests/unit/remote/test_git.py
+++ b/tests/unit/remote/test_git.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Remote-build git tests."""
+
+import pytest
+from craft_application.git import GitType
+from craft_application.remote import errors, git
+
+
+@pytest.fixture
+def mock_get_git_repo_type(mocker):
+    return mocker.patch("craft_application.remote.git.get_git_repo_type")
+
+
+def test_git_normal(tmp_path, mock_get_git_repo_type):
+    """No-op for a normal git repo."""
+    mock_get_git_repo_type.return_value = GitType.NORMAL
+
+    assert git.check_git_repo_for_remote_build(tmp_path) is None
+
+
+def test_git_invalid_error(tmp_path, mock_get_git_repo_type):
+    """Raise an error for invalid git repos."""
+    mock_get_git_repo_type.return_value = GitType.INVALID
+
+    with pytest.raises(errors.RemoteBuildInvalidGitRepoError) as err:
+        git.check_git_repo_for_remote_build(tmp_path)
+
+    assert str(err.value) == f"Could not find a git repository in {str(tmp_path)!r}"
+    assert (
+        err.value.resolution == "Initialize a git repository in the project directory"
+    )
+
+
+def test_git_shallow_clone_error(tmp_path, mock_get_git_repo_type):
+    """Raise an error for shallowly cloned repos."""
+    mock_get_git_repo_type.return_value = GitType.SHALLOW
+
+    with pytest.raises(errors.RemoteBuildInvalidGitRepoError) as err:
+        git.check_git_repo_for_remote_build(tmp_path)
+
+    assert (
+        str(err.value) == "Remote builds for shallow cloned git repos are not supported"
+    )
+    assert err.value.resolution == "Make a non-shallow clone of the repository"

--- a/tests/unit/remote/test_utils.py
+++ b/tests/unit/remote/test_utils.py
@@ -25,6 +25,7 @@ from craft_application.remote import (
     validate_architectures,
 )
 from craft_application.remote.utils import _SUPPORTED_ARCHS
+from craft_application.util import humanize_list
 
 ###############################
 # validate architecture tests #
@@ -57,7 +58,7 @@ def test_validate_architectures_error(archs, expected_archs):
 
     assert (
         "The following architectures are not supported by the remote builder: "
-        f"{expected_archs}"
+        f"{humanize_list(expected_archs, 'and')}"
     ) in str(raised.value)
 
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

1. Refactor `RemoteBuild` errors to subclass `CraftError`
2. Slight changes to how remote build error are presented (moving information from `details` to `brief`)
3. Release notes for 4.2.4

Unblocks https://github.com/canonical/snapcraft/issues/4908
(CRAFT-3101)