### PR TITLE
fix(docs): fix docs for canonical-sphinx 0.2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,26 +12,16 @@ Craft-Application
    reference/index
    explanation/index
 
-.. grid:: 1 1 2 2
+.. list-table::
 
-   .. grid-item-card:: :ref:`Tutorial <tutorial>`
-
-      **Get started** with a hands-on introduction to Craft-Application
-
-   .. grid-item-card:: :ref:`How-to guides <howto>`
-
-      **Step-by-step guides** covering key operations and common tasks
-
-.. grid:: 1 1 2 2
-   :reverse:
-
-   .. grid-item-card:: :ref:`Reference <reference>`
-
-      **Technical information** about Craft-Application
-
-   .. grid-item-card:: :ref:`Explanation <explanation>`
-
-      **Discussion and clarification** of key topics
+    * - | :ref:`Tutorial <tutorial>`
+        | **Get started** with a hands-on introduction to craft-application
+      - | :ref:`How-to guides <howto>`
+        | **Step-by-step guides** covering key operations and common tasks
+    * - | :ref:`Reference <reference>`
+        | **Technical information** about craft-application
+      - | :ref:`Explanation <explanation>`
+        | **Discussion and clarification** of key topics
 
 Project and community
 =====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ types = [
     "types-urllib3",
 ]
 docs = [
-    "canonical-sphinx~=0.1",
+    "canonical-sphinx~=0.2.0",
     "sphinx-autobuild==2024.9.3",
     "sphinx-lint==0.9.1",
 ]


### PR DESCRIPTION
This replaces the diataxis grid with a list-table. https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table

Needed because the update to canonical-sphinx caused doc builds to fail and this was how they fixed it for themselves. https://github.com/canonical/canonical-sphinx/commit/e67baa49c47bb99319cfb720ff0964dbed6795eb

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
