### PR TITLE
fix(test): remove env var set by snapped testing programs

### DIFF
--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -173,6 +173,8 @@ def test_install_snap(
     monkeypatch.delenv("SNAP", raising=False)
     monkeypatch.delenv("CRAFT_SNAP_CHANNEL", raising=False)
     monkeypatch.delenv("SNAP_INSTANCE_NAME", raising=False)
+    monkeypatch.delenv("SNAP_NAME", raising=False)
+    monkeypatch.delenv("CRAFT_SNAP_CHANNEL", raising=False)
     for name, value in environment.items():
         monkeypatch.setenv(name, value)
     service = provider.ProviderService(

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -172,6 +172,7 @@ def test_install_snap(
 ):
     monkeypatch.delenv("SNAP", raising=False)
     monkeypatch.delenv("CRAFT_SNAP_CHANNEL", raising=False)
+    monkeypatch.delenv("SNAP_INSTANCE_NAME", raising=False)
     for name, value in environment.items():
         monkeypatch.setenv(name, value)
     service = provider.ProviderService(


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Two particular tests would, down the line, run a check against `os.getenv("SNAP_INSTANCE_NAME")` and default to a known value if it was unset. If these tests were ran directly in a standard ("non-snapped") program, this was fine. However, when running it using a snapped program (in my case, snapped VS Code's integrated testing tools), `SNAP_INSTANCE_NAME` will be set to the name of that program (again, in my case, `code`). 

Since the known value was never assigned, the test could not know what string to look for, causing this test to fail.

To avoid this failure, this PR removes that potentially confusing environment variable before running the test.