### PR TITLE
ci: build and publish artifacts on amd64

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   source-wheel:
-    runs-on: [self-hosted, jammy]
+    runs-on: [self-hosted, jammy, amd64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           path: dist/
   pypi:
     needs: ["source-wheel"]
-    runs-on: [self-hosted, jammy]
+    runs-on: [self-hosted, jammy, amd64]
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
@@ -55,7 +55,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
   github-release:
     needs: ["source-wheel"]
-    runs-on: [self-hosted, jammy]
+    runs-on: [self-hosted, jammy, amd64]
     steps:
       - name: Get pypi artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

ghcr.io/pypa/gh-action-pypi-publish seems to only be available on amd64:
```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```
([source](https://github.com/canonical/craft-application/actions/runs/12752890346/job/35543369150#step:4:13))

Also, I think it makes sense to build the wheel on amd64.