### PR TITLE
fix(fetch): don't pass config dir if empty

### DIFF
--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -18,6 +18,7 @@
 import contextlib
 import io
 import logging
+import os
 import pathlib
 import shlex
 import subprocess
@@ -149,10 +150,16 @@ def start_service() -> subprocess.Popen[str] | None:
     # Set config and spool directories
     base_dir = _get_service_base_dir()
 
-    for dir_name in ("config", "spool"):
-        dir_path = base_dir / dir_name
-        dir_path.mkdir(exist_ok=True)
-        cmd.append(f"--{dir_name}={dir_path}")
+    config_dir = base_dir / "config"
+    config_dir.mkdir(exist_ok=True)
+    if len(os.listdir(config_dir)) > 0:
+        cmd.append(f"--config={config_dir}")
+    else:
+        emit.debug(f"Local config dir {config_dir} is empty; skipping it.")
+
+    spool_path = base_dir / "spool"
+    spool_path.mkdir(exist_ok=True)
+    cmd.append(f"--spool={spool_path}")
 
     cert, cert_key = _obtain_certificate()
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,15 @@
 Changelog
 *********
 
+4.X.Y (2025-MMM-DD)
+-------------------
+
+Application
+===========
+
+- The integration with the fetch-service will no longer pass the custom configuration
+  directory option when starting the service if said directory is empty.
+
 4.10.0 (2025-Feb-27)
 --------------------
 


### PR DESCRIPTION
Stop passing the "--config=<dir>" parameter if said <dir> is empty. This lets the fetch-service use its own defaults, while still enabling configuration if the user actively puts configuration files in there.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
