### PR TITLE
fix: properly log the fetch-service's output

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,7 +111,8 @@ jobs:
         run: |
           echo "::group::Begin snap install"
           echo "Installing snaps in the background while running apt and pip..."
-          sudo snap install --no-wait --channel=candidate fetch-service
+          # TODO revert this before merging
+          sudo snap install --no-wait --channel=edge fetch-service
           echo "::endgroup::"
           echo "::group::apt-get"
           sudo apt update

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,8 +111,7 @@ jobs:
         run: |
           echo "::group::Begin snap install"
           echo "Installing snaps in the background while running apt and pip..."
-          # TODO revert this before merging
-          sudo snap install --no-wait --channel=edge fetch-service
+          sudo snap install --no-wait --channel=candidate fetch-service
           echo "::endgroup::"
           echo "::group::apt-get"
           sudo apt update

--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -22,6 +22,7 @@ import pathlib
 import shlex
 import signal
 import subprocess
+import tempfile
 import time
 from dataclasses import dataclass
 from typing import Any, cast
@@ -173,7 +174,7 @@ def start_service() -> subprocess.Popen[str] | None:
     # Shutdown after 5 minutes with no live sessions
     cmd.append("--idle-shutdown=300")
 
-    log_filepath = _get_log_filepath()
+    log_filepath = get_log_filepath()
     log_filepath.parent.mkdir(parents=True, exist_ok=True)
 
     str_cmd = f"{shlex.join(cmd)} > {log_filepath.absolute()}"
