### PR TITLE
fix(launchpad): use the project's privacy for repos and recipes

### DIFF
--- a/craft_application/launchpad/launchpad.py
+++ b/craft_application/launchpad/launchpad.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import pathlib
 from typing import Any, Literal, overload
 
+import craft_cli
 import launchpadlib.launchpad  # type: ignore[import-untyped]
 import launchpadlib.uris  # type: ignore[import-untyped]
 import lazr.restfulclient.errors  # type: ignore[import-untyped]
@@ -246,9 +247,21 @@ class Launchpad:
         :param owner: (Optional) the username of the owner (defaults to oneself).
         :param project: (Optional) the project to which the repository will be attached.
         """
+        kwargs: dict[str, Any] = {}
         if isinstance(project, models.Project):
+            kwargs = {"information_type": project.information_type}
             project = project.name
+        else:
+            craft_cli.emit.progress(
+                "Warning: Creating a repository without a project model is deprecated."
+                "and will always create public repositories.",
+                permanent=True,
+            )
         if owner is None:
             owner = self.username
 
-        return models.GitRepository.new(self, name, owner, project)
+        craft_cli.emit.debug(
+            f"Creating new repository {name} for {owner} in project {project} with kwargs {kwargs}"
+        )
+
+        return models.GitRepository.new(self, name, owner, project, **kwargs)

--- a/craft_application/launchpad/models/base.py
+++ b/craft_application/launchpad/models/base.py
@@ -147,7 +147,7 @@ class LaunchpadObject:
             return
         annotations = util.get_annotations(self.__class__)
         if key in annotations:
-            attr_path = self._attr_map.get(key, default=key)
+            attr_path = self._attr_map.get(key, key)
             util.set_innermost_attr(self._obj, attr_path, value)
         elif key in self._attr_map:
             util.set_innermost_attr(self._obj, self._attr_map[key], value)

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -339,6 +339,8 @@ class RemoteBuildService(base.AppService):
     ) -> launchpad.models.Recipe:
         """Create a new recipe for the given repository."""
         repository.lp_refresh()  # Prevents a race condition on new repositories.
+
+        # public repos use https for backward compatibility
         url = repository.git_ssh_url if repository.private else repository.git_https_url
         git_ref = parse.urlparse(str(url)).path + "/+ref/main"
 

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -272,9 +272,7 @@ class RemoteBuildService(base.AppService):
         work_tree = WorkTree(self._app.name, self._name, project_dir)
         work_tree.init_repo()
         try:
-            lp_repository = self.lp.new_repository(
-                self._name, project=self._lp_project.name
-            )
+            lp_repository = self.lp.new_repository(self._name, project=self._lp_project)
         except launchpadlib.errors.HTTPError:
             lp_repository = self.lp.get_repository(
                 name=self._name, project=self._lp_project.name
@@ -285,10 +283,7 @@ class RemoteBuildService(base.AppService):
             expiry=datetime.datetime.now(tz=datetime.timezone.utc)
             + datetime.timedelta(seconds=300),
         )
-        repo_url = parse.urlparse(str(lp_repository.git_https_url))
-        push_url = repo_url._replace(
-            netloc=f"{self.lp.lp.me.name}:{token}@{repo_url.netloc}"  # pyright: ignore[reportOptionalMemberAccess,reportAttributeAccessIssue,reportUnknownMemberType]
-        )
+        push_url = self._get_push_url(lp_repository, token)
 
         try:
             local_repository = GitRepo(work_tree.repo_dir)
@@ -299,6 +294,25 @@ class RemoteBuildService(base.AppService):
             ) from git_error
         else:
             return work_tree, lp_repository
+
+    def _get_push_url(
+        self, lp_repository: launchpad.models.GitRepository, token: str
+    ) -> urllib.parse.ParseResult:
+        if self.is_project_private():
+            # private repositories can only be accessed via ssh
+            repo_url = parse.urlparse(str(lp_repository.git_ssh_url))
+            push_url = repo_url._replace(
+                netloc=f"{self.lp.lp.me.name}@{repo_url.netloc}"  # pyright: ignore[reportOptionalMemberAccess,reportAttributeAccessIssue,reportUnknownMemberType]
+            )
+            craft_cli.emit.debug(f"Using ssh url for private repository: {push_url}")
+        else:
+            repo_url = parse.urlparse(str(lp_repository.git_https_url))
+            push_url = repo_url._replace(
+                netloc=f"{self.lp.lp.me.name}:{token}@{repo_url.netloc}"  # pyright: ignore[reportOptionalMemberAccess,reportAttributeAccessIssue,reportUnknownMemberType]
+            )
+            craft_cli.emit.debug(f"Using https url for public repository: {push_url}")
+
+        return push_url
 
     def _get_repository(self) -> launchpad.models.GitRepository:
         """Get an existing repository on Launchpad."""
@@ -325,7 +339,8 @@ class RemoteBuildService(base.AppService):
     ) -> launchpad.models.Recipe:
         """Create a new recipe for the given repository."""
         repository.lp_refresh()  # Prevents a race condition on new repositories.
-        git_ref = parse.urlparse(str(repository.git_https_url)).path + "/+ref/main"
+        url = repository.git_ssh_url if repository.private else repository.git_https_url
+        git_ref = parse.urlparse(str(url)).path + "/+ref/main"
 
         # if kwargs has a collection of 'architectures',  replace 'all' with 'amd64'
         # because the amd64 runners are fast to build on
@@ -339,7 +354,7 @@ class RemoteBuildService(base.AppService):
             name,
             self.lp.username,
             git_ref=git_ref,
-            project=self._lp_project.name,
+            project=self._lp_project,
             **kwargs,
         )
 

--- a/tests/unit/launchpad/test_launchpad.py
+++ b/tests/unit/launchpad/test_launchpad.py
@@ -34,6 +34,14 @@ def flatten_enum(e: type[enum.Enum]) -> list:
     return [*e, *(val.name for val in e), *(val.value for val in e)]
 
 
+@pytest.fixture
+def mock_project():
+    _mock_project = mock.Mock(spec=models.Project)
+    _mock_project.name = "test-name"
+    _mock_project.information_type = models.InformationType.PUBLIC
+    return _mock_project
+
+
 @pytest.mark.parametrize(
     "cache_path",
     [
@@ -181,6 +189,86 @@ def test_get_recipe_snap(fake_launchpad, type_, owner):
 
     mock_get.assert_called_once_with(
         fake_launchpad, "my_recipe", owner or fake_launchpad.username
+    )
+
+
+@pytest.mark.parametrize("information_type", list(models.InformationType))
+@pytest.mark.parametrize("project", [None, "test-project", mock_project])
+@pytest.mark.parametrize(
+    ("recipe", "recipe_name"),
+    [
+        (models.SnapRecipe, "snaps"),
+        (models.CharmRecipe, "charm_recipes"),
+        (models.RockRecipe, "rock_recipes"),
+    ],
+)
+def test_recipe_new_info_type(information_type, project, recipe, recipe_name):
+    """Pass the information_type to the recipe."""
+    mock_launchpad = mock.Mock(spec=launchpad.Launchpad)
+    mock_launchpad.lp = mock.Mock(spec=launchpadlib.launchpad.Launchpad)
+    mock_recipe = mock.Mock()
+
+    mock_entry = mock.Mock(spec=Entry)
+    mock_entry.resource_type_link = "http://blah/#snap"
+    mock_entry.name = "test-snap"
+
+    mock_recipe.new = mock.Mock(return_value=mock_entry)
+    setattr(mock_launchpad.lp, f"{recipe_name}", mock_recipe)
+
+    actual_recipe = recipe.new(
+        mock_launchpad,
+        "my_recipe",
+        "test_user",
+        git_ref="my_ref",
+        # `information_type` overrides the project's information_type
+        project=project,
+        information_type=information_type,
+    )
+
+    assert isinstance(actual_recipe, recipe)
+    assert (
+        mock_recipe.new.mock_calls[0].kwargs["information_type"]
+        == information_type.value
+    )
+
+
+@pytest.mark.parametrize("information_type", list(models.InformationType))
+@pytest.mark.parametrize(
+    ("recipe", "recipe_name"),
+    [
+        (models.SnapRecipe, "snaps"),
+        (models.CharmRecipe, "charm_recipes"),
+        (models.RockRecipe, "rock_recipes"),
+    ],
+)
+def test_recipe_new_info_type_in_project(
+    mock_project, information_type, recipe, recipe_name
+):
+    """Use the info type from the project."""
+    mock_launchpad = mock.Mock(spec=launchpad.Launchpad)
+    mock_launchpad.lp = mock.Mock(spec=launchpadlib.launchpad.Launchpad)
+    mock_recipe = mock.Mock()
+
+    mock_entry = mock.Mock(spec=Entry)
+    mock_entry.resource_type_link = "http://blah/#snap"
+    mock_entry.name = "test-snap"
+
+    mock_recipe.new = mock.Mock(return_value=mock_entry)
+    setattr(mock_launchpad.lp, f"{recipe_name}", mock_recipe)
+    mock_project.information_type = information_type
+
+    actual_recipe = recipe.new(
+        mock_launchpad,
+        "my_recipe",
+        "test_user",
+        project=mock_project,
+        git_ref="my_ref",
+    )
+
+    assert isinstance(actual_recipe, recipe)
+    assert (
+        mock_recipe.new.mock_calls[0].kwargs["information_type"]
+        == information_type.value
     )
 
 

--- a/tests/unit/services/conftest.py
+++ b/tests/unit/services/conftest.py
@@ -56,7 +56,7 @@ def mock_project_entry():
     return get_mock_lazr_entry(
         resource_type="project",
         name="craft_test_user-craft-remote-build",
-        information_type="Public",
+        information_type=launchpad.models.InformationType.PUBLIC.value,
     )
 
 

--- a/tests/unit/services/conftest.py
+++ b/tests/unit/services/conftest.py
@@ -56,6 +56,7 @@ def mock_project_entry():
     return get_mock_lazr_entry(
         resource_type="project",
         name="craft_test_user-craft-remote-build",
+        information_type="Public",
     )
 
 
@@ -65,6 +66,7 @@ def mock_git_repository():
         "git_repository",
         issueAccessToken=mock.Mock(spec=Callable, return_value="super_secret_token"),
         git_https_url="https://git.launchpad.net/",
+        private=False,
     )
 
 

--- a/tests/unit/services/conftest.py
+++ b/tests/unit/services/conftest.py
@@ -66,6 +66,7 @@ def mock_git_repository():
         "git_repository",
         issueAccessToken=mock.Mock(spec=Callable, return_value="super_secret_token"),
         git_https_url="https://git.launchpad.net/",
+        git_ssh_url="ssh:git.launchpad.net/",
         private=False,
     )
 

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -254,7 +254,10 @@ def test_create_new_recipe(remote_build_service, mock_lp_project):
     """Test that _new_recipe works correctly."""
     remote_build_service._lp_project = mock_lp_project
     remote_build_service.RecipeClass = mock.Mock()
-    repo = mock.Mock(git_https_url="https://localhost/~me/some-project/+git/my-repo")
+    repo = mock.Mock(
+        git_https_url="https://localhost/~me/some-project/+git/my-repo",
+        private=False,
+    )
 
     remote_build_service._new_recipe("test-recipe", repo)
 
@@ -263,7 +266,7 @@ def test_create_new_recipe(remote_build_service, mock_lp_project):
         "test-recipe",
         "craft_test_user",
         git_ref="/~me/some-project/+git/my-repo/+ref/main",
-        project="craft_test_user-craft-remote-build",
+        project=mock_lp_project,
     )
 
 
@@ -288,7 +291,10 @@ def test_create_new_recipe_archs(
     """Test that _new_recipe works correctly with architectures."""
     remote_build_service._lp_project = mock_lp_project
     remote_build_service.RecipeClass = mock.Mock()
-    repo = mock.Mock(git_https_url="https://localhost/~me/some-project/+git/my-repo")
+    repo = mock.Mock(
+        git_https_url="https://localhost/~me/some-project/+git/my-repo",
+        private=False,
+    )
 
     remote_build_service._new_recipe("test-recipe", repo, architectures=archs)
 
@@ -297,7 +303,7 @@ def test_create_new_recipe_archs(
         "test-recipe",
         "craft_test_user",
         git_ref="/~me/some-project/+git/my-repo/+ref/main",
-        project="craft_test_user-craft-remote-build",
+        project=mock_lp_project,
         architectures=expected_archs,
     )
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Fixes a bug where the remote-builder would create a public repository and recipe, even when the project is private.

This is a backward-compatible change, but raises a deprecation warning if a project could be public.

I tested with snapcraft and can confirm the recipe and repo are private.

Fixes #614
(CRAFT-3984)