### PR TITLE
fix: cleanup UI for fetch-service-related commands

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -53,7 +53,7 @@ DEFAULT_CLI_LOGGERS = frozenset(
         "craft_parts",
         "craft_providers",
         "craft_store",
-        "craft_application.remote",
+        "craft_application",
     }
 )
 

--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -106,6 +106,7 @@ class FetchService(services.ProjectService):
         strict_session = self._session_policy == "strict"
         self._session_data = fetch.create_session(strict=strict_session)
         self._instance = instance
+        emit.progress("Configuring fetch-service integration")
         return fetch.configure_instance(instance, self._session_data)
 
     def teardown_session(self) -> dict[str, typing.Any]:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -14,6 +14,7 @@ Application
   dict.
 - Fixes a bug where the fetch-service integration would try to spawn the
   fetch-service process when running in managed mode.
+- Cleans up the output from the fetch-service integration.
 
 Commands
 ========

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -670,7 +670,7 @@ def test_craft_lib_log_level(app_metadata, fake_services):
         "craft_parts",
         "craft_providers",
         "craft_store",
-        "craft_application.remote",
+        "craft_application",
     ]
 
     # The logging module is stateful and global, so first lets clear the logging level

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -117,6 +117,7 @@ def test_start_service(mocker, tmp_path):
             "F6ECB3762474EDA9D21B7022871920D1991BC93C",
         ],
         text=True,
+        stderr=subprocess.PIPE,
     )
 
     assert mock_obtain_certificate.called
@@ -243,21 +244,30 @@ def test_configure_build_instance(mocker):
     env = fetch.configure_instance(instance, session_data)
     assert env == expected_env
 
+    default_args = {"check": True, "stdout": subprocess.PIPE, "stderr": subprocess.PIPE}
+
     # Execution calls on the instance
     assert instance.execute_run.mock_calls == [
         call(
             ["/bin/sh", "-c", "/usr/sbin/update-ca-certificates > /dev/null"],
-            check=True,
+            **default_args,
         ),
-        call(["mkdir", "-p", "/root/.pip"]),
-        call(["systemctl", "restart", "snapd"]),
+        call(
+            ["mkdir", "-p", "/root/.pip"],
+            **default_args,
+        ),
+        call(
+            ["systemctl", "restart", "snapd"],
+            **default_args,
+        ),
         call(
             [
                 "snap",
                 "set",
                 "system",
                 f"proxy.http={expected_proxy}",
-            ]
+            ],
+            **default_args,
         ),
         call(
             [
@@ -265,15 +275,16 @@ def test_configure_build_instance(mocker):
                 "set",
                 "system",
                 f"proxy.https={expected_proxy}",
-            ]
+            ],
+            **default_args,
         ),
-        call(["/bin/rm", "-Rf", "/var/lib/apt/lists"], check=True),
+        call(
+            ["/bin/rm", "-Rf", "/var/lib/apt/lists"],
+            **default_args,
+        ),
         call(
             ["apt", "update"],
-            env=expected_env,
-            check=True,
-            stdout=mocker.ANY,
-            stderr=mocker.ANY,
+            **default_args,
         ),
     ]
 


### PR DESCRIPTION
Add some steps under the "Configuring fetch-service integration :: " progress, to give some feedback that things are happening without all of the noisy output from Apt.

Fixes #536

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
