### PR TITLE
build(deps): loosen requests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ dependencies = [
     # Pygit2 changelog: https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md
     "pygit2>=1.13.0,<1.15.0",
     "PyYaml>=6.0",
-    # see https://github.com/psf/requests/issues/6707
-    "requests<2.32",
+    "requests",
     "typing_extensions>=4.4.0",
 ]
 classifiers = [


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

The relevant requests bug has been fixed, and this combines with upstream changes to let us use a newer requests.