### PR TITLE
Fix: _check_pro_requirement function to not ignore empty ProServices set

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -525,7 +525,7 @@ class Application:
         run_managed: bool,  # noqa: FBT001
         is_managed: bool,  # noqa: FBT001
     ) -> None:
-        if pro_services:
+        if pro_services is not None:  # should not be None for all lifecycle commands.
             # Validate requested pro services on the host if we are running in destructive mode.
             if not run_managed and not is_managed:
                 craft_cli.emit.debug(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This PR fixes a bug where pro services validation would be skipped in destructive mode if no parameter to --pro was given.