### PR TITLE
test(fixtures): always enter debug mode for tests

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -718,7 +718,7 @@ class Application:
                 craft_cli.CraftError(f"{self.app.name} internal error: {err!r}"),
                 cause=err,
             )
-            if self.services.config.get("debug"):
+            if self.services.get("config").get("debug"):
                 raise
             return_code = os.EX_SOFTWARE
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,12 @@ def debug_mode(monkeypatch):
     monkeypatch.setenv("CRAFT_DEBUG", "1")
 
 
+@pytest.fixture
+def production_mode(monkeypatch, debug_mode):
+    # This uses debug_mode to ensure that we run after it.
+    monkeypatch.delenv("CRAFT_DEBUG")
+
+
 def _create_fake_build_plan(num_infos: int = 1) -> list[models.BuildInfo]:
     """Create a build plan that is able to execute on the running system."""
     arch = util.get_host_architecture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
 
 
+@pytest.fixture(autouse=True)
+def debug_mode(monkeypatch):
+    monkeypatch.setenv("CRAFT_DEBUG", "1")
+
+
 def _create_fake_build_plan(num_infos: int = 1) -> list[models.BuildInfo]:
     """Create a build plan that is able to execute on the running system."""
     arch = util.get_host_architecture()

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -254,7 +254,7 @@ def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):
     """Run a command without having a project instance shall not fail."""
     monkeypatch.setattr("sys.argv", ["testcraft", "nothing"])
 
-    class NothingCommand(craft_cli.BaseCommand):
+    class NothingCommand(craft_application.commands.AppCommand):
         name = "nothing"
         help_msg = "none"
         overview = "nothing to see here"
@@ -503,6 +503,9 @@ def test_runtime_error_logging(monkeypatch, tmp_path, create_app, mocker):
         "craft_application.services.lifecycle._get_parts_action_message",
         side_effect=runtime_error,
     )
+    # Override the default of setting debug - here we're explicitly that we return
+    # properly in non-debug mode.
+    monkeypatch.setenv("CRAFT_DEBUG", "0")
 
     monkeypatch.setattr("sys.argv", ["testcraft", "pack", "--destructive-mode"])
     app = create_app()

--- a/tests/unit/services/test_config.py
+++ b/tests/unit/services/test_config.py
@@ -249,6 +249,7 @@ def test_default_config_handler_success(default_config_handler, item, expected):
         ),
     ],
 )
+@pytest.mark.usefixtures("production_mode")
 def test_config_service_converts_type(
     monkeypatch: pytest.MonkeyPatch,
     fake_process: pytest_subprocess.FakeProcess,

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -717,6 +717,9 @@ def test_get_arg_or_config(monkeypatch, app, parsed_args, environ, item, expecte
 def test_get_dispatcher_error(
     monkeypatch, check, capsys, app, mock_dispatcher, managed, error, exit_code, message
 ):
+    # Override the default of setting debug - here we're explicitly that we return
+    # properly in non-debug mode.
+    monkeypatch.setenv("CRAFT_DEBUG", "0")
     monkeypatch.setattr(
         app.services.get_class("provider"), "is_managed", lambda: managed
     )
@@ -1022,6 +1025,9 @@ def test_run_error(
     mock_dispatcher.load_command.side_effect = error
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
+    # Override the default of setting debug - here we're explicitly that we return
+    # properly in non-debug mode.
+    monkeypatch.setenv("CRAFT_DEBUG", "0")
 
     pytest_check.equal(app.run(), return_code)
     _, err = capsys.readouterr()

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -713,13 +713,10 @@ def test_get_arg_or_config(monkeypatch, app, parsed_args, environ, item, expecte
         ),
     ],
 )
-@pytest.mark.usefixtures("emitter")
+@pytest.mark.usefixtures("emitter", "production_mode")
 def test_get_dispatcher_error(
     monkeypatch, check, capsys, app, mock_dispatcher, managed, error, exit_code, message
 ):
-    # Override the default of setting debug - here we're explicitly that we return
-    # properly in non-debug mode.
-    monkeypatch.setenv("CRAFT_DEBUG", "0")
     monkeypatch.setattr(
         app.services.get_class("provider"), "is_managed", lambda: managed
     )
@@ -1010,7 +1007,7 @@ def test_run_success_managed_inside_managed(
         ),
     ],
 )
-@pytest.mark.usefixtures("emitter")
+@pytest.mark.usefixtures("emitter", "production_mode")
 def test_run_error(
     monkeypatch,
     capsys,
@@ -1025,9 +1022,6 @@ def test_run_error(
     mock_dispatcher.load_command.side_effect = error
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
-    # Override the default of setting debug - here we're explicitly that we return
-    # properly in non-debug mode.
-    monkeypatch.setenv("CRAFT_DEBUG", "0")
 
     pytest_check.equal(app.run(), return_code)
     _, err = capsys.readouterr()
@@ -1089,7 +1083,6 @@ def test_run_error_debug(monkeypatch, mock_dispatcher, app, fake_project, error)
     mock_dispatcher.load_command.side_effect = error
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
-    monkeypatch.setenv("CRAFT_DEBUG", "1")
 
     with pytest.raises(error.__class__):
         app.run()


### PR DESCRIPTION
This should make testing the Application more straightforward, as we're always in debug mode when we run tests (so `run()` raises exceptions that would otherwise become InternalErrors).

Already caught a test issue :-)

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
