### PR TITLE
Rocks 1504 craft application enables requested ubuntu pro services

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -32,13 +32,14 @@ from typing import TYPE_CHECKING, Any, cast, final
 import craft_cli
 import craft_parts
 import craft_providers
+import craft_providers.lxd
 from craft_parts.plugins.plugins import PluginType
 from platformdirs import user_cache_path
 
 from craft_application import commands, errors, grammar, models, secrets, util
 from craft_application.errors import PathInvalidError
 from craft_application.models import BuildInfo, GrammarAwareProject
-from craft_application.util import ValidatorOptions
+from craft_application.util import ProServices, ValidatorOptions
 
 if TYPE_CHECKING:
     from craft_application.services import service_factory
@@ -149,6 +150,10 @@ class Application:
         # Set a globally usable project directory for the application.
         # This may be overridden by specific application implementations.
         self.project_dir = pathlib.Path.cwd()
+        # Ubuntu ProServices instance containing relevant pro services specified by the user.
+        # Storage of this instance may change in the future as we migrate Pro operations towards
+        # an application service.
+        self._pro_services: ProServices | None = None
 
         if self.is_managed():
             self._work_dir = pathlib.Path("/root")
@@ -367,13 +372,33 @@ class Application:
             with self.services.provider.instance(
                 build_info, work_dir=self._work_dir
             ) as instance:
+                # if pro services are required, ensure the pro client is
+                # installed, attached and the correct services are enabled
+                if self._pro_services:
+                    # Suggestion: create a Pro abstract class used to ensure minimum support by instances.
+                    # we can then check for pro support by inheritance.
+                    if not isinstance(instance, craft_providers.lxd.LXDInstance):
+                        raise errors.UbuntuProNotSupportedError(
+                            "Ubuntu Pro builds are only supported on LXC."
+                        )
+
+                    craft_cli.emit.debug(
+                        f"Enabling Ubuntu Pro Services {self._pro_services} on"
+                    )
+                    # TODO: remove pyright ignores after these methods are merged into main.
+                    # see https://github.com/canonical/craft-providers/pull/664/files
+                    instance.install_pro_client()  #  pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+                    instance.attach_pro_subscription()  #  pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+                    instance.enable_pro_service(  #  pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+                        self._pro_services
+                    )
+
                 cmd = [self.app.name, *sys.argv[1:]]
                 craft_cli.emit.debug(
                     f"Executing {cmd} in instance location {instance_path} with {extra_args}."
                 )
                 try:
                     with craft_cli.emit.pause():
-                        # Pyright doesn't fully understand craft_providers's CompletedProcess.
                         instance.execute_run(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
                             cmd,
                             cwd=instance_path,
@@ -493,6 +518,34 @@ class Application:
                     resolution="Ensure the path entered is correct.",
                 )
 
+    @staticmethod
+    def _check_pro_requirement(
+        pro_services: ProServices | None,
+        run_managed: bool,  # noqa: FBT001
+        is_managed: bool,  # noqa: FBT001
+    ) -> None:
+        if pro_services is not None:
+            # Validate requested pro services on the host if we are running in destructive mode.
+            if not run_managed and not is_managed:
+                craft_cli.emit.debug(
+                    f"Validating requested Ubuntu Pro status on host: {pro_services}"
+                )
+                pro_services.validate()
+            # Validate requested pro services running in managed mode inside a managed instance.
+            elif run_managed and is_managed:
+                craft_cli.emit.debug(
+                    f"Validating requested Ubuntu Pro status in managed instance: {pro_services}"
+                )
+                pro_services.validate()
+            # Validate pro attachment and service names on the host before starting a managed instance.
+            elif run_managed and not is_managed:
+                craft_cli.emit.debug(
+                    f"Validating requested Ubuntu Pro attachment on host: {pro_services}"
+                )
+                pro_services.validate(
+                    options=ValidatorOptions.ATTACHMENT | ValidatorOptions.SUPPORT
+                )
+
     def run(  # noqa: PLR0912,PLR0915  (too many branches, too many statements)
         self,
     ) -> int:
@@ -511,7 +564,6 @@ class Application:
 
             platform = getattr(dispatcher.parsed_args(), "platform", None)
             build_for = getattr(dispatcher.parsed_args(), "build_for", None)
-            pro_services = getattr(dispatcher.parsed_args(), "pro", None)
 
             run_managed = command.run_managed(dispatcher.parsed_args())
             is_managed = self.is_managed()
@@ -526,29 +578,12 @@ class Application:
 
             provider_name = command.provider_name(dispatcher.parsed_args())
 
