### PR TITLE
feat: mark ServiceFactory.set_kwargs() as deprecated

### DIFF
--- a/craft_application/services/service_factory.py
+++ b/craft_application/services/service_factory.py
@@ -157,11 +157,11 @@ class ServiceFactory:
     ) -> None:
         """Set up the keyword arguments to pass to a particular service class.
 
-        PENDING DEPRECATION: use update_kwargs instead
+        DEPRECATED: use update_kwargs instead
         """
         warnings.warn(
-            PendingDeprecationWarning(
-                "ServiceFactory.set_kwargs is pending deprecation. Use update_kwargs instead."
+            DeprecationWarning(
+                "ServiceFactory.set_kwargs is deprecated. Use update_kwargs instead."
             ),
             stacklevel=2,
         )

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -7,6 +7,14 @@ Changelog
 5.0.0 (2025-Mon-DD)
 -------------------
 
+Services
+========
+
+- Setting the arguments for a service using the service factory's ``set_kwargs`` is
+  deprecated. Use ``update_kwargs`` instead or file `an issue
+  <https://github.com/canonical/craft-application/issues/new?template=bug.yaml>`_
+  if you still need this method.
+
 Testing
 =======
 

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -136,7 +136,7 @@ def test_set_kwargs(
         app_metadata, project=fake_project, PackageClass=MockPackageService
     )
 
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(DeprecationWarning):
         factory.set_kwargs("package", **kwargs)
 
     check.equal(factory.package, MockPackageService.mock_class.return_value)


### PR DESCRIPTION
This moves set_kwargs() from pending deprecation to deprecated. It doesn't change any behaviour other than the type of warning that it raises.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
