### PR TITLE
refactor: extract common code from CharmRecipe

### DIFF
--- a/craft_application/launchpad/models/recipe.py
+++ b/craft_application/launchpad/models/recipe.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import enum
 import time
 from collections.abc import Collection, Iterable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import lazr.restfulclient.errors  # type: ignore[import-untyped]
 from typing_extensions import Any, Self, TypedDict, override
@@ -327,10 +327,15 @@ class SnapRecipe(_StoreRecipe):
 
 
 class _StandardRecipe(_StoreRecipe):
-    """A recipe for a charm.
+    """A base class for recipes with common launchpad builds."""
 
-    https://api.launchpad.net/devel.html#charm_recipe
-    """
+    ARTIFACT: ClassVar[str]
+    """The artifact type this recipe creates: charm, rock, etc."""
+
+    @classmethod
+    def _lp_recipe(cls, lp: Launchpad) -> Any:  # noqa: ANN401 (use of any)
+        """Get the launchpad utility to manipulate recipes."""
+        raise NotImplementedError
 
     @classmethod
     def new(  # noqa: PLR0913
@@ -349,16 +354,14 @@ class _StandardRecipe(_StoreRecipe):
         store_channels: Collection[str] = ("latest/edge",),
         git_ref: str | None = None,
     ) -> Self:
-        """Create a new charm recipe.
-
-        See: https://api.launchpad.net/devel.html#charm_recipes-new
+        """Create a new recipe.
 
         :param lp: The Launchpad client to use for this recipe.
         :param name: The recipe name
         :param owner: The username of the person or team who owns the recipe
         :param project: The name of the project to which this recipe should be attached.
         :param build_path: (Optional) The path to the directory containing
-            charmcraft.yaml (if it's not the root directory).
+            the project file (if it's not the root directory).
         :param git_ref: A link to a git repository and branch from which to build.
             Mutually exclusive with bzr_branch.
         :param auto_build: Whether to automatically build on pushes to the branch.
@@ -366,10 +369,10 @@ class _StandardRecipe(_StoreRecipe):
         :param auto_build_channels: (Optional) A dictionary of channels to use for
             snaps installed in the build environment.
         :param store_name: (Optional) The name in the store to which to upload this
-            charm.
-        :param store_channels: (Optional) The channels onto which to publish the charm
+            asset.
+        :param store_channels: (Optional) The channels onto which to publish the asset
             if uploaded.
-        :returns: The Charm recipe.
+        :returns: The recipe.
         """
         kwargs: dict[str, Any] = {}
         if auto_build:
@@ -383,10 +386,10 @@ class _StandardRecipe(_StoreRecipe):
         )
         cls._fill_repo_info(kwargs, git_ref=git_ref)
 
-        charm_entry = retry(
-            f"create charm recipe {name!r}",
+        created_entry = retry(
+            f"create {cls.ARTIFACT} recipe {name!r}",
             lazr.restfulclient.errors.BadRequest,
-            lp.lp.charm_recipes.new,
+            cls._lp_recipe(lp).new,
             name=name,
             owner=util.get_person_link(owner),
             project=f"/{project}",
@@ -394,23 +397,23 @@ class _StandardRecipe(_StoreRecipe):
             **kwargs,
         )
 
-        if not charm_entry:
-            raise ValueError("Failed to create charm recipe")
+        if not created_entry:
+            raise ValueError(f"Failed to create {cls.ARTIFACT} recipe")
 
-        return cls(lp, charm_entry)
+        return cls(lp, created_entry)
 
     @classmethod
     def get(  # pyright: ignore[reportIncompatibleMethodOverride]
         cls, lp: Launchpad, name: str, owner: str, project: str | None = None
     ) -> Self:
-        """Get a charm recipe."""
+        """Get a recipe."""
         try:
             return cls(
                 lp,
                 retry(
-                    f"get charm recipe {name!r}",
+                    f"get {cls.ARTIFACT} recipe {name!r}",
                     lazr.restfulclient.errors.NotFound,
-                    lp.lp.charm_recipes.getByName,
+                    cls._lp_recipe(lp).getByName,
                     name=name,
                     owner=util.get_person_link(owner),
                     project=f"/{project}",
@@ -418,16 +421,16 @@ class _StandardRecipe(_StoreRecipe):
             )
         except lazr.restfulclient.errors.NotFound:
             raise ValueError(
-                f"Could not find charm recipe {name!r} in project {project!r} with owner {owner!r}",
+                f"Could not find {cls.ARTIFACT} recipe {name!r} in project {project!r} with owner {owner!r}",
             ) from None
 
     @classmethod
     def find(  # pyright: ignore[reportIncompatibleMethodOverride]
         cls, lp: Launchpad, owner: str, *, name: str = ""
     ) -> Iterable[Self]:
-        """Find a Charm recipe by the owner."""
+        """Find a recipe by the owner."""
         owner = util.get_person_link(owner)
-        lp_recipes = lp.lp.charm_recipes.findByOwner(owner=util.get_person_link(owner))
+        lp_recipes = cls._lp_recipe(lp).findByOwner(owner=util.get_person_link(owner))
         for recipe in lp_recipes:
             if name and recipe.name != name:
                 continue
@@ -448,6 +451,14 @@ class CharmRecipe(_StandardRecipe):
 
     https://api.launchpad.net/devel.html#charm_recipe
     """
+
+    ARTIFACT: ClassVar[Literal["charm"]] = "charm"  # type: ignore[reportIncompatibleVariableOverride]
+
+    @override
+    @classmethod
+    def _lp_recipe(cls, lp: Launchpad) -> Any:
+        """https://api.launchpad.net/devel.html#charm_recipes."""
+        return lp.lp.charm_recipes
 
 
 Recipe = SnapRecipe | CharmRecipe

--- a/craft_application/launchpad/models/recipe.py
+++ b/craft_application/launchpad/models/recipe.py
@@ -326,7 +326,7 @@ class SnapRecipe(_StoreRecipe):
         return self._build(deadline, request_build_kwargs)
 
 
-class CharmRecipe(_StoreRecipe):
+class _StandardRecipe(_StoreRecipe):
     """A recipe for a charm.
 
     https://api.launchpad.net/devel.html#charm_recipe
@@ -441,6 +441,13 @@ class CharmRecipe(_StoreRecipe):
         """Create a new set of builds for this recipe."""
         kwargs = {"channels": channels} if channels else {}
         return self._build(deadline, kwargs)
+
+
+class CharmRecipe(_StandardRecipe):
+    """A recipe for a charm.
+
+    https://api.launchpad.net/devel.html#charm_recipe
+    """
 
 
 Recipe = SnapRecipe | CharmRecipe


### PR DESCRIPTION
The code in CharmRecipe is 99% artifact-type-agnostic; generalize it out so that we can provide more artifact types with little new code.

The first commit just "renames" the existing CharmRecipe to _StandardRecipe; the second commit then has the actual changes to generalize the class, with the concrete CharmRecipe implementation.
