### PR TITLE
chore: add exceptions for stdlib module shadowing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: mixed-line-ending
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # renovate: datasource=pypi;depName=ruff
-    rev: "v0.8.1"
+    rev: "v0.9.0"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/craft_application/launchpad/models/code.py
+++ b/craft_application/launchpad/models/code.py
@@ -1,3 +1,4 @@
+# noqa: A005 (stdlib-module-shadowing)
 #  This file is part of craft-application.
 #
 #  Copyright 2024 Canonical Ltd.

--- a/craft_application/secrets.py
+++ b/craft_application/secrets.py
@@ -1,3 +1,4 @@
+# noqa: A005 (stdlib-module-shadowing)
 # This file is part of craft_application.
 #
 # Copyright 2023 Canonical Ltd.

--- a/craft_application/util/logging.py
+++ b/craft_application/util/logging.py
@@ -1,3 +1,4 @@
+# noqa: A005 (stdlib-module-shadowing)
 # This file is part of craft_application.
 #
 # Copyright 2023 Canonical Ltd.

--- a/craft_application/util/string.py
+++ b/craft_application/util/string.py
@@ -1,3 +1,4 @@
+# noqa: A005 (stdlib-module-shadowing)
 #  This file is part of craft-application.
 #
 #  Copyright 2024 Canonical Ltd.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,8 +257,8 @@ select = [  # Base linting rule selections.
     # The team have chosen to only use type-checking blocks when necessary to prevent circular imports.
     # As such, the only enabled type-checking checks are those that warn of an import that needs to be
     # removed from a type-checking block.
-    "TCH004",  # Remove imports from type-checking guard blocks if used at runtime
-    "TCH005",  # Delete empty type-checking blocks
+    "TC004",  # Remove imports from type-checking guard blocks if used at runtime
+    "TC005",  # Delete empty type-checking blocks
     "ARG",  # Unused arguments
     "PTH",  # Migrate to pathlib
     "FIX",  # All TODOs, FIXMEs, etc. should be turned into issues instead.


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

New ruff is flagging https://docs.astral.sh/ruff/rules/stdlib-module-shadowing/

Renaming these modules feels like an API breakage, so I added exceptions.