-            # Check that pro services are correctly configured. A ProServices instance will
-            # only be available for lifecycle commands, otherwise we default to None
-            if pro_services is not None:
-                # Validate requested pro services on the host if we are running in destructive mode...
-                if not run_managed and not is_managed:
-                    craft_cli.emit.debug(
-                        f"Validating requested Ubuntu Pro status on host: {pro_services}"
-                    )
-                    pro_services.validate()
-                # .. or running in managed mode inside a managed instance
-                elif run_managed and is_managed:
-                    craft_cli.emit.debug(
-                        f"Validating requested Ubuntu Pro status in managed instance: {pro_services}"
-                    )
-                    pro_services.validate()
-                # .. or validate pro attachment and service names on the host before starting a managed instance.
-                elif run_managed and not is_managed:
-                    craft_cli.emit.debug(
-                        f"Validating requested Ubuntu Pro attachment on host: {pro_services}"
-                    )
-                    pro_services.validate(
-                        options=ValidatorOptions.ATTACHMENT | ValidatorOptions.SUPPORT
-                    )
+            # TODO: Move pro operations out to new service for managing Ubuntu Pro
+            # A ProServices instance will only be available for lifecycle commands,
+            # which may consume pro packages,
+            self._pro_services = getattr(dispatcher.parsed_args(), "pro", None)
+            # Check that pro services are correctly configured if available
+            self._check_pro_requirement(self._pro_services, run_managed, is_managed)
 
             if run_managed or command.needs_project(dispatcher.parsed_args()):
                 self.services.project = self.get_project(

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -76,23 +76,6 @@ class _BaseLifecycleCommand(base.ExtensibleCommand):
             help="Build in a LXD container.",
         )
 
-        supported_pro_services = ", ".join(
-            [f"'{name}'" for name in ProServices.supported_services]
-        )
-
-        parser.add_argument(
-            "--pro",
-            type=ProServices.from_csv,
-            metavar="<pro-services>",
-            help=(
-                "Enable Ubuntu Pro services for this command. "
-                f"Supported values include: {supported_pro_services}. "
-                "Multiple values can be passed separated by commas. "
-                "Note: This feature requires an Ubuntu Pro compatible host and build base."
-            ),
-            default=ProServices(),
-        )
-
     @override
     def get_managed_cmd(self, parsed_args: argparse.Namespace) -> list[str]:
         cmd = super().get_managed_cmd(parsed_args)
@@ -151,6 +134,23 @@ class LifecycleCommand(_BaseLifecycleCommand):
                 action="store_true",
                 help="Shell into the environment after the step has run.",
             )
