### PR TITLE
feat!(test): add a pytest plugin

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -718,7 +718,7 @@ class Application:
                 craft_cli.CraftError(f"{self.app.name} internal error: {err!r}"),
                 cause=err,
             )
-            if self.services.config.get("debug"):
+            if self.services.get("config").get("debug"):
                 raise
             return_code = os.EX_SOFTWARE
         else:

--- a/craft_application/pytest_plugin.py
+++ b/craft_application/pytest_plugin.py
@@ -95,7 +95,7 @@ def _optional_pyfakefs(request: pytest.FixtureRequest) -> FakeFilesystem | None:
 def fake_host_architecture(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[craft_platforms.DebianArchitecture]:
-    """Run this test across all supported architectures.
+    """Run this test as though running on each supported architecture.
 
     This parametrized fixture provides architecture values for all supported
     architectures, simulating as though the application is running on that architecture.
@@ -130,3 +130,16 @@ def project_path(request: pytest.FixtureRequest) -> pathlib.Path:
     path = tmp_path / "project"
     path.mkdir()
     return path
+
+
+@pytest.fixture
+def in_project_path(
+    project_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> pathlib.Path:
+    """Run the test inside the project path.
+
+    Changes the working directory of the test to use the project path.
+    Best to use with ``pytest.mark.usefixtures``
+    """
+    monkeypatch.chdir(project_path)
+    return project_path

--- a/craft_application/pytest_plugin.py
+++ b/craft_application/pytest_plugin.py
@@ -13,9 +13,22 @@
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """A pytest plugin for assisting in testing apps that use craft-application."""
 
-import os
+from __future__ import annotations
 
+import os
+import pathlib
+import platform
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import craft_platforms
 import pytest
+
+from craft_application import util
+from craft_application.util import platforms
+
+if TYPE_CHECKING:
+    from pyfakefs.fake_filesystem import FakeFilesystem
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -37,3 +50,83 @@ def production_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     between debug mode and production mode.
     """
     monkeypatch.setenv("CRAFT_DEBUG", "0")
+
+
+@pytest.fixture
+def managed_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tell the application it's running in managed mode.
+
+    This fixture sets up the application's environment so that it appears to be using
+    managed mode. Useful for testing behaviours that only occur in managed mode.
+    """
+    if os.getenv("CRAFT_BUILD_ENVIRONMENT") == "host":
+        raise LookupError("Managed mode and destructive mode are mutually exclusive.")
+    monkeypatch.setenv(platforms.ENVIRONMENT_CRAFT_MANAGED_MODE, "1")
+
+
+@pytest.fixture
+def destructive_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tell the application it's running in destructive mode.
+
+    This fixture sets up the application's environment so that it appears to be running
+    in destructive mode with the "CRAFT_BUILD_ENVIRONMENT" environment variable set.
+    """
+    if os.getenv(platforms.ENVIRONMENT_CRAFT_MANAGED_MODE):
+        raise LookupError("Destructive mode and managed mode are mutually exclusive.")
+    monkeypatch.setenv("CRAFT_BUILD_ENVIRONMENT", "host")
+
+
+def _optional_pyfakefs(request: pytest.FixtureRequest) -> FakeFilesystem | None:
+    """Get pyfakefs if it's in use by the fixture request."""
+    if {"fs", "fs_class", "fs_module", "fs_session"} & set(request.fixturenames):
+        try:
+            from pyfakefs.fake_filesystem import FakeFilesystem
+
+            fs = request.getfixturevalue("fs")
+            if isinstance(fs, FakeFilesystem):
+                return fs
+        except ImportError:
+            # pyfakefs isn't installed,so this fixture means something else.
+            pass
+    return None
+
+
+@pytest.fixture(params=craft_platforms.DebianArchitecture)
+def fake_host_architecture(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[craft_platforms.DebianArchitecture]:
+    """Run this test across all supported architectures.
+
+    This parametrized fixture provides architecture values for all supported
+    architectures, simulating as though the application is running on that architecture.
+    This fixture is limited to setting the architecture within this python process.
+    """
+    arch: craft_platforms.DebianArchitecture = request.param
+    platform_arch = arch.to_platform_arch()
+    real_uname = platform.uname()
+    monkeypatch.setattr(
+        "platform.uname", lambda: real_uname._replace(machine=platform_arch)
+    )
+    util.get_host_architecture.cache_clear()
+    yield arch
+    util.get_host_architecture.cache_clear()
+
+
+@pytest.fixture
+def project_path(request: pytest.FixtureRequest) -> pathlib.Path:
+    """Get a temporary path for a project.
+
+    This fixture creates a temporary path for a project. It does not create any files
+    in the project directory, but rather provides a pristine project directory without
+    the need to worry about other fixtures loading things.
+
+    This fixture can be used with or without pyfakefs.
+    """
+    if fs := _optional_pyfakefs(request):
+        project_path = pathlib.Path("/test/project")
+        fs.create_dir(project_path)  # type: ignore[reportUnknownMemberType]
+        return project_path
+    tmp_path: pathlib.Path = request.getfixturevalue("tmp_path")
+    path = tmp_path / "project"
+    path.mkdir()
+    return path

--- a/craft_application/pytest_plugin.py
+++ b/craft_application/pytest_plugin.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""A pytest plugin for assisting in testing apps that use craft-application."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def debug_mode() -> None:
+    """Ensure that the application is in debug mode, raising exceptions from run().
+
+    This fixture is automatically used. To disable debug mode for specific tests that
+    require it, use the :py:func:`production_mode` fixture.
+    """
+    os.environ["CRAFT_DEBUG"] = "1"
+
+
+@pytest.fixture
+def production_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put the application into production mode.
+
+    This fixture puts the application into production mode rather than debug mode.
+    It should only be used if the application needs to test behaviour that differs
+    between debug mode and production mode.
+    """
+    monkeypatch.setenv("CRAFT_DEBUG", "0")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ html_context = {
 
 extensions = [
     "canonical_sphinx",
+    "sphinx.ext.autodoc",
 ]
 # endregion
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,23 @@
 Changelog
 *********
 
+5.0.0 (2025-Mon-DD)
+-------------------
+
+Testing
+=======
+
+- A new :doc:`pytest-plugin` with a fixture that enables production mode for the
+  application if a test requires it.
+
+Breaking changes
+================
+
+- The pytest plugin includes an auto-used fixture that puts the app into debug mode
+  by default for tests.
+
+For a complete list of commits, check out the `5.0.0`_ release on GitHub.
+
 4.9.1 (2025-Feb-12)
 -------------------
 
@@ -23,7 +40,7 @@ Application
 ===========
 
 - Add a feature to allow `Python plugins
-  https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/>`_
+  <https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/>`_
   to extend or modify the behaviour of applications that use craft-application as a
   framework. The plugin packages must be installed in the same virtual environment
   as the application.
@@ -588,3 +605,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _4.8.3: https://github.com/canonical/craft-application/releases/tag/4.8.3
 .. _4.9.0: https://github.com/canonical/craft-application/releases/tag/4.9.0
 .. _4.9.1: https://github.com/canonical/craft-application/releases/tag/4.9.1
+.. _5.0.0: https://github.com/canonical/craft-application/releases/tag/5.0.0

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,6 +9,7 @@ Reference
    changelog
    environment-variables
    platforms
+   pytest-plugin
 
 Indices and tables
 ==================

--- a/docs/reference/pytest-plugin.rst
+++ b/docs/reference/pytest-plugin.rst
@@ -19,9 +19,11 @@ Fixtures
 
 .. autofunction:: destructive_mode
 
+.. autofunction:: fake_host_architecture
+
 .. autofunction:: project_path
 
-.. autofunction:: host_architecture
+.. autofunction:: in_project_path
 
 Auto-used fixtures
 ~~~~~~~~~~~~~~~~~~

--- a/docs/reference/pytest-plugin.rst
+++ b/docs/reference/pytest-plugin.rst
@@ -1,0 +1,16 @@
+.. py:module:: craft_application.pytest_plugin
+
+pytest plugin
+=============
+
+craft-application includes a pytest plugin to help ease the testing of apps that use
+it as a framework.
+
+By default, this plugin sets the application into debug mode, meaning the
+:py:meth:`~craft_application.Application.run()` method will re-raise generic exceptions.
+
+
+Fixtures
+--------
+
+.. autofunction:: production_mode

--- a/docs/reference/pytest-plugin.rst
+++ b/docs/reference/pytest-plugin.rst
@@ -3,7 +3,7 @@
 pytest plugin
 =============
 
-craft-application includes a pytest plugin to help ease the testing of apps that use
+craft-application includes a `pytest`_ plugin to help ease the testing of apps that use
 it as a framework.
 
 By default, this plugin sets the application into debug mode, meaning the
@@ -14,3 +14,23 @@ Fixtures
 --------
 
 .. autofunction:: production_mode
+
+.. autofunction:: managed_mode
+
+.. autofunction:: destructive_mode
+
+.. autofunction:: project_path
+
+.. autofunction:: host_architecture
+
+Auto-used fixtures
+~~~~~~~~~~~~~~~~~~
+
+Some fixtures are automatically enabled for tests, changing the default behaviour of
+applications during the testing process. This is kept to a minimum, but is done when
+the standard behaviour could cause subtle testing issues.
+
+.. autofunction:: debug_mode
+
+
+.. _pytest: https://docs.pytest.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 
-[project.scripts]
+[project.entry-points.pytest11]
+craft_application = "craft_application.pytest_plugin"
 
 [project.optional-dependencies]
 remote = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,17 +43,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
 
 
-@pytest.fixture(autouse=True)
-def debug_mode(monkeypatch):
-    monkeypatch.setenv("CRAFT_DEBUG", "1")
-
-
-@pytest.fixture
-def production_mode(monkeypatch, debug_mode):
-    # This uses debug_mode to ensure that we run after it.
-    monkeypatch.delenv("CRAFT_DEBUG")
-
-
 def _create_fake_build_plan(num_infos: int = 1) -> list[models.BuildInfo]:
     """Create a build plan that is able to execute on the running system."""
     arch = util.get_host_architecture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,17 @@ if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
 
 
+@pytest.fixture(autouse=True)
+def debug_mode(monkeypatch):
+    monkeypatch.setenv("CRAFT_DEBUG", "1")
+
+
+@pytest.fixture
+def production_mode(monkeypatch, debug_mode):
+    # This uses debug_mode to ensure that we run after it.
+    monkeypatch.delenv("CRAFT_DEBUG")
+
+
 def _create_fake_build_plan(num_infos: int = 1) -> list[models.BuildInfo]:
     """Create a build plan that is able to execute on the running system."""
     arch = util.get_host_architecture()

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -499,6 +499,9 @@ def test_runtime_error_logging(monkeypatch, tmp_path, create_app, mocker):
         "craft_application.services.lifecycle._get_parts_action_message",
         side_effect=runtime_error,
     )
+    # Override the default of setting debug - here we're explicitly that we return
+    # properly in non-debug mode.
+    monkeypatch.setenv("CRAFT_DEBUG", "0")
 
     monkeypatch.setattr("sys.argv", ["testcraft", "pack", "--destructive-mode"])
     app = create_app()

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -116,7 +116,6 @@ INVALID_PROJECTS_DIR = TEST_DATA_DIR / "invalid_projects"
     ],
 )
 def test_special_inputs(capsys, monkeypatch, app, argv, stdout, stderr, exit_code):
-    monkeypatch.setenv("CRAFT_DEBUG", "1")
     monkeypatch.setattr("sys.argv", ["testcraft", *argv])
 
     with pytest.raises(SystemExit) as exc_info:
@@ -177,7 +176,6 @@ def test_registering_new_commands(
 @pytest.mark.usefixtures("pretend_jammy")
 @pytest.mark.parametrize("project", (d.name for d in VALID_PROJECTS_DIR.iterdir()))
 def test_project_managed(capsys, monkeypatch, tmp_path, project, create_app):
-    monkeypatch.setenv("CRAFT_DEBUG", "1")
     monkeypatch.setenv("CRAFT_MANAGED_MODE", "1")
     monkeypatch.setattr("sys.argv", ["testcraft", "pack"])
     monkeypatch.chdir(tmp_path)
@@ -254,7 +252,7 @@ def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):
     """Run a command without having a project instance shall not fail."""
     monkeypatch.setattr("sys.argv", ["testcraft", "nothing"])
 
-    class NothingCommand(craft_cli.BaseCommand):
+    class NothingCommand(craft_application.commands.AppCommand):
         name = "nothing"
         help_msg = "none"
         overview = "nothing to see here"
@@ -270,7 +268,6 @@ def test_non_lifecycle_command_does_not_require_project(monkeypatch, app):
 @pytest.mark.parametrize("cmd", ["clean", "pull", "build", "stage", "prime", "pack"])
 def test_run_always_load_project(capsys, monkeypatch, app, cmd):
     """Run a lifecycle command without having a project shall fail."""
-    monkeypatch.setenv("CRAFT_DEBUG", "1")
     monkeypatch.setattr("sys.argv", ["testcraft", cmd])
 
     assert app.run() == 66
@@ -394,7 +391,6 @@ def setup_secrets_project(create_app, monkeypatch, tmp_path):
     """Test the use of build secrets in destructive mode."""
 
     def _inner(*, destructive_mode: bool):
-        monkeypatch.setenv("CRAFT_DEBUG", "1")
         monkeypatch.chdir(tmp_path)
         shutil.copytree(TEST_DATA_DIR / "build-secrets", tmp_path, dirs_exist_ok=True)
 
@@ -492,7 +488,7 @@ def test_lifecycle_error_logging(monkeypatch, tmp_path, create_app):
     assert parts_message in log_contents
 
 
-@pytest.mark.usefixtures("pretend_jammy", "emitter")
+@pytest.mark.usefixtures("pretend_jammy", "emitter", "production_mode")
 def test_runtime_error_logging(monkeypatch, tmp_path, create_app, mocker):
     monkeypatch.chdir(tmp_path)
     shutil.copytree(INVALID_PROJECTS_DIR / "build-error", tmp_path, dirs_exist_ok=True)

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -499,14 +499,12 @@ def test_runtime_error_logging(monkeypatch, tmp_path, create_app, mocker):
         "craft_application.services.lifecycle._get_parts_action_message",
         side_effect=runtime_error,
     )
-    # Override the default of setting debug - here we're explicitly that we return
-    # properly in non-debug mode.
-    monkeypatch.setenv("CRAFT_DEBUG", "0")
 
     monkeypatch.setattr("sys.argv", ["testcraft", "pack", "--destructive-mode"])
     app = create_app()
 
-    app.run()
+    with pytest.raises(RuntimeError):
+        app.run()
 
     log_contents = craft_cli.emit._log_filepath.read_text()
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -488,7 +488,7 @@ def test_lifecycle_error_logging(monkeypatch, tmp_path, create_app):
     assert parts_message in log_contents
 
 
-@pytest.mark.usefixtures("pretend_jammy", "emitter", "production_mode")
+@pytest.mark.usefixtures("pretend_jammy", "emitter")
 def test_runtime_error_logging(monkeypatch, tmp_path, create_app, mocker):
     monkeypatch.chdir(tmp_path)
     shutil.copytree(INVALID_PROJECTS_DIR / "build-error", tmp_path, dirs_exist_ok=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,7 +22,7 @@ from unittest import mock
 import pytest
 import pytest_mock
 
-from craft_application import git, services, util
+from craft_application import git, services
 from craft_application.services import service_factory
 
 BASIC_PROJECT_YAML = """
@@ -35,12 +35,6 @@ parts:
   mypart:
     plugin: nil
 """
-
-
-@pytest.fixture(params=["amd64", "arm64", "riscv64"])
-def fake_host_architecture(monkeypatch, request) -> str:
-    monkeypatch.setattr(util, "get_host_architecture", lambda: request.param)
-    return request.param
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -104,11 +104,8 @@ def expected_git_command(
 
 
 @pytest.fixture
-def fake_project_file(monkeypatch, tmp_path):
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    project_path = project_dir / "testcraft.yaml"
-    project_path.write_text(BASIC_PROJECT_YAML)
-    monkeypatch.chdir(project_dir)
+def fake_project_file(in_project_path):
+    project_file = in_project_path / "testcraft.yaml"
+    project_file.write_text(BASIC_PROJECT_YAML)
 
-    return project_path
+    return project_file

--- a/tests/unit/services/test_config.py
+++ b/tests/unit/services/test_config.py
@@ -249,6 +249,7 @@ def test_default_config_handler_success(default_config_handler, item, expected):
         ),
     ],
 )
+@pytest.mark.usefixtures("production_mode")
 def test_config_service_converts_type(
     monkeypatch: pytest.MonkeyPatch,
     fake_process: pytest_subprocess.FakeProcess,

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1335,41 +1335,39 @@ def test_work_dir_project_managed(monkeypatch, app_metadata, fake_services):
 
 
 @pytest.fixture
-def environment_project(monkeypatch, tmp_path):
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    project_path = project_dir / "testcraft.yaml"
-    project_path.write_text(
+def environment_project(in_project_path):
+    project_file = in_project_path / "testcraft.yaml"
+    project_file.write_text(
         dedent(
+            """\
+            name: myproject
+            version: 1.2.3
+            base: ubuntu@24.04
+            platforms:
+              amd64:
+              arm64:
+              riscv64:
+            parts:
+              mypart:
+                plugin: nil
+                source-tag: v$CRAFT_PROJECT_VERSION
+                build-environment:
+                - BUILD_ON: $CRAFT_ARCH_BUILD_ON
+                - BUILD_FOR: $CRAFT_ARCH_BUILD_FOR
             """
-        name: myproject
-        version: 1.2.3
-        base: ubuntu@24.04
-        platforms:
-          arm64:
-        parts:
-          mypart:
-            plugin: nil
-            source-tag: v$CRAFT_PROJECT_VERSION
-            build-environment:
-              - BUILD_ON: $CRAFT_ARCH_BUILD_ON
-              - BUILD_FOR: $CRAFT_ARCH_BUILD_FOR
-        """
         )
     )
-    monkeypatch.chdir(project_dir)
 
-    return project_path
+    return in_project_path
 
 
+@pytest.mark.usefixtures("in_project_path", "fake_host_architecture")
 def test_expand_environment_build_for_all(
-    monkeypatch, app_metadata, tmp_path, fake_services, emitter
+    monkeypatch, app_metadata, project_path, fake_services, emitter
 ):
     """Expand build-for to the host arch when build-for is 'all'."""
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    project_path = project_dir / "testcraft.yaml"
-    project_path.write_text(
+    project_file = project_path / "testcraft.yaml"
+    project_file.write_text(
         dedent(
             f"""\
             name: myproject
@@ -1388,7 +1386,6 @@ def test_expand_environment_build_for_all(
         """
         )
     )
-    monkeypatch.chdir(project_dir)
 
     app = application.Application(app_metadata, fake_services)
     project = app.get_project()
@@ -1406,7 +1403,7 @@ def test_expand_environment_build_for_all(
     )
 
 
-@pytest.mark.usefixtures("environment_project")
+@pytest.mark.usefixtures("environment_project", "fake_host_architecture")
 def test_application_expand_environment(app_metadata, fake_services):
     app = application.Application(app_metadata, fake_services)
     project = app.get_project(build_for=get_host_architecture())
@@ -1421,30 +1418,27 @@ def test_application_expand_environment(app_metadata, fake_services):
 
 
 @pytest.fixture
-def build_secrets_project(monkeypatch, tmp_path):
-    project_dir = tmp_path / "project"
-    project_dir.mkdir()
-    project_path = project_dir / "testcraft.yaml"
-    project_path.write_text(
+def build_secrets_project(in_project_path):
+    project_file = in_project_path / "testcraft.yaml"
+    project_file.write_text(
         dedent(
             """
-        name: myproject
-        version: 1.2.3
-        base: ubuntu@24.04
-        platforms:
-          arm64:
-        parts:
-          mypart:
-            plugin: nil
-            source: $(HOST_SECRET:echo ${SECRET_VAR_1})/project
-            build-environment:
-              - MY_VAR: $(HOST_SECRET:echo ${SECRET_VAR_2})
-        """
+            name: myproject
+            version: 1.2.3
+            base: ubuntu@24.04
+            platforms:
+              arm64:
+            parts:
+              mypart:
+                plugin: nil
+                source: $(HOST_SECRET:echo ${SECRET_VAR_1})/project
+                build-environment:
+                - MY_VAR: $(HOST_SECRET:echo ${SECRET_VAR_2})
+            """
         )
     )
-    monkeypatch.chdir(project_dir)
 
-    return project_path
+    return in_project_path
 
 
 @pytest.mark.usefixtures("build_secrets_project")
@@ -1652,14 +1646,13 @@ def grammar_project_full(tmp_path):
 
 
 @pytest.fixture
-def non_grammar_build_plan(mocker):
+def non_grammar_build_plan(mocker, fake_host_architecture):
     """A build plan to build on amd64 to riscv64."""
-    host_arch = "amd64"
     base = util.get_host_base()
     build_plan = [
         models.BuildInfo(
             "platform-riscv64",
-            host_arch,
+            fake_host_architecture,
             "riscv64",
             base,
         )

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -717,6 +717,9 @@ def test_get_arg_or_config(monkeypatch, app, parsed_args, environ, item, expecte
 def test_get_dispatcher_error(
     monkeypatch, check, capsys, app, mock_dispatcher, managed, error, exit_code, message
 ):
+    # Override the default of setting debug - here we're explicitly that we return
+    # properly in non-debug mode.
+    monkeypatch.setenv("CRAFT_DEBUG", "0")
     monkeypatch.setattr(
         app.services.get_class("provider"), "is_managed", lambda: managed
     )
@@ -1022,6 +1025,9 @@ def test_run_error(
     mock_dispatcher.load_command.side_effect = error
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
+    # Override the default of setting debug - here we're explicitly that we return
+    # properly in non-debug mode.
+    monkeypatch.setenv("CRAFT_DEBUG", "0")
 
     pytest_check.equal(app.run(), return_code)
     _, err = capsys.readouterr()

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -717,9 +717,6 @@ def test_get_arg_or_config(monkeypatch, app, parsed_args, environ, item, expecte
 def test_get_dispatcher_error(
     monkeypatch, check, capsys, app, mock_dispatcher, managed, error, exit_code, message
 ):
-    # Override the default of setting debug - here we're explicitly that we return
-    # properly in non-debug mode.
-    monkeypatch.setenv("CRAFT_DEBUG", "0")
     monkeypatch.setattr(
         app.services.get_class("provider"), "is_managed", lambda: managed
     )
@@ -1025,9 +1022,6 @@ def test_run_error(
     mock_dispatcher.load_command.side_effect = error
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
-    # Override the default of setting debug - here we're explicitly that we return
-    # properly in non-debug mode.
-    monkeypatch.setenv("CRAFT_DEBUG", "0")
 
     pytest_check.equal(app.run(), return_code)
     _, err = capsys.readouterr()
@@ -1083,7 +1077,7 @@ def test_run_error_with_docs_url(
 
 
 @pytest.mark.parametrize("error", [KeyError(), ValueError(), Exception()])
-@pytest.mark.usefixtures("emitter")
+@pytest.mark.usefixtures("emitter", "debug_mode")
 def test_run_error_debug(monkeypatch, mock_dispatcher, app, fake_project, error):
     app.set_project(fake_project)
     mock_dispatcher.load_command.side_effect = error

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -713,7 +713,7 @@ def test_get_arg_or_config(monkeypatch, app, parsed_args, environ, item, expecte
         ),
     ],
 )
-@pytest.mark.usefixtures("emitter")
+@pytest.mark.usefixtures("emitter", "production_mode")
 def test_get_dispatcher_error(
     monkeypatch, check, capsys, app, mock_dispatcher, managed, error, exit_code, message
 ):
@@ -1007,7 +1007,7 @@ def test_run_success_managed_inside_managed(
         ),
     ],
 )
-@pytest.mark.usefixtures("emitter")
+@pytest.mark.usefixtures("emitter", "production_mode")
 def test_run_error(
     monkeypatch,
     capsys,
@@ -1083,7 +1083,6 @@ def test_run_error_debug(monkeypatch, mock_dispatcher, app, fake_project, error)
     mock_dispatcher.load_command.side_effect = error
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
-    monkeypatch.setenv("CRAFT_DEBUG", "1")
 
     with pytest.raises(error.__class__):
         app.run()

--- a/tests/unit/test_pytest_plugin.py
+++ b/tests/unit/test_pytest_plugin.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Simple tests for the pytest plugin."""
+
+import os
+
+import pytest
+
+
+def test_sets_debug_mode():
+    assert os.getenv("CRAFT_DEBUG") == "1"
+
+
+@pytest.mark.usefixtures("production_mode")
+def test_production_mode_sets_production_mode():
+    assert os.getenv("CRAFT_DEBUG") == "0"

--- a/tests/unit/test_pytest_plugin.py
+++ b/tests/unit/test_pytest_plugin.py
@@ -65,13 +65,13 @@ def test_managed_and_destructive_mode_mutually_exclusive():
     pass
 
 
-def test_host_architecture(host_architecture: craft_platforms.DebianArchitecture):
-    platform_arch = host_architecture.to_platform_arch()
+def test_host_architecture(fake_host_architecture: craft_platforms.DebianArchitecture):
+    platform_arch = fake_host_architecture.to_platform_arch()
     pytest_check.equal(platform_arch, platform.uname().machine)
     pytest_check.equal(platform_arch, platform.machine())
-    pytest_check.equal(host_architecture.value, util.get_host_architecture())
+    pytest_check.equal(fake_host_architecture.value, util.get_host_architecture())
     pytest_check.equal(
-        host_architecture, craft_platforms.DebianArchitecture.from_host()
+        fake_host_architecture, craft_platforms.DebianArchitecture.from_host()
     )
 
 
@@ -87,3 +87,7 @@ def test_project_path_created_with_pyfakefs(fs: FakeFilesystem, project_path):
     assert project_path.is_dir()
     # Check that it's the hardcoded fake path for pyfakefs.
     assert project_path == pathlib.Path("/test/project")
+
+
+def test_in_project_path(in_project_path):
+    assert pathlib.Path.cwd() == in_project_path

--- a/tests/unit/test_pytest_plugin.py
+++ b/tests/unit/test_pytest_plugin.py
@@ -26,8 +26,7 @@ from pyfakefs.fake_filesystem import FakeFilesystem
 from craft_application import services, util
 
 
-@pytest.mark.usefixtures("debug_mode")
-def test_sets_debug_mode(app_metadata):
+def test_sets_debug_mode_auto_used(app_metadata):
     assert os.getenv("CRAFT_DEBUG") == "1"
 
     config_service = services.ConfigService(app=app_metadata, services=mock.Mock())


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

This adds a pytest plugin for craft-application, with several fixtures. The fixtures are documented on a [new reference page](https://canonical-craft-application--645.com.readthedocs.build/en/645/reference/pytest-plugin.html).

This is a breaking change because debug_mode is an auto-used fixture, any tests that rely on production mode will break.