### PR TITLE
feat: allow strict/permissive fetch-service sessions

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -520,10 +520,10 @@ class Application:
                     resolution="Ensure the path entered is correct.",
                 )
 
-        use_fetch_service: str | None = getattr(args, "use_fetch_service", None)
-        if use_fetch_service:
+        fetch_service_policy: str | None = getattr(args, "fetch_service_policy", None)
+        if fetch_service_policy:
             self._use_fetch_service = True
-            self._fetch_service_session = use_fetch_service
+            self._fetch_service_policy = fetch_service_policy
 
     def get_arg_or_config(
         self, parsed_args: argparse.Namespace, item: str

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -158,6 +158,8 @@ class Application:
 
         # Whether the command execution should use the fetch-service
         self._use_fetch_service = False
+        # The kind of sessions that the fetch-service service should create
+        self._fetch_service_policy = "strict"
 
     @property
     def app_config(self) -> dict[str, Any]:
@@ -244,6 +246,7 @@ class Application:
         self.services.update_kwargs(
             "fetch",
             build_plan=self._build_plan,
+            session_policy=self._fetch_service_policy,
         )
 
     def _resolve_project_path(self, project_dir: pathlib.Path | None) -> pathlib.Path:
@@ -517,7 +520,10 @@ class Application:
                     resolution="Ensure the path entered is correct.",
                 )
 
-        self._use_fetch_service = getattr(args, "use_fetch_service", False)
+        use_fetch_service: str | None = getattr(args, "use_fetch_service", None)
+        if use_fetch_service:
+            self._use_fetch_service = True
+            self._fetch_service_session = use_fetch_service
 
     def get_arg_or_config(
         self, parsed_args: argparse.Namespace, item: str

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -357,8 +357,9 @@ class PackCommand(LifecycleCommand):
 
         parser.add_argument(
             "--use-fetch-service",
-            action="store_true",
             help="Use the Fetch Service to inspect downloaded assets.",
+            choices=("strict", "permissive"),
+            metavar="policy",
         )
 
     @override

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -360,6 +360,7 @@ class PackCommand(LifecycleCommand):
             help="Use the Fetch Service to inspect downloaded assets.",
             choices=("strict", "permissive"),
             metavar="policy",
+            dest="fetch_service_policy",
         )
 
     @override
@@ -399,7 +400,7 @@ class PackCommand(LifecycleCommand):
                 _launch_shell()
             raise
 
-        if parsed_args.use_fetch_service and packages:
+        if parsed_args.fetch_service_policy and packages:
             self._services.fetch.create_project_manifest(packages)
 
         if not packages:

--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -257,13 +257,13 @@ def stop_service(fetch_process: subprocess.Popen[str]) -> None:
         os.killpg(os.getpgid(fetch_process.pid), signal.SIGKILL)
 
 
-def create_session() -> SessionData:
+def create_session(*, strict: bool) -> SessionData:
     """Create a new fetch-service session.
 
+    :param strict: Whether the created session should be strict.
     :return: a SessionData object containing the session's id and token.
     """
-    # For now we'll always create permissive (as opposed to strict) sessions.
-    json = {"policy": "permissive"}
+    json = {"policy": "strict" if strict else "permissive"}
     data = _service_request("post", "session", json=json).json()
 
     return SessionData.unmarshal(data=data)

--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -63,11 +63,18 @@ class FetchService(services.ProjectService):
         *,
         project: models.Project,
         build_plan: list[models.BuildInfo],
+        session_policy: str,
     ) -> None:
+        """Create a new FetchService.
+
+        :param session_policy: Whether the created fetch-service sessions should
+          be "strict" or "permissive".
+        """
         super().__init__(app, services, project=project)
         self._fetch_process = None
         self._session_data = None
         self._build_plan = build_plan
+        self._session_policy = session_policy
         self._instance = None
 
     @override
@@ -87,7 +94,8 @@ class FetchService(services.ProjectService):
                 "create_session() called but there's already a live fetch-service session."
             )
 
-        self._session_data = fetch.create_session()
+        strict_session = self._session_policy == "strict"
+        self._session_data = fetch.create_session(strict=strict_session)
         self._instance = instance
         return fetch.configure_instance(instance, self._session_data)
 