+
+        supported_pro_services = ", ".join(
+            [f"'{name}'" for name in ProServices.supported_services]
+        )
+
+        parser.add_argument(
+            "--pro",
+            type=ProServices.from_csv,
+            metavar="<pro-services>",
+            help=(
+                "Enable Ubuntu Pro services for this command. "
+                f"Supported values include: {supported_pro_services}. "
+                "Multiple values can be passed separated by commas. "
+                "Note: This feature requires an Ubuntu Pro compatible host and build base."
+            ),
+            default=ProServices(),
+        )
 
         parser.add_argument(
             "--debug",

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -254,6 +254,10 @@ class InvalidUbuntuProStateError(UbuntuProError):
     # environment. What is the best way to get the is_managed method here?
 
 
+class UbuntuProNotSupportedError(UbuntuProError):
+    """Raised when Ubuntu Pro client is not supported on the base or build base."""
+
+
 class UbuntuProClientNotFoundError(UbuntuProApiError):
     """Raised when Ubuntu Pro client was not found on the system."""
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -53,7 +53,7 @@ from craft_application.util import (
 )
 from craft_cli import emit
 from craft_parts.plugins.plugins import PluginType
-from craft_providers import bases
+from craft_providers import bases, lxd
 from overrides import override
 
 EMPTY_COMMAND_GROUP = craft_cli.CommandGroup("FakeCommands", [])
@@ -532,6 +532,76 @@ def test_run_managed_failure(app, fake_project, fake_build_plan):
     assert exc_info.value.brief == "Failed to execute testcraft in instance."
 
 
+def test_run_managed_configure_pro(mocker, app, fake_project, fake_build_plan):
+    """Ensure that Pro is installed and configured in a managed instance."""
+    mock_provider = mocker.MagicMock(spec_set=services.ProviderService)
+    app.services.provider = mock_provider
+    # provide spec to pass type check for pro support
+    mock_instance = mocker.MagicMock(spec=lxd.LXDInstance)
+
+    # TODO: these methods are currently in review, https://github.com/canonical/craft-providers/pull/664/files
+    # Remove when craft-providers with pro support in lxd is merged to main.
+    mock_instance.install_pro_client = mocker.Mock()
+    mock_instance.attach_pro_subscription = mocker.Mock()
+    mock_instance.enable_pro_service = mocker.Mock()
+
+    mock_provider.instance.return_value.__enter__.return_value = mock_instance
+    app.project = fake_project
+    app._build_plan = fake_build_plan
+    app._pro_services = util.ProServices(["esm-apps"])
+    arch = get_host_architecture()
+
+    app.run_managed(None, arch)
+
+    assert mock_instance.install_pro_client.call_count == 1
+    assert mock_instance.attach_pro_subscription.call_count == 1
+    assert mock_instance.enable_pro_service.call_count == 1
+
+
+def test_run_managed_pro_not_supported(mocker, app, fake_project, fake_build_plan):
+    """Ensure that providers that do not support Ubuntu Pro cause an exception
+    when pro services are requested."""
+    mock_provider = mocker.MagicMock(spec_set=services.ProviderService)
+    app.services.provider = mock_provider
+    # Provide an unsupported instance type to raise exception
+    mock_instance = mocker.MagicMock()
+
+    mock_provider.instance.return_value.__enter__.return_value = mock_instance
+    app.project = fake_project
+    app._build_plan = fake_build_plan
+    app._pro_services = util.ProServices(["esm-apps"])
+    arch = get_host_architecture()
+
+    with pytest.raises(errors.UbuntuProNotSupportedError):
+        app.run_managed(None, arch)
+
+
+def test_run_managed_skip_configure_pro(mocker, app, fake_project, fake_build_plan):
+    """Ensure that Pro is not installed and configured when it is not required."""
+    mock_provider = mocker.MagicMock(spec_set=services.ProviderService)
+    app.services.provider = mock_provider
+    # provide spec to pass type check for pro support
+    mock_instance = mocker.MagicMock(spec=lxd.LXDInstance)
+
+    # TODO: Remove when these mocks when methods are present in main.
+    # see TODO in test_run_managed_configure_pro for details.
+    mock_instance.install_pro_client = mocker.Mock()
+    mock_instance.attach_pro_subscription = mocker.Mock()
+    mock_instance.enable_pro_service = mocker.Mock()
+
+    mock_provider.instance.return_value.__enter__.return_value = mock_instance
+    app.project = fake_project
+    app._build_plan = fake_build_plan
+    app._pro_services = util.ProServices([])
+    arch = get_host_architecture()
+
+    app.run_managed(None, arch)
+
+    assert mock_instance.install_pro_client.call_count == 0
+    assert mock_instance.attach_pro_subscription.call_count == 0
+    assert mock_instance.enable_pro_service.call_count == 0
+
+
 @pytest.mark.enable_features("build_secrets")
 def test_run_managed_secrets(app, fake_project, fake_build_plan):
     mock_provider = mock.MagicMock(spec_set=services.ProviderService)
@@ -822,7 +892,11 @@ def test_run_success_unmanaged(
 
 
 def test_run_success_managed(
-    monkeypatch, app, fake_project, mocker, mock_pro_api_call  # noqa: ARG001
+    monkeypatch,
+    app,
+    fake_project,
+    mocker,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
@@ -834,7 +908,11 @@ def test_run_success_managed(
 
 
 def test_run_success_managed_with_arch(
-    monkeypatch, app, fake_project, mocker, mock_pro_api_call  # noqa: ARG001
+    monkeypatch,
+    app,
+    fake_project,
+    mocker,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
@@ -847,7 +925,11 @@ def test_run_success_managed_with_arch(
 
 
 def test_run_success_managed_with_platform(
-    monkeypatch, app, fake_project, mocker, mock_pro_api_call  # noqa: ARG001
+    monkeypatch,
+    app,
+    fake_project,
+    mocker,
+    mock_pro_api_call,  # noqa: ARG001
 ):
     mocker.patch.object(app, "get_project", return_value=fake_project)
     app.run_managed = mock.Mock()
@@ -2116,3 +2198,28 @@ def test_emitter_docs_url(monkeypatch, mocker, app):
         app.run()
 
     assert spied_init.mock_calls[0].kwargs["docs_base_url"] == expected_url
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    (   "run_managed",     "is_managed",   "call_count",   "validator_options"),
+    [
+        (False,             False,         1,               None),
+        (True,              True,          1,               None),
+        (True,              False,         1,               util.ValidatorOptions.ATTACHMENT | util.ValidatorOptions.SUPPORT,),
+        (False,             True,          0,               None),
+    ],
+)
+# fmt: on
+def test_check_pro_requirement(
+    mocker, app, run_managed, is_managed, call_count, validator_options
+):
+    """Test that _check_pro_requirement validates Pro Services in the correct situations"""
+    pro_services = mocker.Mock()
+    app._check_pro_requirement(pro_services, run_managed, is_managed)
+
+    assert pro_services.validate.call_count == call_count
+
+    for call in pro_services.validate.call_args_list:
+        if validator_options is not None:  # skip assert if default value is passed
+            assert call.kwargs["options"] == validator_options


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This PR introduces the following changes:
- Install Pro client and configure services on managed instances when required.
- Refactor Pro Services validation for ease of testing.
- Check for host Pro attachment when starting a managed command.
