### PR TITLE
chore: update craft-platforms to 0.6.0

### DIFF
--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -573,8 +573,8 @@ def test_platform_invalid_arch(model, platform_label, basic_project_dict):
 
     assert error.value.args[0] == (
         "Bad myproject.yaml content:\n"
-        f"- 'unknown' is not a valid DebianArchitecture (in field 'platforms.{platform_label}.build-on')\n"
-        f"- 'unknown' is not a valid DebianArchitecture (in field 'platforms.{platform_label}.build-for')"
+        f"- 'unknown' is not a valid Debian architecture. (in field 'platforms.{platform_label}.build-on')\n"
+        f"- 'unknown' is not a valid Debian architecture. (in field 'platforms.{platform_label}.build-for')"
     )
 
 
@@ -591,7 +591,7 @@ def test_platform_invalid_build_arch(model, arch, field_name, basic_project_dict
     error_lines = [
         "Bad myproject.yaml content:",
         "- field 'build-on' required in 'platforms.amd64' configuration",
-        f"- 'unknown' is not a valid DebianArchitecture (in field 'platforms.amd64.{field_name}')",
+        f"- 'unknown' is not a valid Debian architecture. (in field 'platforms.amd64.{field_name}')",
     ]
     if field_name == "build-on":
         error_lines.pop(1)

--- a/uv.lock
+++ b/uv.lock
@@ -570,16 +570,16 @@ wheels = [
 
 [[package]]
 name = "craft-platforms"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "distro" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/cb/898d65cfdde700565dc6339e09d919a6e0ac65e27486427ba4d7eb7f6434/craft_platforms-0.5.0.tar.gz", hash = "sha256:f41226163ca111517abd30fd3d1e8c16f08819eb3623b36e5a58d1db3ea8da21", size = 150900 }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/7e/a9a54ac2025f5399689027fd317273f477c7c15478b2c59791aa48f34262/craft_platforms-0.6.0.tar.gz", hash = "sha256:7aa153bfff5a28cf4f8c8a7b3da29c259da3a9d9a2f9a2e7c52e118e5735a927", size = 173964 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/d5/a1231182a3012239940ca84bc3b289d54eba7b5841a140439b03226bbd7a/craft_platforms-0.5.0-py3-none-any.whl", hash = "sha256:f80e0eee22174ddc888a938206716dcb7abf66d1161479206e47127091fdfec1", size = 22332 },
+    { url = "https://files.pythonhosted.org/packages/fc/a8/8a11759a28f90b8461ffb0651e21f2b677b4b0547d475a605772858449c4/craft_platforms-0.6.0-py3-none-any.whl", hash = "sha256:ebb1dc6bd1d8c4cbcdab573b9966b20844a9c32aea755ca51de64d4b2a1e646e", size = 24476 },
 ]
 
 [[package]]


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

Error message has changed in `craft-platforms` 0.6.0, which makes CI to fail with it.

I haven't changed minimal required version in `pyproject.toml` (it's still `>=0.5.0`) as API was left intact.