@@ -292,6 +293,11 @@ def configure_instance(
     _configure_apt(instance, net_info)
 
     return net_info.env
+
+
+def get_log_filepath() -> pathlib.Path:
+    """Get the path containing the fetch-service's output."""
+    return pathlib.Path(tempfile.gettempdir()) / "craft-fetch-log.txt"
 
 
 def _service_request(
@@ -497,12 +503,6 @@ def _get_certificate_dir() -> pathlib.Path:
 def _check_installed() -> bool:
     """Check whether the fetch-service is installed."""
     return pathlib.Path(_FETCH_BINARY).is_file()
-
-
-def _get_log_filepath() -> pathlib.Path:
-    base_dir = _get_service_base_dir()
-
-    return base_dir / "craft/fetch-log.txt"
 
 
 def _execute_run(

--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -180,9 +180,6 @@ def start_service() -> subprocess.Popen[str] | None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
-        # Start a new session because when killing the service we need to kill
-        # both 'bash' and the 'fetch' it spawns.
-        start_new_session=True,
     )
 
     # Wait a bit for the service to come online
@@ -296,7 +293,7 @@ def get_log_filepath() -> pathlib.Path:
     # snap, can write to.
     logdir = _get_service_base_dir() / "craft-logs"
     logdir.mkdir(exist_ok=True, parents=True)
-    return logdir / "fetch-service.txt"
+    return logdir / "fetch-service.log"
 
 
 def verify_installed() -> None:

--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -138,14 +138,7 @@ def start_service() -> subprocess.Popen[str] | None:
         return None
 
     # Check that the fetch service is actually installed
-    if not _check_installed():
-        raise errors.FetchServiceError(
-            "The 'fetch-service' snap is not installed.",
-            resolution=(
-                "Install the fetch-service snap via "
-                "'snap install --channel=candidate fetch-service'."
-            ),
-        )
+    verify_installed()
 
     cmd = [_FETCH_BINARY]
 
@@ -304,6 +297,18 @@ def get_log_filepath() -> pathlib.Path:
     logdir = _get_service_base_dir() / "craft-logs"
     logdir.mkdir(exist_ok=True, parents=True)
     return logdir / "fetch-service.txt"
+
+
+def verify_installed() -> None:
+    """Verify that the fetch-service is installed, raising an error if it isn't."""
+    if not _check_installed():
+        raise errors.FetchServiceError(
+            "The 'fetch-service' snap is not installed.",
+            resolution=(
+                "Install the fetch-service snap via "
+                "'snap install --channel=candidate fetch-service'."
+            ),
+        )
 
 
 def _service_request(

--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -24,6 +24,7 @@ import signal
 import subprocess
 import time
 from dataclasses import dataclass
+from functools import cache
 from typing import Any, cast
 
 import craft_providers
@@ -329,6 +330,7 @@ def _service_request(
     return response
 
 
+@cache
 def _get_service_base_dir() -> pathlib.Path:
     """Get the base directory to contain the fetch-service's runtime files."""
     input_line = "sh -c 'echo $SNAP_USER_COMMON'"

--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -84,6 +84,9 @@ class FetchService(services.ProjectService):
         super().setup()
 
         if not self._services.ProviderClass.is_managed():
+            # Early fail if the fetch-service is not installed.
+            fetch.verify_installed()
+
             # Emit a warning, but only on the host-side.
             logpath = fetch.get_log_filepath()
             emit.message(

--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -85,9 +85,10 @@ class FetchService(services.ProjectService):
 
         if not self._services.ProviderClass.is_managed():
             # Emit a warning, but only on the host-side.
+            logpath = fetch.get_log_filepath()
             emit.message(
-                "Warning: the fetch-service integration is experimental "
-                "and still in development."
+                "Warning: the fetch-service integration is experimental. "
+                f"Logging output to {str(logpath)!r}."
             )
 
             self._fetch_process = fetch.start_service()

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -11,7 +11,9 @@ Application
 ===========
 
 - The fetch-service integration now assumes that the fetch-service snap is
-  tracking the ``latest/candidate`` channel.
+  tracking the ``latest/candidate``.
+- Fix an issue where the fetch-service output was not correctly logged when
+  running in a snapped craft tool.
 
 Commands
 ========

--- a/tests/integration/services/test_fetch.py
+++ b/tests/integration/services/test_fetch.py
@@ -176,12 +176,15 @@ def test_service_logging(app_service, mocker, tmp_path, monkeypatch, mock_instan
 
     # Mock get_log_filepath() so that the test doesn't interfere with whatever
     # fetch-service is running on the system.
+    original_logpath = fetch.get_log_filepath()
     mocker.patch.object(
-        fetch, "get_log_filepath", return_value=tmp_path / "craft-fetch-log.txt"
+        fetch,
+        "get_log_filepath",
+        return_value=original_logpath.with_name("fetch-testcraft.log"),
     )
 
     logfile = fetch.get_log_filepath()
-    assert not logfile.is_file()
+    logfile.unlink(missing_ok=True)
 
     app_service.setup()
 

--- a/tests/integration/services/test_fetch.py
+++ b/tests/integration/services/test_fetch.py
@@ -174,7 +174,13 @@ def test_service_logging(app_service, mocker, tmp_path, monkeypatch, mock_instan
     monkeypatch.chdir(tmp_path)
     mocker.patch.object(fetch, "_get_gateway", return_value="127.0.0.1")
 
-    logfile = fetch._get_log_filepath()
+    # Mock get_log_filepath() so that the test doesn't interfere with whatever
+    # fetch-service is running on the system.
+    mocker.patch.object(
+        fetch, "get_log_filepath", return_value=tmp_path / "craft-fetch-log.txt"
+    )
+
+    logfile = fetch.get_log_filepath()
     assert not logfile.is_file()
 
     app_service.setup()

--- a/tests/unit/services/test_fetch.py
+++ b/tests/unit/services/test_fetch.py
@@ -176,6 +176,7 @@ def test_teardown_session_create_manifest(
 def test_warning_experimental(mocker, fetch_service, run_on_host, emitter):
     """The fetch-service warning should only be emitted when running on the host."""
     mocker.patch.object(fetch, "start_service")
+    mocker.patch.object(fetch, "verify_installed")
     mocker.patch.object(fetch, "_get_service_base_dir", return_value=pathlib.Path())
     mocker.patch.object(ProviderService, "is_managed", return_value=not run_on_host)
 

--- a/tests/unit/services/test_fetch.py
+++ b/tests/unit/services/test_fetch.py
@@ -179,9 +179,10 @@ def test_warning_experimental(mocker, fetch_service, run_on_host, emitter):
 
     fetch_service.setup()
 
+    logpath = fetch.get_log_filepath()
     warning = (
-        "Warning: the fetch-service integration is experimental "
-        "and still in development."
+        "Warning: the fetch-service integration is experimental. "
+        f"Logging output to {str(logpath)!r}."
     )
     warning_emitted = call("message", warning) in emitter.interactions
 

--- a/tests/unit/services/test_fetch.py
+++ b/tests/unit/services/test_fetch.py
@@ -24,6 +24,7 @@ the FetchService class.
 """
 import contextlib
 import json
+import pathlib
 import re
 import textwrap
 from datetime import datetime
@@ -175,6 +176,7 @@ def test_teardown_session_create_manifest(
 def test_warning_experimental(mocker, fetch_service, run_on_host, emitter):
     """The fetch-service warning should only be emitted when running on the host."""
     mocker.patch.object(fetch, "start_service")
+    mocker.patch.object(fetch, "_get_service_base_dir", return_value=pathlib.Path())
     mocker.patch.object(ProviderService, "is_managed", return_value=not run_on_host)
 
     fetch_service.setup()

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -15,7 +15,6 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for fetch-service-related functions."""
 import re
-import shlex
 import subprocess
 from pathlib import Path
 from unittest import mock
@@ -108,22 +107,16 @@ def test_start_service(mocker, tmp_path):
     popen_call = mock_popen.mock_calls[0]
     assert popen_call == call(
         [
-            "bash",
-            "-c",
-            shlex.join(
-                [
-                    fetch._FETCH_BINARY,
-                    f"--control-port={CONTROL}",
-                    f"--proxy-port={PROXY}",
-                    f"--config={tmp_path/'config'}",
-                    f"--spool={tmp_path/'spool'}",
-                    f"--cert={fake_cert}",
-                    f"--key={fake_key}",
-                    "--permissive-mode",
-                    "--idle-shutdown=300",
-                ]
-            )
-            + f" > {fetch.get_log_filepath()}",
+            fetch._FETCH_BINARY,
+            f"--control-port={CONTROL}",
+            f"--proxy-port={PROXY}",
+            f"--config={tmp_path / 'config'}",
+            f"--spool={tmp_path / 'spool'}",
+            f"--cert={fake_cert}",
+            f"--key={fake_key}",
+            "--permissive-mode",
+            "--idle-shutdown=300",
+            f"--log-file={tmp_path / 'craft-logs/fetch-service.txt'}",
         ],
         env={
             "FETCH_SERVICE_AUTH": AUTH,

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -123,7 +123,7 @@ def test_start_service(mocker, tmp_path):
                     "--idle-shutdown=300",
                 ]
             )
-            + f" > {fetch._get_log_filepath()}",
+            + f" > {fetch.get_log_filepath()}",
         ],
         env={
             "FETCH_SERVICE_AUTH": AUTH,

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -116,7 +116,7 @@ def test_start_service(mocker, tmp_path):
             f"--key={fake_key}",
             "--permissive-mode",
             "--idle-shutdown=300",
-            f"--log-file={tmp_path / 'craft-logs/fetch-service.txt'}",
+            f"--log-file={tmp_path / 'craft-logs/fetch-service.log'}",
         ],
         env={
             "FETCH_SERVICE_AUTH": AUTH,
@@ -124,7 +124,6 @@ def test_start_service(mocker, tmp_path):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
-        start_new_session=True,
     )
 
 


### PR DESCRIPTION
The issue with redirecting the fetch-service's output to a file via bash is this: as a strict snap, the fetch-service cannot inherit the file descriptors from the bash process if said process is spawned by a classic snap. This is the case when the integration is controlled by a snapped craft tool:

```
+----------------------------+        +-------------+
|(snapped) craft-tool -> bash| -----> |fetch-service|
+----------------------------+        +-------------+
```

The solution here is to pass the path to the logfile to the fetch-service itself through a new, recently implemented command-line option. We also print the path to the logfile when emitting the warning about the integration being experimental.

Refs:

- https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1849753

Fixes #550

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
