### PR TITLE
feat: set GOPROXY=direct in fetch-service runs

### DIFF
--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -104,6 +104,8 @@ class NetInfo:
             "REQUESTS_CA_BUNDLE": str(_FETCH_CERT_INSTANCE_PATH),
             # Same, but for cargo.
             "CARGO_HTTP_CAINFO": str(_FETCH_CERT_INSTANCE_PATH),
+            # Have go download directly from repositories
+            "GOPROXY": "direct",
         }
 
 

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -234,6 +234,7 @@ def test_configure_build_instance(mocker):
         "https_proxy": expected_proxy,
         "REQUESTS_CA_BUNDLE": "/usr/local/share/ca-certificates/local-ca.crt",
         "CARGO_HTTP_CAINFO": "/usr/local/share/ca-certificates/local-ca.crt",
+        "GOPROXY": "direct",
     }
 
     env = fetch.configure_instance(instance, session_data)


### PR DESCRIPTION
The value makes Go download directly from version-controlled repositories, instead of module proxies like the default https://proxy.golang.org. It's currently a requirement for the Go inspector.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
