### PR TITLE
fix: only run post prime in the process that ran the lifecycle

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -325,6 +325,10 @@ class PrimeCommand(LifecyclePartsCommand):
     ) -> None:
         """Run the prime command."""
         super()._run(parsed_args, step_name=step_name)
+        if self._use_provider(parsed_args=parsed_args):
+            return
+        # Only run the post prime steps in the process that
+        # ran the lifecycle
         self._run_post_prime_steps()
 
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 *********
 
+5.0.3 (2025-MM-DD)
+------------------
+
+Fixes
+=====
+
+- `#716 <https://github.com/canonical/craft-application/issues/716>`_ - ``prime``
+  command fails in managed mode
+
+For a complete list of commits, check out the `5.0.3`_ release on GitHub.
+
 5.0.2 (2025-04-11)
 ------------------
 
@@ -12,6 +23,8 @@ Fixes
 
 - The craft-spread base model now contains an optional ``project`` key. It is currently
   overwritten by the ``test`` command.
+
+For a complete list of commits, check out the `5.0.2`_ release on GitHub.
 
 5.0.1 (2025-04-10)
 ------------------
@@ -679,3 +692,5 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _4.10.0: https://github.com/canonical/craft-application/releases/tag/4.10.0
 .. _5.0.0: https://github.com/canonical/craft-application/releases/tag/5.0.0
 .. _5.0.1: https://github.com/canonical/craft-application/releases/tag/5.0.1
+.. _5.0.2: https://github.com/canonical/craft-application/releases/tag/5.0.2
+.. _5.0.3: https://github.com/canonical/craft-application/releases/tag/5.0.3

--- a/tests/spread/testcraft/init-pack/task.yaml
+++ b/tests/spread/testcraft/init-pack/task.yaml
@@ -9,7 +9,14 @@ execute: |
   cd init-test
 
   testcraft init
+
+  # Test each step of the lifecycle in order.
+  testcraft pull
+  testcraft build
+  testcraft stage
+  testcraft prime
   testcraft pack
+
   testcraft clean
 
   if [[ $(find . -maxdepth 1 -name '*.testcraft') == "" ]]; then

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -750,3 +750,65 @@ def test_debug_pack(
         command.run(parsed_args)
 
     mock_subprocess_run.assert_called_once_with(["bash"], check=False)
+
+
+def test_run_post_prime(app_metadata, mock_services, mocker, fake_project_file):
+    command = PrimeCommand(
+        {
+            "app": app_metadata,
+            "services": mock_services,
+        }
+    )
+    mocked_run_post_prime_steps = mocker.patch.object(command, "_run_post_prime_steps")
+
+    parsed_args = argparse.Namespace(
+        destructive_mode=False,
+        parts=[],
+    )
+
+    command.run(parsed_args)
+
+    mocked_run_post_prime_steps.assert_not_called()
+
+
+def test_run_post_prime_destructive_mode(
+    app_metadata, mock_services, mocker, fake_project_file
+):
+    command = PrimeCommand(
+        {
+            "app": app_metadata,
+            "services": mock_services,
+        }
+    )
+    mocked_run_post_prime_steps = mocker.patch.object(command, "_run_post_prime_steps")
+
+    parsed_args = argparse.Namespace(
+        destructive_mode=True,
+        parts=[],
+    )
+
+    command.run(parsed_args)
+
+    mocked_run_post_prime_steps.assert_called_once()
+
+
+@pytest.mark.usefixtures("managed_mode")
+def test_run_post_prime_managed_mode(
+    app_metadata, mock_services, mocker, fake_project_file
+):
+    command = PrimeCommand(
+        {
+            "app": app_metadata,
+            "services": mock_services,
+        }
+    )
+    mocked_run_post_prime_steps = mocker.patch.object(command, "_run_post_prime_steps")
+
+    parsed_args = argparse.Namespace(
+        destructive_mode=False,
+        parts=[],
+    )
+
+    command.run(parsed_args)
+
+    mocked_run_post_prime_steps.assert_called_once()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,7 +48,7 @@ def provider_service(app_metadata, fake_project, fake_services, tmp_path):
 
 
 @pytest.fixture
-def mock_services(monkeypatch, app_metadata, fake_project):
+def mock_services(monkeypatch, app_metadata, fake_project, project_path):
     mock_config = mock.Mock(spec=services.ConfigService)
     mock_config.return_value.get.return_value = None
     services.ServiceFactory.register("config", mock_config)
@@ -75,7 +75,9 @@ def mock_services(monkeypatch, app_metadata, fake_project):
     monkeypatch.setattr(
         service_factory, "issubclass", forgiving_is_subclass, raising=False
     )
-    return services.ServiceFactory(app_metadata, project=fake_project)
+    factory = services.ServiceFactory(app_metadata, project=fake_project)
+    factory.update_kwargs("project", project_dir=project_path)
+    return factory
 
 
 @pytest.fixture


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Fixes #716
CRAFT-4425