### PR TITLE
feat: add ordered to the add_command_group API

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -268,10 +268,14 @@ class Application:
         self._global_arguments.append(argument)
 
     def add_command_group(
-        self, name: str, commands: Sequence[type[craft_cli.BaseCommand]]
+        self,
+        name: str,
+        commands: Sequence[type[craft_cli.BaseCommand]],
+        *,
+        ordered: bool = False,
     ) -> None:
         """Add a CommandGroup to the Application."""
-        self._command_groups.append(craft_cli.CommandGroup(name, commands))
+        self._command_groups.append(craft_cli.CommandGroup(name, commands, ordered))
 
     @cached_property
     def cache_dir(self) -> pathlib.Path:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -31,6 +31,11 @@ Git
 - Use ``craft.git`` for Git-related operations run with ``subprocess`` in
   ``GitRepo``.
 
+Application
+===========
+
+- Add support for keeping order in help for commands provided to
+  ``add_command_group()``.
 
 .. For a complete list of commits, check out the `4.6.0`_ release on GitHub.
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU Lesser General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Integration tests for the Application."""
+
 import argparse
 import pathlib
 import shutil
@@ -125,6 +126,49 @@ def test_special_inputs(capsys, monkeypatch, app, argv, stdout, stderr, exit_cod
 
     pytest_check.equal(captured.out, stdout, "stdout does not match")
     pytest_check.equal(captured.err, stderr, "stderr does not match")
+
+
+def _create_command(command_name):
+    class _FakeCommand(craft_application.commands.AppCommand):
+        name = command_name
+
+    return _FakeCommand
+
+
+@pytest.mark.parametrize(
+    "ordered",
+    [True, False],
+    ids=lambda ordered: f"keep_order={ordered}",
+)
+def test_registering_new_commands(
+    app: TestableApplication,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    ordered: bool,
+) -> None:
+    command_names = ["second", "first"]
+    app.add_command_group(
+        "TestingApplicationGroup",
+        [_create_command(name) for name in command_names],
+        ordered=ordered,
+    )
+
+    monkeypatch.setattr("sys.argv", ["testcraft", "help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        app.run()
+    assert exc_info.value.code == 0, "App should finish without any problems"
+
+    captured_help = capsys.readouterr()
+    # if ordered is set to True, craft_cli should not reorder commands
+    expected_command_order_in_help = ", ".join(
+        sorted(command_names) if not ordered else command_names
+    )
+    assert (
+        f"TestingApplicationGroup:  {expected_command_order_in_help}"
+        in captured_help.err
+    ), "Commands are positioned in the wrong order"
 
 
 @pytest.mark.usefixtures("pretend_jammy")

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -19,6 +19,7 @@ import shutil
 import textwrap
 
 import craft_application
+import craft_application.commands
 import craft_cli
 import pytest
 import pytest_check
@@ -161,9 +162,9 @@ def test_registering_new_commands(
     assert exc_info.value.code == 0, "App should finish without any problems"
 
     captured_help = capsys.readouterr()
-    # if ordered is set to True, craft_cli should not reorder commands
+    # if ordered is set to True, craft_cli should respect command ordering
     expected_command_order_in_help = ", ".join(
-        sorted(command_names) if not ordered else command_names
+        command_names if ordered else sorted(command_names)
     )
     assert (
         f"TestingApplicationGroup:  {expected_command_order_in_help}"


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

Allow persisting ordering in help, when commands are registered through `add_command_group` API.

Linter issues are unrelated (they're from `ruff` update), fixed in #580 
