### PR TITLE
chore: pin requests version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # Pygit2 changelog: https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md
     "pygit2>=1.13.0,<1.15.0",
     "PyYaml>=6.0",
-    "requests",
+    "requests<2.32",
     "typing_extensions>=4.4.0",
 ]
 classifiers = [


### PR DESCRIPTION
This MR addresses: https://github.com/canonical/craft-application/issues/511 

The proposed change is to pin requests < 2.32 in line with craft-parts.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
