### PR TITLE
 ci(rtd): pin python version to 3.12 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.12"
 
 python:
   install:


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

It sets explicit version of Python for RTD builder, as today's upgrade to `3.13` breaks ci, due to missing `pygit2` wheel.
