### PR TITLE
refactor(ServiceFactory): de-dataclass the ServiceFactory 

### DIFF
--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -153,7 +153,8 @@ class FetchService(services.ProjectService):
 
         Only supports a single generated artifact, and only in managed runs.
         """
-        if not self._services.ProviderClass.is_managed():
+        # mypy doesn't accept accept ignore[union-attr] for unknown reasons.
+        if not self._services.ProviderClass.is_managed():  # type: ignore  # noqa: PGH003
             emit.debug("Unable to generate the project manifest on the host.")
             return
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

This makes the ServiceFactory no longer a dataclass. It's only a dataclass for historical reasons around the old way of registering services, but this is no longer necessary.

Requires #653 