### PR TITLE
feat(models): make the Platforms schema and processing work the same

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ publish: publish-pypi  ## Publish packages
 publish-pypi: clean pack-pip lint-twine  ##- Publish Python packages to pypi
 	uv tool run twine upload dist/*
 
+.PHONY: schema
+schema: install-uv  ## Make a schema file for testcraft.
+	mkdir -p schema
+	uv run python -c 'from craft_application.models import Project;import json; print(json.dumps(Project.model_json_schema(), indent=2))' > schema/testcraft.json
+
 # Find dependencies that need installing
 APT_PACKAGES :=
 ifeq ($(wildcard /usr/include/libxml2/libxml/xpath.h),)

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -70,7 +70,7 @@ class AppMetadata:
     summary: str | None = None
     version: str = field(init=False)
     docs_url: str | None = None
-    source_ignore_patterns: list[str] = field(default_factory=list)
+    source_ignore_patterns: list[str] = field(default_factory=list[str])
     managed_instance_project_path = pathlib.PurePosixPath("/root/project")
     project_variables: list[str] = field(default_factory=lambda: ["version"])
     mandatory_adoptable_fields: list[str] = field(default_factory=lambda: ["version"])

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -29,10 +29,14 @@ from craft_application.models.grammar import (
     get_grammar_aware_part_keywords,
 )
 from craft_application.models.metadata import BaseMetadata
+from craft_application.models.platforms import (
+    GenericPlatformsDict,
+    Platform,
+    PlatformsDict,
+)
 from craft_application.models.project import (
     DEVEL_BASE_INFOS,
     DEVEL_BASE_WARNING,
-    Platform,
     Project,
 )
 from craft_application.models.spread import (
@@ -49,7 +53,9 @@ __all__ = [
     "CraftBaseModel",
     "get_grammar_aware_part_keywords",
     "GrammarAwareProject",
+    "GenericPlatformsDict",
     "Platform",
+    "PlatformsDict",
     "Project",
     "ProjectName",
     "ProjectTitle",

--- a/craft_application/models/platforms.py
+++ b/craft_application/models/platforms.py
@@ -16,6 +16,7 @@
 """Models that describe platforms."""
 
 import enum
+import re
 from collections.abc import Iterable, Mapping
 from typing import ClassVar, get_args
 
@@ -135,7 +136,9 @@ class GenericPlatformsDict(dict[str, PT]):
     ) -> pydantic.json_schema.JsonSchemaValue:
         json_schema = handler(core_schema)
         json_schema = handler.resolve_ref_schema(json_schema)
-        arch_pattern_values = "|".join(key.value for key in cls._shorthand_keys)
+        arch_pattern_values = "|".join(
+            re.escape(key.value) for key in cls._shorthand_keys
+        )
         arch_platform_schema = cs.typed_dict_schema(
             {
                 "build-on": cs.typed_dict_field(

--- a/craft_application/models/platforms.py
+++ b/craft_application/models/platforms.py
@@ -1,0 +1,164 @@
+# This file is part of craft-application.
+#
+# Copyright 2023-2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Models that describe platforms."""
+
+import enum
+from collections.abc import Iterable, Mapping
+from typing import ClassVar, get_args
+
+import craft_platforms
+import pydantic
+from pydantic_core import core_schema as cs
+from typing_extensions import Any, Self, TypeVar
+
+from craft_application import errors
+from craft_application.models import base
+from craft_application.models.constraints import SingleEntryList, UniqueList
+
+
+class Platform(base.CraftBaseModel):
+    """Project platform definition.
+
+    This model defines how a single value under the ``platforms`` key works for a project.
+    """
+
+    build_on: UniqueList[str] | str = pydantic.Field(min_length=1)
+    build_for: SingleEntryList[str] | str
+
+    @pydantic.field_validator("build_on", "build_for", mode="before")
+    @classmethod
+    def _vectorise_architectures(cls, values: str | list[str]) -> list[str]:
+        """Convert string build-on and build-for to lists."""
+        if isinstance(values, str):
+            return [values]
+        return values
+
+    @pydantic.field_validator("build_on", "build_for", mode="after")
+    @classmethod
+    def _validate_architectures(cls, values: list[str]) -> list[str]:
+        """Validate the architecture entries.
+
+        Entries must be a valid debian architecture or 'all'. Architectures may
+        be preceded by an optional base prefix formatted as '[<base>:]<arch>'.
+
+        :raises ValueError: If any of the bases or architectures are not valid.
+        """
+        [craft_platforms.parse_base_and_architecture(arch) for arch in values]
+
+        return values
+
+    @pydantic.field_validator("build_on", mode="after")
+    @classmethod
+    def _validate_build_on_real_arch(cls, values: list[str]) -> list[str]:
+        """Validate that we must build on a real architecture."""
+        for value in values:
+            _, arch = craft_platforms.parse_base_and_architecture(value)
+            if arch == "all":
+                raise ValueError("'all' cannot be used for 'build-on'")
+        return values
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def _validate_platform_set(
+        cls, values: Mapping[str, list[str]]
+    ) -> Mapping[str, Any]:
+        """If build_for is provided, then build_on must also be."""
+        # "if values" here ensures that a None value errors properly.
+        if values and values.get("build_for") and not values.get("build_on"):
+            raise errors.CraftValidationError(
+                "'build-for' expects 'build-on' to also be provided."
+            )
+
+        return values
+
+    @classmethod
+    def from_platforms(cls, platforms: craft_platforms.Platforms) -> dict[str, Self]:
+        """Create a dictionary of these objects from craft_platforms PlatformDicts."""
+        result: dict[str, Self] = {}
+        for key, value in platforms.items():
+            name = str(key)
+            platform = (
+                {"build-on": [name], "build-for": [name]} if value is None else value
+            )
+            result[name] = cls.model_validate(platform)
+        return result
+
+
+PT = TypeVar("PT", bound=Platform)
+
+
+class GenericPlatformsDict(dict[str, PT]):
+    """A generic dictionary describing the contents of the platforms key.
+
+    This class exists to generate Pydantic and JSON schemas for the platforms key on
+    a project. By making it a generic, an application can override the Platform
+    definition and provide its own PlatformsDict. A side effect of this, however, is
+    that an application cannot simply.
+    """
+
+    _shorthand_keys: ClassVar[type[enum.Enum] | Iterable[enum.Enum]] = (
+        craft_platforms.DebianArchitecture
+    )
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: type, handler: pydantic.GetCoreSchemaHandler
+    ) -> cs.CoreSchema:
+        try:
+            (value_type,) = get_args(
+                cls.__orig_bases__[0]  # type: ignore[attr-defined]
+            )
+        except (ValueError, AttributeError):
+            raise RuntimeError(
+                "Cannot get value type. This likely means the application is using "
+                "GenericPlatformsDict directly rather than creating a child class."
+            )
+        return cs.dict_schema(cs.str_schema(), value_type.__pydantic_core_schema__)
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: cs.CoreSchema, handler: pydantic.GetJsonSchemaHandler
+    ) -> pydantic.json_schema.JsonSchemaValue:
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        arch_pattern_values = "|".join(key.value for key in cls._shorthand_keys)
+        arch_platform_schema = cs.typed_dict_schema(
+            {
+                "build-on": cs.typed_dict_field(
+                    cs.union_schema([cs.str_schema(), cs.list_schema(cs.str_schema())]),
+                    required=True,
+                ),
+                "build-for": cs.typed_dict_field(
+                    cs.union_schema([cs.str_schema(), cs.list_schema(cs.str_schema())]),
+                    required=False,
+                ),
+            },
+            total=True,
+        )
+        json_schema["patternProperties"] = {
+            f"({arch_pattern_values})": handler(
+                cs.union_schema([cs.none_schema(), arch_platform_schema])
+            )
+        }
+        return json_schema
+
+
+class PlatformsDict(GenericPlatformsDict[Platform]):
+    """A dictionary with a pydantic schema for the general platforms key.
+
+    It is a non-generic implementation of GenericPlatformsDict using the default
+    Platforms model.
+    """

--- a/craft_application/models/platforms.py
+++ b/craft_application/models/platforms.py
@@ -106,7 +106,8 @@ class GenericPlatformsDict(dict[str, PT]):
     This class exists to generate Pydantic and JSON schemas for the platforms key on
     a project. By making it a generic, an application can override the Platform
     definition and provide its own PlatformsDict. A side effect of this, however, is
-    that an application cannot simply.
+    that an application cannot simply use the generic directly. Instead, it must create
+    a non-generic child class and use that.
     """
 
     _shorthand_keys: ClassVar[type[enum.Enum] | Iterable[enum.Enum]] = (

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -1,6 +1,6 @@
 # This file is part of craft-application.
 #
-# Copyright 2023-2024 Canonical Ltd.
+# Copyright 2023-2025 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -19,27 +19,25 @@ This defines the structure of the input file (e.g. snapcraft.yaml)
 """
 
 import dataclasses
-from collections.abc import Mapping
 from typing import Annotated, Any
 
 import craft_parts
-import craft_platforms
 import craft_providers.bases
 import pydantic
 from craft_cli import emit
 from craft_providers.errors import BaseConfigurationError
-from typing_extensions import Self
 
-from craft_application import errors
 from craft_application.models import base
 from craft_application.models.constraints import (
     ProjectName,
     ProjectTitle,
-    SingleEntryList,
     SummaryStr,
-    UniqueList,
     UniqueStrList,
     VersionStr,
+)
+from craft_application.models.platforms import (
+    Platform,
+    PlatformsDict,
 )
 
 
@@ -68,74 +66,6 @@ DEVEL_BASE_WARNING = (
     "as its contents are bound to change with the opening of new Ubuntu releases, "
     "suddenly and without warning."
 )
-
-
-class Platform(base.CraftBaseModel):
-    """Project platform definition.
-
-    This model defines how the ``platforms`` key works for a project.
-    """
-
-    build_on: UniqueList[str] = pydantic.Field(min_length=1)
-    build_for: SingleEntryList[str]
-
-    @pydantic.field_validator("build_on", "build_for", mode="before")
-    @classmethod
-    def _vectorise_architectures(cls, values: str | list[str]) -> list[str]:
-        """Convert string build-on and build-for to lists."""
-        if isinstance(values, str):
-            return [values]
-        return values
-
-    @pydantic.field_validator("build_on", "build_for", mode="after")
-    @classmethod
-    def _validate_architectures(cls, values: list[str]) -> list[str]:
-        """Validate the architecture entries.
-
-        Entries must be a valid debian architecture or 'all'. Architectures may
-        be preceded by an optional base prefix formatted as '[<base>:]<arch>'.
-
-        :raises ValueError: If any of the bases or architectures are not valid.
-        """
-        [craft_platforms.parse_base_and_architecture(arch) for arch in values]
-
-        return values
-
-    @pydantic.field_validator("build_on", mode="after")
-    @classmethod
-    def _validate_build_on_real_arch(cls, values: list[str]) -> list[str]:
-        """Validate that we must build on a real architecture."""
-        for value in values:
-            _, arch = craft_platforms.parse_base_and_architecture(value)
-            if arch == "all":
-                raise ValueError("'all' cannot be used for 'build-on'")
-        return values
-
-    @pydantic.model_validator(mode="before")
-    @classmethod
-    def _validate_platform_set(
-        cls, values: Mapping[str, list[str]]
-    ) -> Mapping[str, Any]:
-        """If build_for is provided, then build_on must also be."""
-        # "if values" here ensures that a None value errors properly.
-        if values and values.get("build_for") and not values.get("build_on"):
-            raise errors.CraftValidationError(
-                "'build-for' expects 'build-on' to also be provided."
-            )
-
-        return values
-
-    @classmethod
-    def from_platforms(cls, platforms: craft_platforms.Platforms) -> dict[str, Self]:
-        """Create a dictionary of these objects from craft_platforms PlatformDicts."""
-        result: dict[str, Self] = {}
-        for key, value in platforms.items():
-            name = str(key)
-            platform = (
-                {"build-on": [name], "build-for": [name]} if value is None else value
-            )
-            result[name] = cls.model_validate(platform)
-        return result
 
 
 def _expand_shorthand_platforms(platforms: dict[str, Any]) -> dict[str, Any]:
@@ -189,7 +119,7 @@ class Project(base.CraftBaseModel):
 
     base: str | None = None
     build_base: str | None = None
-    platforms: dict[str, Platform]
+    platforms: PlatformsDict
 
     contact: str | UniqueStrList | None = None
     issues: str | UniqueStrList | None = None

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -121,7 +121,9 @@ class SpreadBackend(SpreadBaseModel):
     type: str | None = None
     allocate: str | None = None
     discard: str | None = None
-    systems: list[dict[str, SpreadSystem]] = pydantic.Field(default_factory=list)
+    systems: list[dict[str, SpreadSystem]] = pydantic.Field(
+        default_factory=list[dict[str, SpreadSystem]]
+    )
     prepare: str | None = None
     restore: str | None = None
     prepare_each: str | None = None

--- a/craft_application/util/yaml.py
+++ b/craft_application/util/yaml.py
@@ -98,7 +98,7 @@ class _SafeYamlLoader(yaml.SafeLoader):
         )
 
 
-def safe_yaml_load(stream: TextIO) -> Any:  # noqa: ANN401 - The YAML could be anything
+def safe_yaml_load(stream: TextIO | str) -> Any:  # noqa: ANN401 - The YAML could be anything
     """Equivalent to pyyaml's safe_load function, but constraining duplicate keys.
 
     :param stream: Any text-like IO object.
@@ -109,7 +109,10 @@ def safe_yaml_load(stream: TextIO) -> Any:  # noqa: ANN401 - The YAML could be a
         # using our own safe loader.
         return yaml.load(stream, Loader=_SafeYamlLoader)  # noqa: S506
     except yaml.YAMLError as error:
-        filename = pathlib.Path(stream.name).name
+        if isinstance(stream, str):
+            filename = "(unknown)"
+        else:
+            filename = pathlib.Path(stream.name).name
         raise errors.YamlError.from_yaml_error(filename, error) from error
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dev = [
     "pytest-subprocess~=1.5.2",
     "pytest-time>=0.3.1",
     "responses~=0.25.0",
-    "craft-application[remote]"
+    "craft-application[remote]",
+    "jsonschema>=4.23.0",
 ]
 lint = [
     "black~=24.0",

--- a/tests/integration/models/invalid_testcraft/platforms-build-for.yaml
+++ b/tests/integration/models/invalid_testcraft/platforms-build-for.yaml
@@ -1,0 +1,8 @@
+name: bad-platforms
+parts: {}
+version: "0.0"
+summary: A platform missing a build-for
+
+platforms:
+  my-laptop:
+    build-on: [amd64, riscv64]

--- a/tests/integration/models/invalid_testcraft/platforms_short.yaml
+++ b/tests/integration/models/invalid_testcraft/platforms_short.yaml
@@ -1,0 +1,7 @@
+name: bad-platforms
+parts: {}
+version: "0.0"
+summary: A bad short-form platforms entry.
+
+platforms:
+  my-laptop:

--- a/tests/integration/models/test_project_schema.py
+++ b/tests/integration/models/test_project_schema.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Integration tests for checking valid project schemas."""
+
+import pathlib
+
+import jsonschema
+import pytest
+
+from craft_application import models, util
+from craft_application.errors import CraftValidationError
+from craft_application.models.platforms import Platform
+from craft_application.services.project import ProjectService
+from craft_application.services.service_factory import ServiceFactory
+
+VALID_SCHEMAS_DIR = pathlib.Path(__file__).parent / "valid_testcraft"
+INVALID_SCHEMAS_DIR = pathlib.Path(__file__).parent / "invalid_testcraft"
+
+
+@pytest.fixture
+def project_service(app_metadata, fake_services, in_project_path: pathlib.Path):
+    return ProjectService(
+        app=app_metadata, services=fake_services, project_dir=in_project_path
+    )
+
+
+@pytest.mark.parametrize(
+    "fake_project_yaml",
+    [
+        pytest.param(path.read_text(), id=path.name)
+        for path in VALID_SCHEMAS_DIR.glob("*.yaml")
+    ],
+)
+def test_valid_testcraft_projects(
+    fake_package_service_class,
+    app_metadata,
+    in_project_path,
+    fake_project_yaml: str,
+    fake_project_file: pathlib.Path,
+):
+    ServiceFactory.register("package", fake_package_service_class)
+    project_service = ProjectService(
+        app=app_metadata,
+        services=ServiceFactory(app_metadata),
+        project_dir=in_project_path,
+    )
+    schema = models.Project.model_json_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+
+    # Test that it's valid according to the schema.
+    validator.validate(util.safe_yaml_load(fake_project_yaml))
+
+    # Test that we can load it with the ProjectService
+    project_service.configure(platform=None, build_for=None)
+    project = project_service.get()
+
+    # Ensure that our resulting PlatformsDict is a normal dictionary.
+    assert isinstance(project.platforms, dict)
+    for name, platform in project.platforms.items():
+        assert isinstance(name, str)
+        assert isinstance(platform, Platform)
+
+
+@pytest.mark.parametrize(
+    "project_yaml",
+    [
+        pytest.param(path.read_text(), id=path.name)
+        for path in INVALID_SCHEMAS_DIR.glob("*.yaml")
+    ],
+)
+def test_invalid_testcraft_projects(
+    app_metadata,
+    in_project_path,
+    project_yaml: str,
+    fake_project_file: pathlib.Path,
+    fake_package_service_class,
+):
+    fake_project_file.write_text(project_yaml)
+    schema = models.Project.model_json_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(util.safe_yaml_load(project_yaml))
+
+    ServiceFactory.register("package", fake_package_service_class)
+    project_service = ProjectService(
+        app=app_metadata,
+        services=ServiceFactory(app_metadata),
+        project_dir=in_project_path,
+    )
+    with pytest.raises(CraftValidationError):  # noqa: PT012
+        project_service.configure(platform=None, build_for=None)
+        project_service.get()

--- a/tests/integration/models/valid_testcraft/minimal.yaml
+++ b/tests/integration/models/valid_testcraft/minimal.yaml
@@ -1,0 +1,7 @@
+name: minimal-valid-project
+parts: {}
+version: "0.0"
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]

--- a/tests/integration/models/valid_testcraft/platforms.yaml
+++ b/tests/integration/models/valid_testcraft/platforms.yaml
@@ -1,0 +1,17 @@
+name: platforms
+summary: Tests many possible platforms layouts.
+parts: {}
+version: "0.0"
+
+platforms:
+  amd64:  # Architecture-only shorthand
+  raspi:
+    build-on: [amd64, arm64]
+    build-for: [arm64]
+  riscv64:
+    build-on: [amd64, arm64, riscv64]
+  s390x:
+    build-on: amd64
+  phone:
+    build-on: [amd64, arm64, riscv64]
+    build-for: riscv64

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -200,7 +200,7 @@ def test_platform_from_platforms(incoming, expected):
         pytest.param({}, "build-on\n  Field required", id="empty"),
         pytest.param(
             {"build-on": [], "build-for": ["all"]},
-            "build-on\n  List should have at least 1 item",
+            "build-on\n  Value should have at least 1 item",
             id="empty-build-on",
         ),
         pytest.param(

--- a/uv.lock
+++ b/uv.lock
@@ -406,6 +406,7 @@ dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "craft-application", extra = ["remote"] },
     { name = "hypothesis" },
+    { name = "jsonschema" },
     { name = "pyfakefs" },
     { name = "pytest" },
     { name = "pytest-check" },
@@ -474,6 +475,7 @@ dev = [
     { name = "coverage", extras = ["toml"], specifier = "==7.6.12" },
     { name = "craft-application", extras = ["remote"] },
     { name = "hypothesis", specifier = ">=6.0" },
+    { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "pyfakefs", specifier = "~=5.3" },
     { name = "pytest", specifier = "==8.3.5" },
     { name = "pytest-check", specifier = "==2.4.1" },
@@ -726,6 +728,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462 },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2024.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/db/58f950c996c793472e336ff3655b13fbcf1e3b359dcf52dcf3ed3b52c352/jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272", size = 15561 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf", size = 18459 },
 ]
 
 [[package]]
@@ -1523,6 +1552,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'group-17-craft-application-dev-jammy' and extra == 'group-17-craft-application-dev-noble') or (extra == 'group-17-craft-application-dev-jammy' and extra == 'group-17-craft-application-dev-oracular') or (extra == 'group-17-craft-application-dev-jammy' and extra == 'group-17-craft-application-dev-plucky') or (extra == 'group-17-craft-application-dev-noble' and extra == 'group-17-craft-application-dev-oracular') or (extra == 'group-17-craft-application-dev-noble' and extra == 'group-17-craft-application-dev-plucky') or (extra == 'group-17-craft-application-dev-oracular' and extra == 'group-17-craft-application-dev-plucky')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775 },
+]
+
+[[package]]
 name = "regex"
 version = "2024.11.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1631,6 +1674,102 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/97/63/759996eea0f17e8dc4c9ea9c60765292d28a7750bdbee073ad55d83caa57/responses-0.25.6.tar.gz", hash = "sha256:eae7ce61a9603004e76c05691e7c389e59652d91e94b419623c12bbfb8e331d8", size = 79145 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/c4/8d23584b3a3471ea6f5a18cfb035e11eeb9fa9b3112d901477c6ad10cc4e/responses-0.25.6-py3-none-any.whl", hash = "sha256:9cac8f21e1193bb150ec557875377e41ed56248aed94e4567ed644db564bacf1", size = 34730 },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/b3/52b213298a0ba7097c7ea96bee95e1947aa84cc816d48cebb539770cdf41/rpds_py-0.24.0.tar.gz", hash = "sha256:772cc1b2cd963e7e17e6cc55fe0371fb9c704d63e44cacec7b9b7f523b78919e", size = 26863 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/21/cbc43b220c9deb536b07fbd598c97d463bbb7afb788851891252fc920742/rpds_py-0.24.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:006f4342fe729a368c6df36578d7a348c7c716be1da0a1a0f86e3021f8e98724", size = 377531 },
+    { url = "https://files.pythonhosted.org/packages/42/15/cc4b09ef160483e49c3aab3b56f3d375eadf19c87c48718fb0147e86a446/rpds_py-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2d53747da70a4e4b17f559569d5f9506420966083a31c5fbd84e764461c4444b", size = 362273 },
+    { url = "https://files.pythonhosted.org/packages/8c/a2/67718a188a88dbd5138d959bed6efe1cc7413a4caa8283bd46477ed0d1ad/rpds_py-0.24.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8acd55bd5b071156bae57b555f5d33697998752673b9de554dd82f5b5352727", size = 388111 },
+    { url = "https://files.pythonhosted.org/packages/e5/e6/cbf1d3163405ad5f4a1a6d23f80245f2204d0c743b18525f34982dec7f4d/rpds_py-0.24.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7e80d375134ddb04231a53800503752093dbb65dad8dabacce2c84cccc78e964", size = 394447 },
+    { url = "https://files.pythonhosted.org/packages/21/bb/4fe220ccc8a549b38b9e9cec66212dc3385a82a5ee9e37b54411cce4c898/rpds_py-0.24.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60748789e028d2a46fc1c70750454f83c6bdd0d05db50f5ae83e2db500b34da5", size = 448028 },
+    { url = "https://files.pythonhosted.org/packages/a5/41/d2d6e0fd774818c4cadb94185d30cf3768de1c2a9e0143fc8bc6ce59389e/rpds_py-0.24.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e1daf5bf6c2be39654beae83ee6b9a12347cb5aced9a29eecf12a2d25fff664", size = 447410 },
+    { url = "https://files.pythonhosted.org/packages/a7/a7/6d04d438f53d8bb2356bb000bea9cf5c96a9315e405b577117e344cc7404/rpds_py-0.24.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b221c2457d92a1fb3c97bee9095c874144d196f47c038462ae6e4a14436f7bc", size = 389531 },
+    { url = "https://files.pythonhosted.org/packages/23/be/72e6df39bd7ca5a66799762bf54d8e702483fdad246585af96723109d486/rpds_py-0.24.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:66420986c9afff67ef0c5d1e4cdc2d0e5262f53ad11e4f90e5e22448df485bf0", size = 420099 },
+    { url = "https://files.pythonhosted.org/packages/8c/c9/ca100cd4688ee0aa266197a5cb9f685231676dd7d573041ca53787b23f4e/rpds_py-0.24.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:43dba99f00f1d37b2a0265a259592d05fcc8e7c19d140fe51c6e6f16faabeb1f", size = 564950 },
+    { url = "https://files.pythonhosted.org/packages/05/98/908cd95686d33b3ac8ac2e582d7ae38e2c3aa2c0377bf1f5663bafd1ffb2/rpds_py-0.24.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a88c0d17d039333a41d9bf4616bd062f0bd7aa0edeb6cafe00a2fc2a804e944f", size = 591778 },
+    { url = "https://files.pythonhosted.org/packages/7b/ac/e143726f1dd3215efcb974b50b03bd08a8a1556b404a0a7872af6d197e57/rpds_py-0.24.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc31e13ce212e14a539d430428cd365e74f8b2d534f8bc22dd4c9c55b277b875", size = 560421 },
+    { url = "https://files.pythonhosted.org/packages/60/28/add1c1d2fcd5aa354f7225d036d4492261759a22d449cff14841ef36a514/rpds_py-0.24.0-cp310-cp310-win32.whl", hash = "sha256:fc2c1e1b00f88317d9de6b2c2b39b012ebbfe35fe5e7bef980fd2a91f6100a07", size = 222089 },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/81f8066c6de44c507caca488ba336ae30d35d57f61fe10578824d1a70196/rpds_py-0.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:c0145295ca415668420ad142ee42189f78d27af806fcf1f32a18e51d47dd2052", size = 234622 },
+    { url = "https://files.pythonhosted.org/packages/80/e6/c1458bbfb257448fdb2528071f1f4e19e26798ed5ef6d47d7aab0cb69661/rpds_py-0.24.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2d3ee4615df36ab8eb16c2507b11e764dcc11fd350bbf4da16d09cda11fcedef", size = 377679 },
+    { url = "https://files.pythonhosted.org/packages/dd/26/ea4181ef78f58b2c167548c6a833d7dc22408e5b3b181bda9dda440bb92d/rpds_py-0.24.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e13ae74a8a3a0c2f22f450f773e35f893484fcfacb00bb4344a7e0f4f48e1f97", size = 362571 },
+    { url = "https://files.pythonhosted.org/packages/56/fa/1ec54dd492c64c280a2249a047fc3369e2789dc474eac20445ebfc72934b/rpds_py-0.24.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf86f72d705fc2ef776bb7dd9e5fbba79d7e1f3e258bf9377f8204ad0fc1c51e", size = 388012 },
+    { url = "https://files.pythonhosted.org/packages/3a/be/bad8b0e0f7e58ef4973bb75e91c472a7d51da1977ed43b09989264bf065c/rpds_py-0.24.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c43583ea8517ed2e780a345dd9960896afc1327e8cf3ac8239c167530397440d", size = 394730 },
+    { url = "https://files.pythonhosted.org/packages/35/56/ab417fc90c21826df048fc16e55316ac40876e4b790104ececcbce813d8f/rpds_py-0.24.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4cd031e63bc5f05bdcda120646a0d32f6d729486d0067f09d79c8db5368f4586", size = 448264 },
+    { url = "https://files.pythonhosted.org/packages/b6/75/4c63862d5c05408589196c8440a35a14ea4ae337fa70ded1f03638373f06/rpds_py-0.24.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:34d90ad8c045df9a4259c47d2e16a3f21fdb396665c94520dbfe8766e62187a4", size = 446813 },
+    { url = "https://files.pythonhosted.org/packages/e7/0c/91cf17dffa9a38835869797a9f041056091ebba6a53963d3641207e3d467/rpds_py-0.24.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e838bf2bb0b91ee67bf2b889a1a841e5ecac06dd7a2b1ef4e6151e2ce155c7ae", size = 389438 },
+    { url = "https://files.pythonhosted.org/packages/1b/b0/60e6c72727c978276e02851819f3986bc40668f115be72c1bc4d922c950f/rpds_py-0.24.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04ecf5c1ff4d589987b4d9882872f80ba13da7d42427234fce8f22efb43133bc", size = 420416 },
+    { url = "https://files.pythonhosted.org/packages/a1/d7/f46f85b9f863fb59fd3c534b5c874c48bee86b19e93423b9da8784605415/rpds_py-0.24.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:630d3d8ea77eabd6cbcd2ea712e1c5cecb5b558d39547ac988351195db433f6c", size = 565236 },
+    { url = "https://files.pythonhosted.org/packages/2a/d1/1467620ded6dd70afc45ec822cdf8dfe7139537780d1f3905de143deb6fd/rpds_py-0.24.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ebcb786b9ff30b994d5969213a8430cbb984cdd7ea9fd6df06663194bd3c450c", size = 592016 },
+    { url = "https://files.pythonhosted.org/packages/5d/13/fb1ded2e6adfaa0c0833106c42feb290973f665300f4facd5bf5d7891d9c/rpds_py-0.24.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:174e46569968ddbbeb8a806d9922f17cd2b524aa753b468f35b97ff9c19cb718", size = 560123 },
+    { url = "https://files.pythonhosted.org/packages/1e/df/09fc1857ac7cc2eb16465a7199c314cbce7edde53c8ef21d615410d7335b/rpds_py-0.24.0-cp311-cp311-win32.whl", hash = "sha256:5ef877fa3bbfb40b388a5ae1cb00636a624690dcb9a29a65267054c9ea86d88a", size = 222256 },
+    { url = "https://files.pythonhosted.org/packages/ff/25/939b40bc4d54bf910e5ee60fb5af99262c92458f4948239e8c06b0b750e7/rpds_py-0.24.0-cp311-cp311-win_amd64.whl", hash = "sha256:e274f62cbd274359eff63e5c7e7274c913e8e09620f6a57aae66744b3df046d6", size = 234718 },
+    { url = "https://files.pythonhosted.org/packages/1a/e0/1c55f4a3be5f1ca1a4fd1f3ff1504a1478c1ed48d84de24574c4fa87e921/rpds_py-0.24.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:d8551e733626afec514b5d15befabea0dd70a343a9f23322860c4f16a9430205", size = 366945 },
+    { url = "https://files.pythonhosted.org/packages/39/1b/a3501574fbf29118164314dbc800d568b8c1c7b3258b505360e8abb3902c/rpds_py-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e374c0ce0ca82e5b67cd61fb964077d40ec177dd2c4eda67dba130de09085c7", size = 351935 },
+    { url = "https://files.pythonhosted.org/packages/dc/47/77d3d71c55f6a374edde29f1aca0b2e547325ed00a9da820cabbc9497d2b/rpds_py-0.24.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d69d003296df4840bd445a5d15fa5b6ff6ac40496f956a221c4d1f6f7b4bc4d9", size = 390817 },
+    { url = "https://files.pythonhosted.org/packages/4e/ec/1e336ee27484379e19c7f9cc170f4217c608aee406d3ae3a2e45336bff36/rpds_py-0.24.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8212ff58ac6dfde49946bea57474a386cca3f7706fc72c25b772b9ca4af6b79e", size = 401983 },
+    { url = "https://files.pythonhosted.org/packages/07/f8/39b65cbc272c635eaea6d393c2ad1ccc81c39eca2db6723a0ca4b2108fce/rpds_py-0.24.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:528927e63a70b4d5f3f5ccc1fa988a35456eb5d15f804d276709c33fc2f19bda", size = 451719 },
+    { url = "https://files.pythonhosted.org/packages/32/05/05c2b27dd9c30432f31738afed0300659cb9415db0ff7429b05dfb09bbde/rpds_py-0.24.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a824d2c7a703ba6daaca848f9c3d5cb93af0505be505de70e7e66829affd676e", size = 442546 },
+    { url = "https://files.pythonhosted.org/packages/7d/e0/19383c8b5d509bd741532a47821c3e96acf4543d0832beba41b4434bcc49/rpds_py-0.24.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44d51febb7a114293ffd56c6cf4736cb31cd68c0fddd6aa303ed09ea5a48e029", size = 393695 },
+    { url = "https://files.pythonhosted.org/packages/9d/15/39f14e96d94981d0275715ae8ea564772237f3fa89bc3c21e24de934f2c7/rpds_py-0.24.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3fab5f4a2c64a8fb64fc13b3d139848817a64d467dd6ed60dcdd6b479e7febc9", size = 427218 },
+    { url = "https://files.pythonhosted.org/packages/22/b9/12da7124905a680f690da7a9de6f11de770b5e359f5649972f7181c8bf51/rpds_py-0.24.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9be4f99bee42ac107870c61dfdb294d912bf81c3c6d45538aad7aecab468b6b7", size = 568062 },
+    { url = "https://files.pythonhosted.org/packages/88/17/75229017a2143d915f6f803721a6d721eca24f2659c5718a538afa276b4f/rpds_py-0.24.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:564c96b6076a98215af52f55efa90d8419cc2ef45d99e314fddefe816bc24f91", size = 596262 },
+    { url = "https://files.pythonhosted.org/packages/aa/64/8e8a1d8bd1b6b638d6acb6d41ab2cec7f2067a5b8b4c9175703875159a7c/rpds_py-0.24.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:75a810b7664c17f24bf2ffd7f92416c00ec84b49bb68e6a0d93e542406336b56", size = 564306 },
+    { url = "https://files.pythonhosted.org/packages/68/1c/a7eac8d8ed8cb234a9b1064647824c387753343c3fab6ed7c83481ed0be7/rpds_py-0.24.0-cp312-cp312-win32.whl", hash = "sha256:f6016bd950be4dcd047b7475fdf55fb1e1f59fc7403f387be0e8123e4a576d30", size = 224281 },
+    { url = "https://files.pythonhosted.org/packages/bb/46/b8b5424d1d21f2f2f3f2d468660085318d4f74a8df8289e3dd6ad224d488/rpds_py-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:998c01b8e71cf051c28f5d6f1187abbdf5cf45fc0efce5da6c06447cba997034", size = 239719 },
+    { url = "https://files.pythonhosted.org/packages/9d/c3/3607abc770395bc6d5a00cb66385a5479fb8cd7416ddef90393b17ef4340/rpds_py-0.24.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3d2d8e4508e15fc05b31285c4b00ddf2e0eb94259c2dc896771966a163122a0c", size = 367072 },
+    { url = "https://files.pythonhosted.org/packages/d8/35/8c7ee0fe465793e3af3298dc5a9f3013bd63e7a69df04ccfded8293a4982/rpds_py-0.24.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f00c16e089282ad68a3820fd0c831c35d3194b7cdc31d6e469511d9bffc535c", size = 351919 },
+    { url = "https://files.pythonhosted.org/packages/91/d3/7e1b972501eb5466b9aca46a9c31bcbbdc3ea5a076e9ab33f4438c1d069d/rpds_py-0.24.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:951cc481c0c395c4a08639a469d53b7d4afa252529a085418b82a6b43c45c240", size = 390360 },
+    { url = "https://files.pythonhosted.org/packages/a2/a8/ccabb50d3c91c26ad01f9b09a6a3b03e4502ce51a33867c38446df9f896b/rpds_py-0.24.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c9ca89938dff18828a328af41ffdf3902405a19f4131c88e22e776a8e228c5a8", size = 400704 },
+    { url = "https://files.pythonhosted.org/packages/53/ae/5fa5bf0f3bc6ce21b5ea88fc0ecd3a439e7cb09dd5f9ffb3dbe1b6894fc5/rpds_py-0.24.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0ef550042a8dbcd657dfb284a8ee00f0ba269d3f2286b0493b15a5694f9fe8", size = 450839 },
+    { url = "https://files.pythonhosted.org/packages/e3/ac/c4e18b36d9938247e2b54f6a03746f3183ca20e1edd7d3654796867f5100/rpds_py-0.24.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b2356688e5d958c4d5cb964af865bea84db29971d3e563fb78e46e20fe1848b", size = 441494 },
+    { url = "https://files.pythonhosted.org/packages/bf/08/b543969c12a8f44db6c0f08ced009abf8f519191ca6985509e7c44102e3c/rpds_py-0.24.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78884d155fd15d9f64f5d6124b486f3d3f7fd7cd71a78e9670a0f6f6ca06fb2d", size = 393185 },
+    { url = "https://files.pythonhosted.org/packages/da/7e/f6eb6a7042ce708f9dfc781832a86063cea8a125bbe451d663697b51944f/rpds_py-0.24.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6a4a535013aeeef13c5532f802708cecae8d66c282babb5cd916379b72110cf7", size = 426168 },
+    { url = "https://files.pythonhosted.org/packages/38/b0/6cd2bb0509ac0b51af4bb138e145b7c4c902bb4b724d6fd143689d6e0383/rpds_py-0.24.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:84e0566f15cf4d769dade9b366b7b87c959be472c92dffb70462dd0844d7cbad", size = 567622 },
+    { url = "https://files.pythonhosted.org/packages/64/b0/c401f4f077547d98e8b4c2ec6526a80e7cb04f519d416430ec1421ee9e0b/rpds_py-0.24.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:823e74ab6fbaa028ec89615ff6acb409e90ff45580c45920d4dfdddb069f2120", size = 595435 },
+    { url = "https://files.pythonhosted.org/packages/9f/ec/7993b6e803294c87b61c85bd63e11142ccfb2373cf88a61ec602abcbf9d6/rpds_py-0.24.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c61a2cb0085c8783906b2f8b1f16a7e65777823c7f4d0a6aaffe26dc0d358dd9", size = 563762 },
+    { url = "https://files.pythonhosted.org/packages/1f/29/4508003204cb2f461dc2b83dd85f8aa2b915bc98fe6046b9d50d4aa05401/rpds_py-0.24.0-cp313-cp313-win32.whl", hash = "sha256:60d9b630c8025b9458a9d114e3af579a2c54bd32df601c4581bd054e85258143", size = 223510 },
+    { url = "https://files.pythonhosted.org/packages/f9/12/09e048d1814195e01f354155fb772fb0854bd3450b5f5a82224b3a319f0e/rpds_py-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:6eea559077d29486c68218178ea946263b87f1c41ae7f996b1f30a983c476a5a", size = 239075 },
+    { url = "https://files.pythonhosted.org/packages/d2/03/5027cde39bb2408d61e4dd0cf81f815949bb629932a6c8df1701d0257fc4/rpds_py-0.24.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d09dc82af2d3c17e7dd17120b202a79b578d79f2b5424bda209d9966efeed114", size = 362974 },
+    { url = "https://files.pythonhosted.org/packages/bf/10/24d374a2131b1ffafb783e436e770e42dfdb74b69a2cd25eba8c8b29d861/rpds_py-0.24.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5fc13b44de6419d1e7a7e592a4885b323fbc2f46e1f22151e3a8ed3b8b920405", size = 348730 },
+    { url = "https://files.pythonhosted.org/packages/7a/d1/1ef88d0516d46cd8df12e5916966dbf716d5ec79b265eda56ba1b173398c/rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c347a20d79cedc0a7bd51c4d4b7dbc613ca4e65a756b5c3e57ec84bd43505b47", size = 387627 },
+    { url = "https://files.pythonhosted.org/packages/4e/35/07339051b8b901ecefd449ebf8e5522e92bcb95e1078818cbfd9db8e573c/rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20f2712bd1cc26a3cc16c5a1bfee9ed1abc33d4cdf1aabd297fe0eb724df4272", size = 394094 },
+    { url = "https://files.pythonhosted.org/packages/dc/62/ee89ece19e0ba322b08734e95441952062391065c157bbd4f8802316b4f1/rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aad911555286884be1e427ef0dc0ba3929e6821cbeca2194b13dc415a462c7fd", size = 449639 },
+    { url = "https://files.pythonhosted.org/packages/15/24/b30e9f9e71baa0b9dada3a4ab43d567c6b04a36d1cb531045f7a8a0a7439/rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0aeb3329c1721c43c58cae274d7d2ca85c1690d89485d9c63a006cb79a85771a", size = 438584 },
+    { url = "https://files.pythonhosted.org/packages/28/d9/49f7b8f3b4147db13961e19d5e30077cd0854ccc08487026d2cb2142aa4a/rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a0f156e9509cee987283abd2296ec816225145a13ed0391df8f71bf1d789e2d", size = 391047 },
+    { url = "https://files.pythonhosted.org/packages/49/b0/e66918d0972c33a259ba3cd7b7ff10ed8bd91dbcfcbec6367b21f026db75/rpds_py-0.24.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aa6800adc8204ce898c8a424303969b7aa6a5e4ad2789c13f8648739830323b7", size = 418085 },
+    { url = "https://files.pythonhosted.org/packages/e1/6b/99ed7ea0a94c7ae5520a21be77a82306aac9e4e715d4435076ead07d05c6/rpds_py-0.24.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a18fc371e900a21d7392517c6f60fe859e802547309e94313cd8181ad9db004d", size = 564498 },
+    { url = "https://files.pythonhosted.org/packages/28/26/1cacfee6b800e6fb5f91acecc2e52f17dbf8b0796a7c984b4568b6d70e38/rpds_py-0.24.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9168764133fd919f8dcca2ead66de0105f4ef5659cbb4fa044f7014bed9a1797", size = 590202 },
+    { url = "https://files.pythonhosted.org/packages/a9/9e/57bd2f9fba04a37cef673f9a66b11ca8c43ccdd50d386c455cd4380fe461/rpds_py-0.24.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f6e3cec44ba05ee5cbdebe92d052f69b63ae792e7d05f1020ac5e964394080c", size = 561771 },
+    { url = "https://files.pythonhosted.org/packages/9f/cf/b719120f375ab970d1c297dbf8de1e3c9edd26fe92c0ed7178dd94b45992/rpds_py-0.24.0-cp313-cp313t-win32.whl", hash = "sha256:8ebc7e65ca4b111d928b669713865f021b7773350eeac4a31d3e70144297baba", size = 221195 },
+    { url = "https://files.pythonhosted.org/packages/2d/e5/22865285789f3412ad0c3d7ec4dc0a3e86483b794be8a5d9ed5a19390900/rpds_py-0.24.0-cp313-cp313t-win_amd64.whl", hash = "sha256:675269d407a257b8c00a6b58205b72eec8231656506c56fd429d924ca00bb350", size = 237354 },
+    { url = "https://files.pythonhosted.org/packages/99/48/11dae46d0c7f7e156ca0971a83f89c510af0316cd5d42c771b7cef945f0c/rpds_py-0.24.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:619ca56a5468f933d940e1bf431c6f4e13bef8e688698b067ae68eb4f9b30e3a", size = 378224 },
+    { url = "https://files.pythonhosted.org/packages/33/18/e8398d255369e35d312942f3bb8ecaff013c44968904891be2ab63b3aa94/rpds_py-0.24.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:4b28e5122829181de1898c2c97f81c0b3246d49f585f22743a1246420bb8d399", size = 363252 },
+    { url = "https://files.pythonhosted.org/packages/17/39/dd73ba691f4df3e6834bf982de214086ac3359ab3ac035adfb30041570e3/rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8e5ab32cf9eb3647450bc74eb201b27c185d3857276162c101c0f8c6374e098", size = 388871 },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/da0530b25cabd0feca2a759b899d2df325069a94281eeea8ac44c6cfeff7/rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:208b3a70a98cf3710e97cabdc308a51cd4f28aa6e7bb11de3d56cd8b74bab98d", size = 394766 },
+    { url = "https://files.pythonhosted.org/packages/4c/ee/dd1c5040a431beb40fad4a5d7868acf343444b0bc43e627c71df2506538b/rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bbc4362e06f950c62cad3d4abf1191021b2ffaf0b31ac230fbf0526453eee75e", size = 448712 },
+    { url = "https://files.pythonhosted.org/packages/f5/ec/6b93ffbb686be948e4d91ec76f4e6757f8551034b2a8176dd848103a1e34/rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ebea2821cdb5f9fef44933617be76185b80150632736f3d76e54829ab4a3b4d1", size = 447150 },
+    { url = "https://files.pythonhosted.org/packages/55/d5/a1c23760adad85b432df074ced6f910dd28f222b8c60aeace5aeb9a6654e/rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9a4df06c35465ef4d81799999bba810c68d29972bf1c31db61bfdb81dd9d5bb", size = 390662 },
+    { url = "https://files.pythonhosted.org/packages/a5/f3/419cb1f9bfbd3a48c256528c156e00f3349e3edce5ad50cbc141e71f66a5/rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d3aa13bdf38630da298f2e0d77aca967b200b8cc1473ea05248f6c5e9c9bdb44", size = 421351 },
+    { url = "https://files.pythonhosted.org/packages/98/8e/62d1a55078e5ede0b3b09f35e751fa35924a34a0d44d7c760743383cd54a/rpds_py-0.24.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:041f00419e1da7a03c46042453598479f45be3d787eb837af382bfc169c0db33", size = 566074 },
+    { url = "https://files.pythonhosted.org/packages/fc/69/b7d1003166d78685da032b3c4ff1599fa536a3cfe6e5ce2da87c9c431906/rpds_py-0.24.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:d8754d872a5dfc3c5bf9c0e059e8107451364a30d9fd50f1f1a85c4fb9481164", size = 592398 },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/1c98bc99338c37faadd28dd667d336df7409d77b4da999506a0b6b1c0aa2/rpds_py-0.24.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:896c41007931217a343eff197c34513c154267636c8056fb409eafd494c3dcdc", size = 561114 },
+    { url = "https://files.pythonhosted.org/packages/2b/41/65c91443685a4c7b5f1dd271beadc4a3e063d57c3269221548dd9416e15c/rpds_py-0.24.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:92558d37d872e808944c3c96d0423b8604879a3d1c86fdad508d7ed91ea547d5", size = 235548 },
+    { url = "https://files.pythonhosted.org/packages/65/53/40bcc246a8354530d51a26d2b5b9afd1deacfb0d79e67295cc74df362f52/rpds_py-0.24.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f9e0057a509e096e47c87f753136c9b10d7a91842d8042c2ee6866899a717c0d", size = 378386 },
+    { url = "https://files.pythonhosted.org/packages/80/b0/5ea97dd2f53e3618560aa1f9674e896e63dff95a9b796879a201bc4c1f00/rpds_py-0.24.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6e109a454412ab82979c5b1b3aee0604eca4bbf9a02693bb9df027af2bfa91a", size = 363440 },
+    { url = "https://files.pythonhosted.org/packages/57/9d/259b6eada6f747cdd60c9a5eb3efab15f6704c182547149926c38e5bd0d5/rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc1c892b1ec1f8cbd5da8de287577b455e388d9c328ad592eabbdcb6fc93bee5", size = 388816 },
+    { url = "https://files.pythonhosted.org/packages/94/c1/faafc7183712f89f4b7620c3c15979ada13df137d35ef3011ae83e93b005/rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c39438c55983d48f4bb3487734d040e22dad200dab22c41e331cee145e7a50d", size = 395058 },
+    { url = "https://files.pythonhosted.org/packages/6c/96/d7fa9d2a7b7604a61da201cc0306a355006254942093779d7121c64700ce/rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d7e8ce990ae17dda686f7e82fd41a055c668e13ddcf058e7fb5e9da20b57793", size = 448692 },
+    { url = "https://files.pythonhosted.org/packages/96/37/a3146c6eebc65d6d8c96cc5ffdcdb6af2987412c789004213227fbe52467/rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9ea7f4174d2e4194289cb0c4e172d83e79a6404297ff95f2875cf9ac9bced8ba", size = 446462 },
+    { url = "https://files.pythonhosted.org/packages/1f/13/6481dfd9ac7de43acdaaa416e3a7da40bc4bb8f5c6ca85e794100aa54596/rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb2954155bb8f63bb19d56d80e5e5320b61d71084617ed89efedb861a684baea", size = 390460 },
+    { url = "https://files.pythonhosted.org/packages/61/e1/37e36bce65e109543cc4ff8d23206908649023549604fa2e7fbeba5342f7/rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04f2b712a2206e13800a8136b07aaedc23af3facab84918e7aa89e4be0260032", size = 421609 },
+    { url = "https://files.pythonhosted.org/packages/20/dd/1f1a923d6cd798b8582176aca8a0784676f1a0449fb6f07fce6ac1cdbfb6/rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:eda5c1e2a715a4cbbca2d6d304988460942551e4e5e3b7457b50943cd741626d", size = 565818 },
+    { url = "https://files.pythonhosted.org/packages/56/ec/d8da6df6a1eb3a418944a17b1cb38dd430b9e5a2e972eafd2b06f10c7c46/rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:9abc80fe8c1f87218db116016de575a7998ab1629078c90840e8d11ab423ee25", size = 592627 },
+    { url = "https://files.pythonhosted.org/packages/b3/14/c492b9c7d5dd133e13f211ddea6bb9870f99e4f73932f11aa00bc09a9be9/rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6a727fd083009bc83eb83d6950f0c32b3c94c8b80a9b667c87f4bd1274ca30ba", size = 560885 },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds a PlatformDict class that behaves as a standard dictionary, but allows pydantic to model it and its schema correctly. The implementation is in a generic class (GenericPlatformsDict) that allows overriding of both the Platform type (if an application needs to modify its Platform model) and the keys that can be used as shorthands.

Demo in Rockcraft: https://github.com/canonical/rockcraft/pull/862

Fixes #688
CRAFT-4421

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
