### PR TITLE
fix: discover correct path to the SSL certificates

### DIFF
--- a/craft_application/git/_git_repo.py
+++ b/craft_application/git/_git_repo.py
@@ -36,10 +36,12 @@ from typing_extensions import Self
 try:
     import pygit2  # type: ignore[import-untyped]
 except Exception:  # noqa: BLE001 (narrower types are provided by the import)
+    from ._utils import find_ssl_cert_dir
+
     # This environment comes from ssl.get_default_verify_paths
     _old_env = os.getenv("SSL_CERT_DIR")
-    # Needs updating when the base changes for applications' snap
-    os.environ["SSL_CERT_DIR"] = "/snap/core22/current/etc/ssl/certs"
+
+    os.environ["SSL_CERT_DIR"] = find_ssl_cert_dir()
     import pygit2  # type: ignore[import-untyped]
 
     # Restore the environment in case the application shells out and the

--- a/craft_application/git/_utils.py
+++ b/craft_application/git/_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Git repository class helper utilities."""
+
+import os
+import pathlib
+
+import craft_cli
+import yaml
+
+_FALLBACK_PATH = "/snap/core22/current/etc/ssl/certs"
+
+
+def find_ssl_cert_dir() -> str:
+    """Find a correct path to the certificate files for the snap."""
+    if snap_env := os.environ.get("SNAP"):
+        snap_metadata_path = pathlib.Path(snap_env) / "meta" / "snap.yaml"
+
+        if snap_metadata_path.exists():
+            try:
+                metadata_yaml = yaml.safe_load(snap_metadata_path.read_text())
+            except (yaml.YAMLError, OSError) as err:
+                craft_cli.emit.debug(f"Cannot load: {snap_metadata_path}")
+                craft_cli.emit.debug(f"Error: {err}")
+            else:
+                if metadata_yaml:
+                    base = metadata_yaml.get("base") or "core22"
+                    return f"/snap/{base}/current/etc/ssl/certs"
+
+    return _FALLBACK_PATH

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -12,6 +12,7 @@ Fixes
 
 - `#716 <https://github.com/canonical/craft-application/issues/716>`_ - ``prime``
   command fails in managed mode
+- Correctly set SSL_CERT_DIR during pygit2 import on non-Ubuntu systems.
 
 For a complete list of commits, check out the `5.0.3`_ release on GitHub.
 

--- a/tests/unit/git/test_utils.py
+++ b/tests/unit/git/test_utils.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Tests for the pygit2 utils."""
+
+import pathlib
+import textwrap
+from typing import cast
+
+import pytest
+from pyfakefs import fake_filesystem
+
+from craft_application.git._utils import _FALLBACK_PATH, find_ssl_cert_dir
+
+
+@pytest.fixture
+def fake_snap_path(fs: fake_filesystem.FakeFilesystem) -> pathlib.Path:
+    fake_path = pathlib.Path("/craft", "snap", "test", "current")
+    fs.create_dir(fake_path)
+    return fake_path
+
+
+@pytest.fixture
+def fake_snap_env(
+    fake_snap_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SNAP", str(fake_snap_path))
+
+
+@pytest.fixture(params=["core22", "core24", "core26"])
+def fake_base(
+    request: pytest.FixtureRequest,
+    fake_snap_path: pathlib.Path,
+    fake_snap_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> str:
+    base = cast(str, request.param)
+    write_metadata(
+        fake_snap_path,
+        textwrap.dedent(
+            f"""\
+            base: {base}
+            """
+        ),
+    )
+    return base
+
+
+def write_metadata(snap_path: pathlib.Path, content: str) -> None:
+    snap_metadata = snap_path / "meta" / "snap.yaml"
+    snap_metadata.parent.mkdir()
+    snap_metadata.write_text(content)
+
+
+def test_import_fallback_in_non_snap_environment() -> None:
+    """Fallback to previous one if not running as a snap."""
+    assert find_ssl_cert_dir() == _FALLBACK_PATH, (
+        "Use fallback if not installed as a snap."
+    )
+
+
+@pytest.mark.usefixtures("fake_snap_env")
+def test_import_fallback_missing_metadata() -> None:
+    """Fallback to previous one if metadata is missing."""
+    assert find_ssl_cert_dir() == _FALLBACK_PATH, (
+        "Use fallback if not snap.yaml is missing."
+    )
+
+
+@pytest.mark.usefixtures("fake_snap_env")
+def test_import_fallback_empty_metadata(fake_snap_path: pathlib.Path) -> None:
+    """Fallback to previous one if metadata is empty."""
+    write_metadata(fake_snap_path, "")
+    assert find_ssl_cert_dir() == _FALLBACK_PATH, (
+        "Should return fallback if base not available in snap.yaml."
+    )
+
+
+@pytest.mark.usefixtures("fake_snap_env")
+def test_import_fallback_wrong_metadata(fake_snap_path: pathlib.Path) -> None:
+    """Fallback to previous one if metadata is incorrect."""
+    write_metadata(fake_snap_path, '{"i-am": "json"}')
+    assert find_ssl_cert_dir() == _FALLBACK_PATH, (
+        "Should return fallback if base not available in snap.yaml."
+    )
+
+
+def test_finding_correct_path_with_snap_metadata(fake_base: str) -> None:
+    """SSL_CERT_DIR should be set accordingly to the requesting snap base"""
+    assert find_ssl_cert_dir() == f"/snap/{fake_base}/current/etc/ssl/certs", (
+        f"Incorrect SSL_CERT_DIR for base: {fake_base!r}"
+    )


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

Use `meta/snap.yaml` to determine the base from which SSL certs should be downloaded during `pygit2` import on non-Ubuntu OS.

Closes: #679

(CRAFT-4321)

