### PR TITLE
feat(application): merge commands within groups

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -225,7 +225,7 @@ class Application:
         if not app_commands:
             return default_commands
 
-        craft_cli.emit.trace(f"Merging commands for group {default_commands.name!r}.")
+        craft_cli.emit.debug(f"Merging commands for group {default_commands.name!r}:")
 
         # for lookup of commands by name
         app_commands_dict = {command.name: command for command in app_commands.commands}
@@ -237,12 +237,13 @@ class Application:
             # prefer the application command if it exists
             command_name = default_command.name
             if command_name in app_commands_dict:
-                craft_cli.emit.trace(f"Using application command for {command_name!r}.")
+                craft_cli.emit.debug(
+                    f"  - using application command for {command_name!r}."
+                )
                 merged_commands.append(app_commands_dict[command_name])
                 processed_command_names.add(command_name)
             # otherwise use the default
             else:
-                craft_cli.emit.trace(f"Using default command for {command_name!r}.")
                 merged_commands.append(default_command)
 
         # append remaining commands from the application

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -33,7 +33,6 @@ from typing import TYPE_CHECKING, Any, cast, final
 import craft_cli
 import craft_parts
 import craft_providers
-from craft_cli import CommandGroup
 from craft_parts.plugins.plugins import PluginType
 from platformdirs import user_cache_path
 
@@ -208,7 +207,7 @@ class Application:
         *,
         app_commands: craft_cli.CommandGroup | None,
         default_commands: craft_cli.CommandGroup,
-    ) -> CommandGroup:
+    ) -> craft_cli.CommandGroup:
         """Merge default commands with application commands for a particular group.
 
         Default commands are only used if the application does not have a command

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -184,6 +184,8 @@ class Application:
 
         If the application and craft-application provide a command with the same name
         in the same group, the application's command is used.
+
+        Note that a command with the same name cannot exist in multiple groups.
         """
         lifeycle_default_commands = commands.get_lifecycle_command_group()
         other_default_commands = commands.get_other_command_group()
@@ -223,6 +225,8 @@ class Application:
         if not app_commands:
             return default_commands
 
+        craft_cli.emit.trace(f"Merging commands for group {default_commands.name!r}.")
+
         # for lookup of commands by name
         app_commands_dict = {command.name: command for command in app_commands.commands}
 
@@ -231,11 +235,14 @@ class Application:
 
         for default_command in default_commands.commands:
             # prefer the application command if it exists
-            if default_command.name in app_commands_dict:
-                merged_commands.append(app_commands_dict[default_command.name])
-                processed_command_names.add(default_command.name)
+            command_name = default_command.name
+            if command_name in app_commands_dict:
+                craft_cli.emit.trace(f"Using application command for {command_name!r}.")
+                merged_commands.append(app_commands_dict[command_name])
+                processed_command_names.add(command_name)
             # otherwise use the default
             else:
+                craft_cli.emit.trace(f"Using default command for {command_name!r}.")
                 merged_commands.append(default_command)
 
         # append remaining commands from the application

--- a/craft_application/commands/init.py
+++ b/craft_application/commands/init.py
@@ -72,7 +72,6 @@ class InitCommand(base.AppCommand):
             default=None,
             help="The name of project; defaults to the name of <project_dir>",
         )
-        # TODO: this fails to render in `--help` (#530)
         parser.add_argument(
             "--profile",
             type=str,

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -45,6 +45,7 @@ def get_lifecycle_command_group() -> CommandGroup:
     return CommandGroup(
         "Lifecycle",
         commands,  # type: ignore[arg-type] # https://github.com/canonical/craft-cli/pull/157
+        ordered=True,
     )
 
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,11 @@ Commands
 ========
 
 - Adds an ``init`` command for initialising new projects.
+- Lifecycle commands are ordered in the sequence they run rather than
+  alphabetically in help messages.
+- Preserves order of ``CommandGroups`` defined by the application.
+- Applications can override commands defined by Craft Application in the
+  same ``CommandGroup``.
 
 Services
 ========
@@ -26,7 +31,7 @@ Services
 - Adds an ``InitService`` for initialising new projects.
 
 ..
-  For a complete list of commits, check out the `X.Y.Z`_ release on GitHub.
+  For a complete list of commits, check out the `4.4.0`_ release on GitHub.
 
 4.3.0 (2024-Oct-11)
 -------------------

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -76,7 +76,7 @@ Starter commands:
           version:  Show the application version and exit
 
 Commands can be classified as follows:
-        Lifecycle:  build, clean, pack, prime, pull, stage
+        Lifecycle:  clean, pull, build, stage, prime, pack
             Other:  init, version
 
 For more information about a command, run 'testcraft help <command>'.


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Allows Snapcraft to override default commands like the `InitCommand` and `PackCommand` without a hacky override ([source](https://github.com/canonical/snapcraft/pull/5129/files#r1813199559)).

### Features
- Applications can add a command to a `CommandGroup` where craft-application already provides a default command with the same name.  The application's command will replace the default command. 


### Changes
- `CommandGroup.ordered` is no longer discarded.
- The Lifecycle CommandGroup is ordered.
- If an application registers multiple CommandGroups with the same group name, they will not be merged.
    - I'm OK with this change because it is an odd thing to do, no applications do it, and I would consider it an incorrect way to use craft application.

(CRAFT-3543)