### PR TITLE
fix(git): read remotes without formatting in remote_contains

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -69,7 +69,7 @@ class AppMetadata:
     summary: str | None = None
     version: str = field(init=False)
     docs_url: str | None = None
-    source_ignore_patterns: list[str] = field(default_factory=list)
+    source_ignore_patterns: list[str] = field(default_factory=list[str])
     managed_instance_project_path = pathlib.PurePosixPath("/root/project")
     project_variables: list[str] = field(default_factory=lambda: ["version"])
     mandatory_adoptable_fields: list[str] = field(default_factory=lambda: ["version"])

--- a/craft_application/git/_git_repo.py
+++ b/craft_application/git/_git_repo.py
@@ -590,6 +590,8 @@ class GitRepo:
         checking_command = [
             self.get_git_command(),
             "branch",
+            "--color=never",
+            "--column=never",
             "--remotes",
             "--contains",
             commit_sha,

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -121,7 +121,9 @@ class SpreadBackend(SpreadBaseModel):
     type: str | None = None
     allocate: str | None = None
     discard: str | None = None
-    systems: list[dict[str, SpreadSystem]] = pydantic.Field(default_factory=list)
+    systems: list[dict[str, SpreadSystem]] = pydantic.Field(
+        default_factory=list[dict[str, SpreadSystem]]
+    )
     prepare: str | None = None
     restore: str | None = None
     prepare_each: str | None = None

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 *********
 
+5.0.4 (2025-MM-DD)
+------------------
+
+Fixes
+=====
+
+- Fix inconsistent command output in GitRepo.remote_contains, by removing
+  colors and columns.
+
+For a complete list of commits, check out the `5.0.4`_ release on GitHub.
+
 5.0.3 (2025-04-14)
 ------------------
 
@@ -695,3 +706,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _5.0.1: https://github.com/canonical/craft-application/releases/tag/5.0.1
 .. _5.0.2: https://github.com/canonical/craft-application/releases/tag/5.0.2
 .. _5.0.3: https://github.com/canonical/craft-application/releases/tag/5.0.3
+.. _5.0.4: https://github.com/canonical/craft-application/releases/tag/5.0.4

--- a/tests/unit/git/test_git.py
+++ b/tests/unit/git/test_git.py
@@ -1213,7 +1213,15 @@ def test_remote_contains(
     response: bool,
 ) -> None:
     fake_process.register(
-        [expected_git_command, "branch", "--remotes", "--contains", "fake-commit-sha"],
+        [
+            expected_git_command,
+            "branch",
+            "--color=never",
+            "--column=never",
+            "--remotes",
+            "--contains",
+            "fake-commit-sha",
+        ],
         stdout=command_output,
     )
     git_repo = GitRepo(empty_repository)
@@ -1229,7 +1237,15 @@ def test_remote_contains_fails_if_subprocess_fails(
     expected_git_command: str,
 ) -> None:
     fake_process.register(
-        [expected_git_command, "branch", "--remotes", "--contains", "fake-commit-sha"],
+        [
+            expected_git_command,
+            "branch",
+            "--color=never",
+            "--column=never",
+            "--remotes",
+            "--contains",
+            "fake-commit-sha",
+        ],
         returncode=1,
     )
     git_repo = GitRepo(empty_repository)


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

Fix inconsistent output originating that could be affected by local user settings for `GitRepo.remote_contains` , so discovery is predictable.