### PR TITLE
fix(tests): fix a test broken in Python 3.12.8

### DIFF
--- a/tests/integration/commands/test_init.py
+++ b/tests/integration/commands/test_init.py
@@ -124,7 +124,7 @@ def test_init_name(app, capsys, monkeypatch, project_dir, expected_file):
 def test_init_invalid_profile(app, capsys, monkeypatch):
     """Give a helpful error message for invalid profiles."""
     choices = "other-template, simple"
-    if sys.version_info < (3, 12):
+    if sys.version_info < (3, 12, 8):
         choices = "'other-template', 'simple'"
     expected_error = (
         f"Error: argument --profile: invalid choice: 'bad' (choose from {choices})"

--- a/tests/integration/commands/test_init.py
+++ b/tests/integration/commands/test_init.py
@@ -17,6 +17,7 @@
 """Tests for init command."""
 import os
 import pathlib
+import sys
 import textwrap
 
 import pytest
@@ -122,7 +123,12 @@ def test_init_name(app, capsys, monkeypatch, project_dir, expected_file):
 @pytest.mark.usefixtures("fake_template_dirs")
 def test_init_invalid_profile(app, capsys, monkeypatch):
     """Give a helpful error message for invalid profiles."""
-    expected_error = "Error: argument --profile: invalid choice: 'bad' (choose from 'other-template', 'simple')"
+    choices = "other-template, simple"
+    if sys.version_info < (3, 12):
+        choices = "'other-template', 'simple'"
+    expected_error = (
+        f"Error: argument --profile: invalid choice: 'bad' (choose from {choices})"
+    )
     monkeypatch.setattr("sys.argv", ["testcraft", "init", "--profile", "bad"])
 
     return_code = app.run()


### PR DESCRIPTION
Since 3.12.8, argparse 'choices' are no longer quoted. Ref: https://github.com/python/cpython/pull/11776

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
