### PR TITLE
fix: remove --status from remote-build overview

### DIFF
--- a/craft_application/commands/remote.py
+++ b/craft_application/commands/remote.py
@@ -35,8 +35,7 @@ architecture are retrieved and will be available in the
 local filesystem.
 
 Interrupted remote builds can be resumed using the --recover
-option, followed by the build number informed when the remote
-build was originally dispatched.
+option.
 
 To set a timeout on the remote-build command, use the option
 ``--launchpad-timeout=<seconds>``. The timeout is local, so

--- a/craft_application/commands/remote.py
+++ b/craft_application/commands/remote.py
@@ -28,7 +28,7 @@ from craft_application.commands import ExtensibleCommand
 from craft_application.launchpad.models import Build, BuildState
 from craft_application.remote.utils import get_build_id
 
-OVERVIEW = """\
+OVERVIEW = """
 Command remote-build sends the current project to be built
 remotely. After the build is complete, packages for each
 architecture are retrieved and will be available in the

--- a/craft_application/commands/remote.py
+++ b/craft_application/commands/remote.py
@@ -36,9 +36,7 @@ local filesystem.
 
 Interrupted remote builds can be resumed using the --recover
 option, followed by the build number informed when the remote
-build was originally dispatched. The current state of the
-remote build for each architecture can be checked using the
---status option.
+build was originally dispatched.
 
 To set a timeout on the remote-build command, use the option
 ``--launchpad-timeout=<seconds>``. The timeout is local, so


### PR DESCRIPTION
We don't have a --status argument and we don't want to implement one, so this just removes it from the overview text.

Fixes #620
CRAFT-4028

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
