### PR TITLE
ci: lock to 24.04 amd64 image on google backend

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -21,6 +21,7 @@ backends:
     halt-timeout: 3h
     systems:
       - ubuntu-24.04-64:
+          image: ubuntu-2404-64
           workers: 4
           memory: 2G
           storage: 10G


### PR DESCRIPTION
arm support was recently added causing conflict

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
