### PR TITLE
feat(Application): capture httpx logs by default

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -56,6 +56,7 @@ DEFAULT_CLI_LOGGERS = frozenset(
         "craft_providers",
         "craft_store",
         "craft_application",
+        "httpx",  # Used by craft-store
     }
 )
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,15 @@
 Changelog
 *********
 
+5.1.0 (2025-MM-DD)
+------------------
+
+Application
+===========
+
+- The application now has craft-cli capture logs from HTTPX by default,
+  logging store requests for craft-store's Publisher Gateway.
+
 5.0.3 (2025-04-14)
 ------------------
 


### PR DESCRIPTION
This adds capturing of httpx logs to the log file to all apps by default. This is irrelevant if httpx is not used, but allows capturing request information from craft-store.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
