### PR TITLE
fix(testing): more intelligent test handling

### DIFF
--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -28,7 +28,7 @@ class SpreadBase(CraftBaseModel):
 
     model_config = pydantic.ConfigDict(
         CraftBaseModel.model_config,  # type: ignore[misc]
-        extra="ignore",
+        extra="allow",
     )
 
 
@@ -98,19 +98,15 @@ class SpreadBaseModel(SpreadBase):
 class SpreadSystem(SpreadBaseModel):
     """Processed spread system configuration."""
 
-    username: str
-    password: str
+    username: str | None = None
+    password: str | None = None
     workers: int | None = None
 
     @classmethod
     def from_craft(cls, simple: CraftSpreadSystem | None) -> Self:
         """Create a spread system configuration from the simplified version."""
         workers = simple.workers if simple else 1
-        return cls(
-            workers=workers,
-            username="spread",
-            password="spread",  # noqa: S106 (possible hardcoded password)
-        )
+        return cls(workers=workers)
 
 
 class SpreadBackend(SpreadBaseModel):
@@ -183,6 +179,11 @@ class SpreadSuite(SpreadBaseModel):
 
 class SpreadYaml(SpreadBaseModel):
     """Processed spread project configuration."""
+
+    model_config = pydantic.ConfigDict(
+        SpreadBaseModel.model_config,  # type: ignore[misc]
+        extra="forbid",
+    )
 
     project: str
     environment: dict[str, str]

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,7 +4,7 @@
 Changelog
 *********
 
-5.0.1 (2025-MM-DD)
+5.0.1 (2025-04-10)
 ------------------
 
 Commands
@@ -19,6 +19,9 @@ Services
 
 - The ``TestingService`` now outputs a correct discard script for spread.
 - ``Platforms`` models are more strictly validated.
+- ``spread.yaml`` files are parsed strictly for  top level keys, but pass through
+  second level keys to the spread process.
+- Spread tests run on their runners as root.
 
 5.0.0 (2025-03-26)
 ------------------


### PR DESCRIPTION
This runs spread tests as root and strictly parses only the top level of spread.yaml keys.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
