### PR TITLE
chore(lint): silent false positive for PLC0206 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: mixed-line-ending
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # renovate: datasource=pypi;depName=ruff
-    rev: "v0.6.3"
+    rev: "v0.8.1"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/craft_application/grammar.py
+++ b/craft_application/grammar.py
@@ -52,7 +52,7 @@ def process_part(
     *, part_yaml_data: dict[str, Any], processor: GrammarProcessor
 ) -> dict[str, Any]:
     """Process grammar for a given part."""
-    for key in part_yaml_data:
+    for key in part_yaml_data:  # noqa: PLC0206
         unprocessed_grammar = part_yaml_data[key]
 
         # ignore non-grammar keywords
@@ -119,9 +119,11 @@ def process_parts(
     # TODO: make checker optional in craft-grammar.
     processor = GrammarProcessor(arch=arch, target_arch=target_arch, checker=self_check)
 
-    for part_name in parts_yaml_data:
-        parts_yaml_data[part_name] = process_part(
-            part_yaml_data=parts_yaml_data[part_name], processor=processor
-        )
+    parts_yaml_data.update(
+        {
+            part_name: process_part(part_yaml_data=part_data, processor=processor)
+            for part_name, part_data in parts_yaml_data.items()
+        }
+    )
 
     return parts_yaml_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,8 +231,8 @@ lint.select = [  # Base linting rule selections.
     "RSE",  # Errors on pytest raises.
     "RET",  # Simpler logic after return, raise, continue or break
     "SIM",  # Code simplification
-    "TCH004",  # Remove imports from type-checking guard blocks if used at runtime
-    "TCH005",  # Delete empty type-checking blocks
+    "TC004",  # Remove imports from type-checking guard blocks if used at runtime
+    "TC005",  # Delete empty type-checking blocks
     "ARG",  # Unused arguments
     "PTH",  # Migrate to pathlib
     "ERA",  # Don't check in commented out code


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

Ruff from version `0.8.0` marks incorrectly loops that writes to the dict, as those who should use `.items()`. This PR silences this error for those specific cases, additionally bumps `ruff` in `pre-commit` and fixes warning for `pyproject.toml`.

For reference: https://github.com/astral-sh/ruff/issues/14585


