### PR TITLE
feat: use craft-platforms build planning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,8 @@ markers = [
 filterwarnings = [
     "ignore:The craft-application BuildPlanner:PendingDeprecationWarning",
     "ignore:BuildInfo:PendingDeprecationWarning",
+    "ignore:ServiceFactory.set_kwargs:PendingDeprecationWarning",
+    "ignore:The BuildPlanner class is deprecated. Override Application.get_build_plan:DeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/data/valid_projects/environment/testcraft.yaml
+++ b/tests/integration/data/valid_projects/environment/testcraft.yaml
@@ -3,13 +3,9 @@ summary: A project with environment variables
 version: 1.0
 base: "ubuntu@22.04"
 platforms:
-  amd64:
-  arm64:
-  armhf:
-  i386:
-  ppc64el:
-  riscv64:
-  s390x:
+  my-platform:
+    build-on: [amd64, arm64, armhf, i386, ppc64el, riscv64, s390x]
+    build-for: [s390x]
 
 parts:
   my-part:

--- a/tests/integration/services/test_fetch.py
+++ b/tests/integration/services/test_fetch.py
@@ -17,6 +17,7 @@
 import contextlib
 import io
 import json
+import os
 import pathlib
 import shutil
 import socket
@@ -30,6 +31,13 @@ from craft_application import errors, fetch, services, util
 from craft_application.models import BuildInfo
 from craft_application.services.fetch import _PROJECT_MANIFEST_MANAGED_PATH
 from craft_providers import bases
+
+pytestmark = [
+    pytest.mark.skipif(
+        not os.getenv("CI") and not shutil.which("fetch-service"),
+        reason="Fetch service is not installed.",
+    )
+]
 
 
 @cache


### PR DESCRIPTION
This also fully deprecates BuildPlanner classes, but doesn't remove them.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