--- a/tests/integration/services/test_fetch.py
+++ b/tests/integration/services/test_fetch.py
@@ -78,7 +78,11 @@ def mock_instance():
 @pytest.fixture
 def app_service(app_metadata, fake_services, fake_project, fake_build_plan):
     fetch_service = services.FetchService(
-        app_metadata, fake_services, project=fake_project, build_plan=fake_build_plan
+        app_metadata,
+        fake_services,
+        project=fake_project,
+        build_plan=fake_build_plan,
+        session_policy="permissive",
     )
     yield fetch_service
     fetch_service.shutdown(force=True)

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -433,7 +433,7 @@ def test_pack_fill_parser(
         "platform": None,
         "build_for": None,
         "output": pathlib.Path(output_arg),
-        "use_fetch_service": None,
+        "fetch_service_policy": None,
         **shell_dict,
         **debug_dict,
         **build_env_dict,
@@ -467,7 +467,7 @@ def test_pack_run(
 ):
     mock_services.package.pack.return_value = packages
     parsed_args = argparse.Namespace(
-        parts=parts, output=tmp_path, use_fetch_service=False
+        parts=parts, output=tmp_path, fetch_service_policy=None
     )
     command = PackCommand(
         {
@@ -487,16 +487,16 @@ def test_pack_run(
 
 
 @pytest.mark.parametrize(
-    ("use_fetch_service", "expect_create_called"),
+    ("fetch_service_policy", "expect_create_called"),
     [("strict", True), ("permissive", True), (None, False)],
 )
 def test_pack_fetch_manifest(
-    mock_services, app_metadata, tmp_path, use_fetch_service, expect_create_called
+    mock_services, app_metadata, tmp_path, fetch_service_policy, expect_create_called
 ):
     packages = [pathlib.Path("package.zip")]
     mock_services.package.pack.return_value = packages
     parsed_args = argparse.Namespace(
-        output=tmp_path, use_fetch_service=use_fetch_service
+        output=tmp_path, fetch_service_policy=fetch_service_policy
     )
     command = PackCommand(
         {
@@ -626,7 +626,7 @@ def test_shell_after_pack(
     mock_subprocess_run,
 ):
     parsed_args = argparse.Namespace(
-        shell_after=True, output=pathlib.Path(), use_fetch_service=False
+        shell_after=True, output=pathlib.Path(), fetch_service_policy=None
     )
     mock_lifecycle_run = mocker.patch.object(fake_services.lifecycle, "run")
     mock_pack = mocker.patch.object(fake_services.package, "pack")

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -433,7 +433,7 @@ def test_pack_fill_parser(
         "platform": None,
         "build_for": None,
         "output": pathlib.Path(output_arg),
-        "use_fetch_service": False,
+        "use_fetch_service": None,
         **shell_dict,
         **debug_dict,
         **build_env_dict,
@@ -487,7 +487,8 @@ def test_pack_run(
 
 
 @pytest.mark.parametrize(
-    ("use_fetch_service", "expect_create_called"), [(True, True), (False, False)]
+    ("use_fetch_service", "expect_create_called"),
+    [("strict", True), ("permissive", True), (None, False)],
 )
 def test_pack_fetch_manifest(
     mock_services, app_metadata, tmp_path, use_fetch_service, expect_create_called

--- a/tests/unit/services/test_fetch.py
+++ b/tests/unit/services/test_fetch.py
@@ -47,7 +47,11 @@ def fetch_service(app, fake_services, fake_project):
         base=bases.BaseName("ubuntu", "24.04"),
     )
     return services.FetchService(
-        app, fake_services, project=fake_project, build_plan=[build_info]
+        app,
+        fake_services,
+        project=fake_project,
+        build_plan=[build_info],
+        session_policy="strict",
     )
 
 

--- a/tests/unit/test_application_fetch.py
+++ b/tests/unit/test_application_fetch.py
@@ -64,7 +64,7 @@ class FakeFetchService(services.FetchService):
         ),
         # --use-fetch-service: full expected calls to the FetchService
         (
-            ["--use-fetch-service"],
+            ["--use-fetch-service", "strict"],
             [
                 # One call to setup
                 "setup",

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -170,16 +170,19 @@ def test_start_service_not_installed(mocker):
 
 
 @assert_requests
-def test_create_session():
+@pytest.mark.parametrize(
+    ("strict", "expected_policy"), [(True, "strict"), (False, "permissive")]
+)
+def test_create_session(strict, expected_policy):
     responses.add(
         responses.POST,
         f"http://localhost:{CONTROL}/session",
         json={"id": "my-session-id", "token": "my-session-token"},
         status=200,
-        match=[matchers.json_params_matcher({"policy": "permissive"})],
+        match=[matchers.json_params_matcher({"policy": expected_policy})],
     )
 
-    session_data = fetch.create_session()
+    session_data = fetch.create_session(strict=strict)
 
     assert session_data.session_id == "my-session-id"
     assert session_data.token == "my-session-token"


### PR DESCRIPTION
'--use-fetch-service' now takes a mandatory argument defining the type of session to use: "strict" or "permissive".

Fixes #487

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
