### PR TITLE
feat: pass the app_config to pre_parse_args()

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -425,15 +425,18 @@ class Application:
 
         try:
             craft_cli.emit.trace("pre-parsing arguments...")
+            app_config = self.app_config
             # Workaround for the fact that craft_cli requires a command.
             # https://github.com/canonical/craft-cli/issues/141
             if "--version" in sys.argv or "-V" in sys.argv:
                 try:
-                    global_args = dispatcher.pre_parse_args(["pull", *sys.argv[1:]])
+                    global_args = dispatcher.pre_parse_args(
+                        ["pull", *sys.argv[1:]], app_config
+                    )
                 except craft_cli.ArgumentParsingError:
-                    global_args = dispatcher.pre_parse_args(sys.argv[1:])
+                    global_args = dispatcher.pre_parse_args(sys.argv[1:], app_config)
             else:
-                global_args = dispatcher.pre_parse_args(sys.argv[1:])
+                global_args = dispatcher.pre_parse_args(sys.argv[1:], app_config)
 
             if global_args.get("version"):
                 craft_cli.emit.message(f"{self.app.name} {self.app.version}")

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -53,13 +53,7 @@ class AppCommand(BaseCommand):
     always_load_project: bool = False
     """The project is also loaded in non-managed mode."""
 
-    def __init__(self, config: dict[str, Any] | None) -> None:
-        if config is None:
-            # This should only be the case when the command is not going to be run.
-            # For example, when requesting help on the command.
-            emit.trace("Not completing command configuration")
-            return
-
+    def __init__(self, config: dict[str, Any]) -> None:
         super().__init__(config)
 
         self._app: application.AppMetadata = config["app"]

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import abc
 import argparse
+import warnings
 from typing import Any, Optional, Protocol, final
 
 from craft_cli import BaseCommand, emit
@@ -53,7 +54,15 @@ class AppCommand(BaseCommand):
     always_load_project: bool = False
     """The project is also loaded in non-managed mode."""
 
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any] | None) -> None:
+        if config is None:
+            warnings.warn(
+                "Creating an AppCommand without a config dict is pending deprecation.",
+                PendingDeprecationWarning,
+            )
+            emit.trace("Not completing command configuration")
+            return
+
         super().__init__(config)
 
         self._app: application.AppMetadata = config["app"]

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -59,6 +59,7 @@ class AppCommand(BaseCommand):
             warnings.warn(
                 "Creating an AppCommand without a config dict is pending deprecation.",
                 PendingDeprecationWarning,
+                stacklevel=3,
             )
             emit.trace("Not completing command configuration")
             return

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,15 @@
 Changelog
 *********
 
+4.4.0 (2024-Oct-XX)
+-------------------
+
+Application
+===========
+
+- ``AppCommand`` subclasses now will always receive a valid ``app_config``
+  dict.
+
 4.3.0 (2024-Oct-11)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A framework for *craft applications."
 dynamic = ["version", "readme"]
 dependencies = [
     "craft-archives>=2.0.0",
-    "craft-cli @ git+https://github.com/canonical/craft-cli@work/CRAFT-3585-command-help-app-config",
+    "craft-cli>=2.9.0",
     "craft-grammar>=2.0.0",
     "craft-parts>=2.1.1",
     "craft-platforms>=0.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A framework for *craft applications."
 dynamic = ["version", "readme"]
 dependencies = [
     "craft-archives>=2.0.0",
-    "craft-cli>=2.6.0",
+    "craft-cli @ git+https://github.com/canonical/craft-cli@work/CRAFT-3585-command-help-app-config",
     "craft-grammar>=2.0.0",
     "craft-parts>=2.1.1",
     "craft-platforms>=0.3.1",

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -63,6 +63,19 @@ def test_get_managed_cmd(fake_command, verbosity, app_metadata):
     ]
 
 
+def test_without_config(emitter):
+    """Test that a command can be initialised without a config.
+    This is pending deprecation but still supported.
+    """
+
+    with pytest.deprecated_call():
+        command = base.AppCommand(None)
+
+    emitter.assert_trace("Not completing command configuration")
+    assert not hasattr(command, "_app")
+    assert not hasattr(command, "_services")
+
+
 @pytest.mark.parametrize("always_load_project", [True, False])
 def test_needs_project(fake_command, always_load_project):
     """`needs_project()` defaults to `always_load_project`."""

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -63,19 +63,6 @@ def test_get_managed_cmd(fake_command, verbosity, app_metadata):
     ]
 
 
-def test_without_config(emitter):
-    """Test that a command can be initialised without a config.
-
-    This is necessary for providing per-command help.
-    """
-
-    command = base.AppCommand(None)
-
-    emitter.assert_trace("Not completing command configuration")
-    assert not hasattr(command, "_app")
-    assert not hasattr(command, "_services")
-
-
 @pytest.mark.parametrize("always_load_project", [True, False])
 def test_needs_project(fake_command, always_load_project):
     """`needs_project()` defaults to `always_load_project`."""


### PR DESCRIPTION
This lets commands be able to always rely on `self.config` existing, even when running `fill_parser()` for help output.

Fixes #530

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
