### PR TITLE
fix: properly capture fetch-service-related output

### DIFF
--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -90,7 +90,7 @@ class FetchService(services.ProjectService):
                 "and still in development."
             )
 
-        self._fetch_process = fetch.start_service()
+            self._fetch_process = fetch.start_service()
 
     def create_session(self, instance: craft_providers.Executor) -> dict[str, str]:
         """Create a new session.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -13,6 +13,12 @@ Application
 - ``AppCommand`` subclasses now will always receive a valid ``app_config``
   dict.
 
+Services
+========
+
+- Fixed a bug where the fetch-service integration would try to spawn the
+  fetch-service process when running in managed mode.
+
 4.3.0 (2024-Oct-11)
 -------------------
 

--- a/tests/unit/services/test_fetch.py
+++ b/tests/unit/services/test_fetch.py
@@ -186,3 +186,13 @@ def test_warning_experimental(mocker, fetch_service, run_on_host, emitter):
     warning_emitted = call("message", warning) in emitter.interactions
 
     assert warning_emitted == run_on_host
+
+
+def test_setup_managed(mocker, fetch_service):
+    """The fetch-service process should only be checked/started when running on the host."""
+    mock_start = mocker.patch.object(fetch, "start_service")
+    mocker.patch.object(ProviderService, "is_managed", return_value=True)
+
+    fetch_service.setup()
+
+    assert not mock_start.called


### PR DESCRIPTION
Wrap all output derived from configuring the instance for the fetch-service,
which can take a little while, into a "Configuring instance :: " progress
stream.

Fixes #536

--------------

Looks like this:

![fetch-service-rockcraft](https://github.com/user-attachments/assets/5a258efc-03ab-4387-8769-1e80d43eaf39)
