### PR TITLE
feat: mark the fetch-service integration as experimental

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -14,20 +14,18 @@
 """Basic lifecycle commands for a Craft Application."""
 from __future__ import annotations
 
+import argparse
 import os
 import pathlib
 import subprocess
 import textwrap
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from craft_cli import CommandGroup, emit
 from craft_parts.features import Features
 from typing_extensions import override
 
 from craft_application.commands import base
-
-if TYPE_CHECKING:  # pragma: no cover
-    import argparse
 
 
 def get_lifecycle_command_group() -> CommandGroup:
@@ -357,7 +355,7 @@ class PackCommand(LifecycleCommand):
 
         parser.add_argument(
             "--use-fetch-service",
-            help="Use the Fetch Service to inspect downloaded assets.",
+            help=argparse.SUPPRESS,
             choices=("strict", "permissive"),
             metavar="policy",
             dest="fetch_service_policy",

--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -81,6 +81,14 @@ class FetchService(services.ProjectService):
     def setup(self) -> None:
         """Start the fetch-service process with proper arguments."""
         super().setup()
+
+        if not self._services.ProviderClass.is_managed():
+            # Emit a warning, but only on the host-side.
+            emit.message(
+                "Warning: the fetch-service integration is experimental "
+                "and still in development."
+            )
+
         self._fetch_process = fetch.start_service()
 
     def create_session(self, instance: craft_providers.Executor) -> dict[str, str]:


### PR DESCRIPTION
By "mark" we mean:

- hide the command-line option from pack's help;
- if enabled, warn that this integration is still in development.

Fixes #488

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
