### PR TITLE
fix(commands/lifecycle): Pass the correct platform and build-for

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -161,6 +161,15 @@ class LifecycleCommand(_BaseLifecycleCommand):
         """Run a lifecycle step command."""
         super()._run(parsed_args)
 
+        build_planner = self.services.get("build_plan")
+        config = self.services.get("config")
+        platform = getattr(parsed_args, "platform", None) or config.get("platform")
+        if platform:
+            build_planner.set_platforms(platform)
+        build_for = getattr(parsed_args, "build_for", None) or config.get("build_for")
+        if build_for:
+            build_planner.set_build_fors(build_for)
+
         if self._use_provider(parsed_args):
             fetch_service_policy = getattr(parsed_args, "fetch_service_policy", None)
             if fetch_service_policy:

--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -182,7 +182,7 @@ def start_service() -> subprocess.Popen[str] | None:
 
     # Wait a bit for the service to come online
     with contextlib.suppress(subprocess.TimeoutExpired):
-        fetch_process.wait(0.1)
+        fetch_process.wait(0.5)
 
     if fetch_process.poll() is not None:
         # fetch-service already exited, something is wrong

--- a/craft_application/services/buildplan.py
+++ b/craft_application/services/buildplan.py
@@ -23,6 +23,8 @@ from typing import Any, Literal, final
 import craft_platforms
 from craft_cli import emit
 
+from craft_application.errors import EmptyBuildPlanError
+
 from . import base
 
 
@@ -58,6 +60,8 @@ class BuildPlanService(base.AppService):
                 build_for=self.__build_for or None,
                 build_on=[craft_platforms.DebianArchitecture.from_host()],
             )
+        if not self.__plan:
+            raise EmptyBuildPlanError
         return self.__plan
 
     def _gen_exhaustive_build_plan(

--- a/testcraft/services/package.py
+++ b/testcraft/services/package.py
@@ -41,7 +41,8 @@ class PackageService(package.PackageService):
     def pack(self, prime_dir: pathlib.Path, dest: pathlib.Path) -> list[pathlib.Path]:
         """Pack a testcraft artifact."""
         project = self._services.get("project").get()
-        tarball_name = f"{project.name}-{project.version}.testcraft"
+        platform = self._services.get("build_plan").plan()[0].platform
+        tarball_name = f"{project.name}-{project.version}-{platform}.testcraft"
         with tarfile.open(dest / tarball_name, mode="w:xz") as tar:
             tar.add(prime_dir, arcname=".")
         return [dest / tarball_name]

--- a/tests/spread/testcraft/init-pack/task.yaml
+++ b/tests/spread/testcraft/init-pack/task.yaml
@@ -1,4 +1,4 @@
-summary: test testcraft init and testcraft pack
+summary: test testcraft init/pack/clean cycle
 
 environment:
   CRAFT_BUILD_ENVIRONMENT/managed: ""

--- a/tests/spread/testcraft/pack-empty-plan/task.yaml
+++ b/tests/spread/testcraft/pack-empty-plan/task.yaml
@@ -1,0 +1,7 @@
+summary: test testcraft pack with multiple platforms
+
+execute: |
+  (! testcraft pack) |& MATCH "No build matches"
+
+restore: |
+  rm -rf *.testcraft

--- a/tests/spread/testcraft/pack-empty-plan/testcraft.yaml
+++ b/tests/spread/testcraft/pack-empty-plan/testcraft.yaml
@@ -1,0 +1,13 @@
+name: empty-build
+description: This shouldn't build in any our spread environments.
+version: "0.1"
+
+base: ubuntu@24.04
+platforms:
+  all:
+    build-on: [s390x]
+    build-for: [all]
+
+parts:
+  my-test:
+    plugin: nil

--- a/tests/spread/testcraft/pack-multi/task.yaml
+++ b/tests/spread/testcraft/pack-multi/task.yaml
@@ -1,0 +1,13 @@
+summary: test testcraft pack with multiple platforms
+
+execute: |
+  testcraft pack
+
+  count=$(find . -maxdepth 1 -name '*.testcraft' | wc -l)
+  if [[ "${count}" != "2" ]]; then
+    echo "Wrong number (${count}) of outputs (expected 2)" >> /dev/stderr
+    exit 1
+  fi
+
+restore: |
+  rm -rf *.testcraft

--- a/tests/spread/testcraft/pack-multi/testcraft.yaml
+++ b/tests/spread/testcraft/pack-multi/testcraft.yaml
@@ -1,0 +1,15 @@
+name: pack-multi
+version: "0.1"
+
+base: ubuntu@24.04
+platforms:
+  ppc64el:
+    build-on: [amd64, arm64, ppc64el, s390x, riscv64]
+    build-for: [ppc64el]
+  s390x:
+    build-on: [amd64, arm64, ppc64el, s390x, riscv64]
+    build-for: s390x
+
+parts:
+  my-test:
+    plugin: nil

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,7 +49,9 @@ def provider_service(app_metadata, fake_project, fake_services, tmp_path):
 
 @pytest.fixture
 def mock_services(monkeypatch, app_metadata, fake_project):
-    services.ServiceFactory.register("config", mock.Mock(spec=services.ConfigService))
+    mock_config = mock.Mock(spec=services.ConfigService)
+    mock_config.return_value.get.return_value = None
+    services.ServiceFactory.register("config", mock_config)
     services.ServiceFactory.register("fetch", mock.Mock(spec=services.FetchService))
     services.ServiceFactory.register("init", mock.MagicMock(spec=services.InitService))
     services.ServiceFactory.register(

--- a/tests/unit/services/test_buildplan.py
+++ b/tests/unit/services/test_buildplan.py
@@ -27,6 +27,7 @@ import pytest_mock
 from craft_cli.pytest_plugin import RecordingEmitter
 from craft_platforms import BuildInfo, DebianArchitecture, DistroBase
 
+from craft_application.errors import EmptyBuildPlanError
 from craft_application.services.buildplan import BuildPlanService
 from craft_application.services.service_factory import ServiceFactory
 
@@ -42,6 +43,15 @@ def test__gen_exhaustive_build_plan(
     mock_create_build_plan.assert_called_once_with(
         app=app_metadata.name, project_data=stub_project
     )
+
+
+def test_plan_empty(
+    mocker: pytest_mock.MockFixture,
+    build_plan_service: BuildPlanService,
+):
+    mocker.patch.object(build_plan_service, "create_build_plan", return_value=[])
+    with pytest.raises(EmptyBuildPlanError):
+        build_plan_service.plan()
 
 
 _base = DistroBase("", "")

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -43,14 +43,16 @@ from craft_parts.executor import (
 )
 
 from craft_application import errors, models, util
-from craft_application.errors import PartsLifecycleError
+from craft_application.errors import EmptyBuildPlanError, PartsLifecycleError
 from craft_application.services import lifecycle
 from craft_application.services.buildplan import BuildPlanService
 from craft_application.util import repositories
 
 
 def skip_if_build_plan_empty(build_planner: BuildPlanService):
-    if not build_planner.plan():
+    try:
+        build_planner.plan()
+    except EmptyBuildPlanError:
         pytest.skip(reason="Empty build plan")
 
 


### PR DESCRIPTION
Fixes this:

```yaml
platforms:
  platform1:
    build-on: [amd64]
    build-for: [amd64]
  platform2:
    build-on: [amd64, arm64]
    build-for: [arm64]
```

-> (error comes from the managed instance, not the host)

```
Multiple builds match the current platform: 'platform1' and 'platform2'.
Recommended resolution: Check the "--platform" and "--build-for" parameters.
```

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
