### PR TITLE
chore: rename parameter to "--enable-fetch-service"

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -157,7 +157,7 @@ class Application:
             self._work_dir = pathlib.Path.cwd()
 
         # Whether the command execution should use the fetch-service
-        self._use_fetch_service = False
+        self._enable_fetch_service = False
         # The kind of sessions that the fetch-service service should create
         self._fetch_service_policy = "strict"
 
@@ -380,9 +380,9 @@ class Application:
             with self.services.provider.instance(
                 build_info,
                 work_dir=self._work_dir,
-                clean_existing=self._use_fetch_service,
+                clean_existing=self._enable_fetch_service,
             ) as instance:
-                if self._use_fetch_service:
+                if self._enable_fetch_service:
                     session_env = self.services.fetch.create_session(instance)
                     env.update(session_env)
 
@@ -404,10 +404,10 @@ class Application:
                         f"Failed to execute {self.app.name} in instance."
                     ) from exc
                 finally:
-                    if self._use_fetch_service:
+                    if self._enable_fetch_service:
                         self.services.fetch.teardown_session()
 
-        if self._use_fetch_service:
+        if self._enable_fetch_service:
             self.services.fetch.shutdown(force=True)
 
     def configure(self, global_args: dict[str, Any]) -> None:
@@ -522,7 +522,7 @@ class Application:
 
         fetch_service_policy: str | None = getattr(args, "fetch_service_policy", None)
         if fetch_service_policy:
-            self._use_fetch_service = True
+            self._enable_fetch_service = True
             self._fetch_service_policy = fetch_service_policy
 
     def get_arg_or_config(

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -354,7 +354,7 @@ class PackCommand(LifecycleCommand):
         )
 
         parser.add_argument(
-            "--use-fetch-service",
+            "--enable-fetch-service",
             help=argparse.SUPPRESS,
             choices=("strict", "permissive"),
             metavar="policy",

--- a/tests/unit/test_application_fetch.py
+++ b/tests/unit/test_application_fetch.py
@@ -56,15 +56,15 @@ class FakeFetchService(services.FetchService):
 @pytest.mark.parametrize(
     ("pack_args", "expected_calls", "expected_clean_existing"),
     [
-        # No --use-fetch-service: no calls to the FetchService
+        # No --enable-fetch-service: no calls to the FetchService
         (
             [],
             [],
             False,
         ),
-        # --use-fetch-service: full expected calls to the FetchService
+        # --enable-fetch-service: full expected calls to the FetchService
         (
-            ["--use-fetch-service", "strict"],
+            ["--enable-fetch-service", "strict"],
             [
                 # One call to setup
                 "setup",


### PR DESCRIPTION
This is more in line with other "enabling" parameters that we have. This is not a breaking change because this fetch-service integration hasn't been released yet.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
