### PR TITLE
chore: use constants for exit codes

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -438,11 +438,11 @@ class Application:
             if global_args.get("version"):
                 craft_cli.emit.message(f"{self.app.name} {self.app.version}")
                 craft_cli.emit.ended_ok()
-                sys.exit(0)
+                sys.exit(os.EX_OK)
         except craft_cli.ProvideHelpException as err:
             print(err, file=sys.stderr)  # to stderr, as argparse normally does
             craft_cli.emit.ended_ok()
-            sys.exit(0)
+            sys.exit(os.EX_OK)
         except craft_cli.ArgumentParsingError as err:
             print(err, file=sys.stderr)  # to stderr, as argparse normally does
             craft_cli.emit.ended_ok()
@@ -582,7 +582,7 @@ class Application:
             return_code = os.EX_OK
         else:
             # command runs in inner instance
-            return_code = dispatcher.run() or 0
+            return_code = dispatcher.run() or os.EX_OK
 
         return return_code
 

--- a/craft_application/git/_git_repo.py
+++ b/craft_application/git/_git_repo.py
@@ -345,7 +345,7 @@ class GitRepo:
 
         if git_proc:
             git_proc.wait()
-            if git_proc.returncode == 0:
+            if git_proc.returncode == os.EX_OK:
                 return
 
         raise GitError(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Drops some [`PLR2004`](https://docs.astral.sh/ruff/rules/magic-value-comparison/) warnings and prefer constants to magic values.

No behavioral changes.