### PR TITLE
chore: make _app_preprocess_project non-static

### DIFF
--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -297,8 +297,8 @@ class ProjectService(base.AppService):
             )
         return self.__partitions
 
-    @staticmethod
     def _app_preprocess_project(
+        self,
         project: dict[str, Any],
         *,
         build_on: str,


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Snapcraft allows a parse-info in parts entries. It's not allowed by craft-parts so snapcraft pops the key from the raw dictionary, saves it, and passes it to the package service where it is consumed.

This method is the best place to do that, but it needs to be non-static.