### PR TITLE
feat(ProviderService): deprecate work_dir on instance

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -470,7 +470,6 @@ class Application:
 
             with self.services.provider.instance(
                 build_info,
-                work_dir=self._work_dir,
                 clean_existing=self._enable_fetch_service,
             ) as instance:
                 if self._enable_fetch_service:

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -24,6 +24,7 @@ import pathlib
 import pkgutil
 import sys
 import urllib.request
+import warnings
 from collections.abc import Generator, Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -125,7 +126,7 @@ class ProviderService(base.ProjectService):
         self,
         build_info: models.BuildInfo,
         *,
-        work_dir: pathlib.Path,
+        work_dir: pathlib.Path | None = None,
         allow_unstable: bool = True,
         clean_existing: bool = False,
         **kwargs: bool | str | None,
@@ -133,12 +134,20 @@ class ProviderService(base.ProjectService):
         """Context manager for getting a provider instance.
 
         :param build_info: Build information for the instance.
-        :param work_dir: Local path to mount inside the provider instance.
+        :param work_dir: (DEPRECATED) Local path to mount inside the provider instance.
         :param allow_unstable: Whether to allow the use of unstable images.
         :param clean_existing: Whether pre-existing instances should be wiped
           and re-created.
         :returns: a context manager of the provider instance.
         """
+        if work_dir is not None:
+            warnings.warn(
+                "work_dir is deprecated. Use the service's work dir instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        else:
+            work_dir = self._work_dir
         instance_name = self._get_instance_name(work_dir, build_info)
         emit.debug(f"Preparing managed instance {instance_name!r}")
         base_name = build_info.base

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,16 @@
 Changelog
 *********
 
+4.10.0 (YYYY-Mon-DD)
+--------------------
+
+Services
+========
+
+- Deprecate the ``work_dir`` parameter on :meth:`ProviderService.instance`. The
+  parameter is still used if provided, but is now optional. It will be removed in
+  a future release.
+
 4.9.1 (2025-Feb-12)
 -------------------
 
@@ -23,7 +33,7 @@ Application
 ===========
 
 - Add a feature to allow `Python plugins
-  https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/>`_
+  <https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/>`_
   to extend or modify the behaviour of applications that use craft-application as a
   framework. The plugin packages must be installed in the same virtual environment
   as the application.

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -527,7 +527,6 @@ def test_run_managed_success(mocker, app, fake_project, fake_build_plan):
     assert (
         mock.call(
             fake_build_plan[0],
-            work_dir=mock.ANY,
             clean_existing=False,
         )
         in mock_provider.instance.mock_calls
@@ -612,7 +611,6 @@ def test_run_managed_multiple(app, fake_project):
     app.run_managed(None, None)
 
     extra_args = {
-        "work_dir": mock.ANY,
         "clean_existing": False,
     }
     assert mock.call(info2, **extra_args) in mock_provider.instance.mock_calls
@@ -632,7 +630,6 @@ def test_run_managed_specified_arch(app, fake_project):
     app.run_managed(None, "arch2")
 
     extra_args = {
-        "work_dir": mock.ANY,
         "clean_existing": False,
     }
     assert mock.call(info2, **extra_args) in mock_provider.instance.mock_calls
@@ -652,7 +649,6 @@ def test_run_managed_specified_platform(app, fake_project):
     app.run_managed("a2", None)
 
     extra_args = {
-        "work_dir": mock.ANY,
         "clean_existing": False,
     }
     assert mock.call(info2, **extra_args) in mock_provider.instance.mock_calls

--- a/tests/unit/test_application_fetch.py
+++ b/tests/unit/test_application_fetch.py
@@ -117,7 +117,7 @@ def test_run_managed_fetch_service(
     instance_calls = [
         call
         for call in mock_provider.instance.mock_calls
-        if "work_dir" in call.kwargs and "clean_existing" in call.kwargs
+        if "clean_existing" in call.kwargs
     ]
 
     assert len(instance_calls) == len(fake_build_plan)


### PR DESCRIPTION
This is not needed since the ProviderService has a work_dir instance attribute.

Does not remove it though, as that will need to wait for a major release.

Related to #606 (but not yet a fix).

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
