### PR TITLE
fix!(services/project): use project generation error

### DIFF
--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -47,6 +47,10 @@ class ProjectFileError(CraftError):
     """Errors to do with the project file or directory."""
 
 
+class ProjectGenerationError(CraftError):
+    """Errors to do with prime project generation."""
+
+
 class ProjectFileMissingError(ProjectFileError, FileNotFoundError):
     """Error finding project file."""
 

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -70,7 +70,7 @@ class ProjectService(base.AppService):
         """
         self._build_on = craft_platforms.DebianArchitecture.from_host()
         if self.is_configured:
-            raise errors.ProjectGenerationError("Project is already configured.")
+            raise RuntimeError("Project is already configured.")
 
         platforms = self.get_platforms()
         if platform and platform not in platforms:

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -70,7 +70,7 @@ class ProjectService(base.AppService):
         """
         self._build_on = craft_platforms.DebianArchitecture.from_host()
         if self.is_configured:
-            raise RuntimeError("Project is already configured.")
+            raise errors.ProjectGenerationError("Project is already configured.")
 
         platforms = self.get_platforms()
         if platform and platform not in platforms:
@@ -97,7 +97,7 @@ class ProjectService(base.AppService):
                 if build_for:
                     # Gives a clean error if the value of build_for is invalid.
                     _convert_build_for(build_for)
-                    raise RuntimeError(
+                    raise errors.ProjectGenerationError(
                         f"Cannot generate a project that builds on "
                         f"{self._build_on} and builds for {build_for}"
                     )

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,7 +4,7 @@
 Changelog
 *********
 
-5.0.1 (2025-MM-DD)
+5.0.1 (2025-04-10)
 ------------------
 
 Commands
@@ -19,6 +19,8 @@ Services
 
 - The ``TestingService`` now outputs a correct discard script for spread.
 - ``Platforms`` models are more strictly validated.
+- Raise ``ProjectGenerationError`` instead of ``RuntimeError`` in ``ProjectService``
+  when a project fails to generate.
 
 5.0.0 (2025-03-26)
 ------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ from jinja2 import FileSystemLoader
 from typing_extensions import override
 
 import craft_application
-from craft_application import application, git, launchpad, models, services
+from craft_application import application, errors, git, launchpad, models, services
 from craft_application.services import service_factory
 from craft_application.services.fetch import FetchService
 from craft_application.util import yaml
@@ -454,7 +454,7 @@ def fake_services(
 
     try:
         factory.get("project").configure(platform=platform, build_for=build_for)
-    except RuntimeError as exc:
+    except errors.ProjectGenerationError as exc:
         pytest.skip(str(exc))
     yield factory
 

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -548,16 +548,16 @@ def test_cannot_reconfigure(
     real_project_service.configure(platform=fake_platform, build_for=build_for)
 
     # Test that we can't re-render no matter the arguments.
-    with pytest.raises(RuntimeError, match="Project is already configured."):
+    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
         real_project_service.configure(platform=fake_platform, build_for=build_for)
 
-    with pytest.raises(RuntimeError, match="Project is already configured."):
+    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
         real_project_service.configure(platform=fake_platform, build_for=None)
 
-    with pytest.raises(RuntimeError, match="Project is already configured."):
+    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
         real_project_service.configure(build_for=build_for, platform=None)
 
-    with pytest.raises(RuntimeError, match="Project is already configured."):
+    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
         real_project_service.configure(platform=None, build_for=None)
 
 
@@ -610,14 +610,14 @@ def test_get_by_build_for(
 ):
     try:
         real_project_service.configure(build_for=build_for, platform=None)
-    except RuntimeError as exc:
+    except errors.ProjectGenerationError as exc:
         pytest.skip(f"Not a valid build on/for combo: {exc}")
     # This test takes two paths because not all build-on/build-for combinations are
     # valid. If the combination is valid, we check that we got the expected output.
     # If the combination is invalid, we check that the error was correct.
     try:
         result = real_project_service.get()
-    except RuntimeError as exc:
+    except errors.ProjectGenerationError as exc:
         assert (  # noqa: PT017
             exc.args[0]
             == f"Cannot generate a project that builds on {fake_host_architecture} and builds for {build_for}"

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -548,16 +548,24 @@ def test_cannot_reconfigure(
     real_project_service.configure(platform=fake_platform, build_for=build_for)
 
     # Test that we can't re-render no matter the arguments.
-    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
+    with pytest.raises(
+        errors.ProjectGenerationError, match="Project is already configured."
+    ):
         real_project_service.configure(platform=fake_platform, build_for=build_for)
 
-    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
+    with pytest.raises(
+        errors.ProjectGenerationError, match="Project is already configured."
+    ):
         real_project_service.configure(platform=fake_platform, build_for=None)
 
-    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
+    with pytest.raises(
+        errors.ProjectGenerationError, match="Project is already configured."
+    ):
         real_project_service.configure(build_for=build_for, platform=None)
 
-    with pytest.raises(errors.ProjectGenerationError, match="Project is already configured."):
+    with pytest.raises(
+        errors.ProjectGenerationError, match="Project is already configured."
+    ):
         real_project_service.configure(platform=None, build_for=None)
 
 

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -548,24 +548,16 @@ def test_cannot_reconfigure(
     real_project_service.configure(platform=fake_platform, build_for=build_for)
 
     # Test that we can't re-render no matter the arguments.
-    with pytest.raises(
-        errors.ProjectGenerationError, match="Project is already configured."
-    ):
+    with pytest.raises(RuntimeError, match="Project is already configured."):
         real_project_service.configure(platform=fake_platform, build_for=build_for)
 
-    with pytest.raises(
-        errors.ProjectGenerationError, match="Project is already configured."
-    ):
+    with pytest.raises(RuntimeError, match="Project is already configured."):
         real_project_service.configure(platform=fake_platform, build_for=None)
 
-    with pytest.raises(
-        errors.ProjectGenerationError, match="Project is already configured."
-    ):
+    with pytest.raises(RuntimeError, match="Project is already configured."):
         real_project_service.configure(build_for=build_for, platform=None)
 
-    with pytest.raises(
-        errors.ProjectGenerationError, match="Project is already configured."
-    ):
+    with pytest.raises(RuntimeError, match="Project is already configured."):
         real_project_service.configure(platform=None, build_for=None)
 
 


### PR DESCRIPTION
Specify a project generation error and use it instead of a generic
runtime error when configuring and generating the prime project.

Fixes #705 

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
