### PR TITLE
chore(lint): get around a Pydantic 2.10.x type bug

### DIFF
--- a/craft_application/services/config.py
+++ b/craft_application/services/config.py
@@ -135,6 +135,7 @@ class DefaultConfigHandler(ConfigHandler):
             self._cache[item] = field.default
             return field.default
         if field.default_factory is not None:
+            # TODO: remove the type ignore after pydantic/pydantic#10945 is fixed
             default = field.default_factory()  # type: ignore[call-arg]
             self._cache[item] = default
             return default

--- a/craft_application/services/config.py
+++ b/craft_application/services/config.py
@@ -135,7 +135,7 @@ class DefaultConfigHandler(ConfigHandler):
             self._cache[item] = field.default
             return field.default
         if field.default_factory is not None:
-            default = field.default_factory()
+            default = field.default_factory()  # type: ignore[call-arg]
             self._cache[item] = default
             return default
 


### PR DESCRIPTION
Both mypy and pyright complain that the "field.default_factory()" call has too few arguments, even though its type is typing.Callable[[], Any]. It should be fixed soon, and in the meantime we can ignore the spurious error.

Ref: https://github.com/pydantic/pydantic/issues/10945

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
