### PR TITLE
feat: support "--platform" for "clean"

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -436,6 +436,12 @@ class CleanCommand(_BaseLifecycleCommand):
             nargs="*",
             help="Optional list of parts to process",
         )
+        parser.add_argument(
+            "--platform",
+            type=str,
+            metavar="name",
+            help="Platform to clean",
+        )
 
     @override
     def _run(

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 *********
 
+X.Y.Z (yyyy-mmm-dd)
+-------------------
+
+Commands
+========
+
+- The ``clean`` command now supports the ``--platform`` argument to filter
+  which build environments to clean.
+
 4.2.4 (2024-Sep-19)
 -------------------
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -26,6 +26,7 @@ import re
 import subprocess
 import sys
 import textwrap
+from io import StringIO
 from textwrap import dedent
 from typing import Any
 from unittest import mock
@@ -39,6 +40,7 @@ import pydantic
 import pytest
 import pytest_check
 from craft_application import (
+    ProviderService,
     application,
     commands,
     errors,
@@ -2104,3 +2106,38 @@ def test_emitter_docs_url(monkeypatch, mocker, app):
         app.run()
 
     assert spied_init.mock_calls[0].kwargs["docs_base_url"] == expected_url
+
+
+def test_clean_platform(monkeypatch, tmp_path, app_metadata, fake_services, mocker):
+    """Test that calling "clean --platform=x" correctly filters the build plan."""
+    data = util.safe_yaml_load(StringIO(BASIC_PROJECT_YAML))
+    # Put a few different platforms on the project
+    arch = util.get_host_architecture()
+    build_on_for = {
+        "build-on": [arch],
+        "build-for": [arch],
+    }
+    data["platforms"] = {
+        "plat1": build_on_for,
+        "plat2": build_on_for,
+        "plat3": build_on_for,
+    }
+    project_file = tmp_path / "testcraft.yaml"
+    project_file.write_text(util.dump_yaml(data))
+    monkeypatch.setattr(sys, "argv", ["testcraft", "clean", "--platform=plat2"])
+
+    mocked_clean = mocker.patch.object(ProviderService, "_clean_instance")
+    app = FakeApplication(app_metadata, fake_services)
+    app.project_dir = tmp_path
+
+    fake_services.project = None
+
+    app.run()
+
+    expected_info = models.BuildInfo(
+        platform="plat2",
+        build_on=arch,
+        build_for=arch,
+        base=bases.BaseName("ubuntu", "24.04"),
+    )
+    mocked_clean.assert_called_once_with(mocker.ANY, mocker.ANY, expected_info)


### PR DESCRIPTION
This brings 'clean' closer to parity with the other lifecycle commands, and is useful for cases where we want to wipe one of the managed instances, but not all of them.

Fixes #425

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
