### PR TITLE
feat: report fetch-service rejections

### DIFF
--- a/tests/data/manifest/craft-manifest-expected.json
+++ b/tests/data/manifest/craft-manifest-expected.json
@@ -69,6 +69,44 @@
       "url": [
         "https://canonical-bos01.cdn.snapcraftcontent.com:443/download-origin/canonical-lgw01/Md1HBASHzP4i0bniScAjXGnOII9cEK6e_10660.snap?interactive=1&token=1720738800_68d3c27ac109407168ed776e46653c7883b8ef40"
       ]
+    },
+    {
+      "component-name": "",
+      "component-version": "",
+      "component-description": "",
+      "component-id": {
+        "hashes": {
+          "sha1": "e98024bd74a166549e5dad777a48bb25eb6163a4",
+          "sha256": "d0bb57a19474b186870c05a22a29bda1d51e5e01e3d46a0bef27987ec2354896"
+        }
+      },
+      "architecture": "",
+      "type": "application/x.git.upload-pack-result.fetch",
+      "component-author": "",
+      "component-vendor": "",
+      "size": 473833,
+      "url": [
+        "https://github.com:443/canonical/sphinx-docs-starter-pack.git/git-upload-pack"
+      ]
+    },
+    {
+      "component-name": "",
+      "component-version": "",
+      "component-description": "",
+      "component-id": {
+        "hashes": {
+          "sha1": "4a212f314a41bf21ceac5015da94bb82c39cad60",
+          "sha256": "84256a52948edee146161970dca15a3440c7011ce53ed7363bd0b4aaa8fe07c4"
+        }
+      },
+      "architecture": "",
+      "type": "text/plain; charset=utf-8",
+      "component-author": "",
+      "component-vendor": "",
+      "size": 73,
+      "url": [
+        "https://proxy.golang.org:443/github.com/go-mmap/mmap/@v/v0.7.0.mod"
+      ]
     }
   ]
 }

--- a/tests/data/manifest/session-manifest-expected.yaml
+++ b/tests/data/manifest/session-manifest-expected.yaml
@@ -40,3 +40,31 @@
   size: 64892928
   url:
   - https://canonical-bos01.cdn.snapcraftcontent.com:443/download-origin/canonical-lgw01/Md1HBASHzP4i0bniScAjXGnOII9cEK6e_10660.snap?interactive=1&token=1720738800_68d3c27ac109407168ed776e46653c7883b8ef40
+- component-name: ''
+  component-version: ''
+  component-description: ''
+  component-id:
+    hashes:
+      sha1: e98024bd74a166549e5dad777a48bb25eb6163a4
+      sha256: d0bb57a19474b186870c05a22a29bda1d51e5e01e3d46a0bef27987ec2354896
+  architecture: ''
+  type: application/x.git.upload-pack-result.fetch
+  component-author: ''
+  component-vendor: ''
+  size: 473833
+  url:
+  - https://github.com:443/canonical/sphinx-docs-starter-pack.git/git-upload-pack
+- component-name: ''
+  component-version: ''
+  component-description: ''
+  component-id:
+    hashes:
+      sha1: 4a212f314a41bf21ceac5015da94bb82c39cad60
+      sha256: 84256a52948edee146161970dca15a3440c7011ce53ed7363bd0b4aaa8fe07c4
+  architecture: ''
+  type: text/plain; charset=utf-8
+  component-author: ''
+  component-vendor: ''
+  size: 73
+  url:
+  - https://proxy.golang.org:443/github.com/go-mmap/mmap/@v/v0.7.0.mod

--- a/tests/data/manifest/session-report.json
+++ b/tests/data/manifest/session-report.json
@@ -62,6 +62,82 @@
                     "url": "https://canonical-bos01.cdn.snapcraftcontent.com:443/download-origin/canonical-lgw01/Md1HBASHzP4i0bniScAjXGnOII9cEK6e_10660.snap?interactive=1&token=1720738800_68d3c27ac109407168ed776e46653c7883b8ef40"
                 }
             ]
+        },
+        {
+            "A NON-SHALLOW GIT CLONE": true,
+            "artefact-metadata-version": "0.1",
+            "request-inspection": {
+              "git.upload-pack": {
+                "opinion": "Rejected",
+                "reason": "fetch is only allowed with depth 1"
+              },
+              "go.module.git": {
+                "opinion": "Pending",
+                "reason": "valid URL for go module download"
+              }
+            },
+            "response-inspection": {
+              "git.upload-pack": {
+                "opinion": "Rejected",
+                "reason": "fetch is allowed only on a single ref"
+              },
+              "go.module.git": {
+                "opinion": "Unknown",
+                "reason": "git repository does not contain a go.mod file"
+              }
+            },
+            "result": "Rejected",
+            "metadata": {
+              "type": "application/x.git.upload-pack-result.fetch",
+              "sha1": "e98024bd74a166549e5dad777a48bb25eb6163a4",
+              "sha256": "d0bb57a19474b186870c05a22a29bda1d51e5e01e3d46a0bef27987ec2354896",
+              "size": 473833,
+              "name": "",
+              "version": "",
+              "vendor": "",
+              "description": "",
+              "author": "",
+              "license": ""
+            },
+            "downloads": [
+                {
+                  "url": "https://github.com:443/canonical/sphinx-docs-starter-pack.git/git-upload-pack"
+                }
+            ]
+        },
+        {
+            "A GO BUILD WITHOUT GOPROXY=DIRECT": true,
+            "artefact-metadata-version": "0.1",
+            "request-inspection": {
+              "default": {
+                "opinion": "Unknown",
+                "reason": "the request was not recognized by any format inspector"
+              }
+            },
+            "response-inspection": {
+              "default": {
+                "opinion": "Unknown",
+                "reason": "the artefact format is unknown"
+              }
+            },
+            "result": "Rejected",
+            "metadata": {
+              "type": "text/plain; charset=utf-8",
+              "sha1": "4a212f314a41bf21ceac5015da94bb82c39cad60",
+              "sha256": "84256a52948edee146161970dca15a3440c7011ce53ed7363bd0b4aaa8fe07c4",
+              "size": 73,
+              "name": "",
+              "version": "",
+              "vendor": "",
+              "description": "",
+              "author": "",
+              "license": ""
+            },
+            "downloads": [
+              {
+                "url": "https://proxy.golang.org:443/github.com/go-mmap/mmap/@v/v0.7.0.mod"
+              }
+            ]
         }
     ]
 }

--- a/tests/unit/models/test_manifest.py
+++ b/tests/unit/models/test_manifest.py
@@ -80,3 +80,20 @@ def test_create_craft_manifest(
     expected = (manifest_data_dir / "craft-manifest-expected.json").read_text()
 
     assert obtained == expected
+
+
+def test_session_report_rejections(session_report):
+    deps = SessionArtifactManifest.from_session_report(session_report)
+    rejected = [d for d in deps if d.rejected]
+
+    assert len(rejected) == 2  # noqa: PLR2004 (magic value in comparison)
+
+    assert rejected[0].rejection_reasons == [
+        "fetch is allowed only on a single ref",
+        "fetch is only allowed with depth 1",
+        "git repository does not contain a go.mod file",
+    ]
+    assert rejected[1].rejection_reasons == [
+        "the artefact format is unknown",
+        "the request was not recognized by any format inspector",
+    ]


### PR DESCRIPTION
This PR is split over two commits; the first one augments the model to hold the rejection info, and the second one actually reports that info.

----

When creating the Craft manifest the FetchService will now also print a report
of those dependencies that were rejected by the fetch-service. This includes
the dependencies' urls and the list of rejection reasons.

Fixes #507 