### PR TITLE
chore(services/testing): reduce spread verbosity level

### DIFF
--- a/craft_application/services/testing.py
+++ b/craft_application/services/testing.py
@@ -137,10 +137,7 @@ class TestingService(base.AppService):
         debug: bool = False,
     ) -> list[str]:
         """Get the full spread command to run."""
-        cmd = [
-            self._get_spread_executable(),
-            "-v",
-        ]
+        cmd = [self._get_spread_executable()]
         if shell:
             cmd.append("-shell")
         if shell_after:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,14 @@
 Changelog
 *********
 
+5.2.1 (2025-XX-YY)
+------------------
+
+Commands
+========
+
+- Reduce spread verbosity level when running the ``test`` command.
+
 5.2.0 (2025-04-25)
 ------------------
 

--- a/tests/spread/testcraft/test-cmd/task.yaml
+++ b/tests/spread/testcraft/test-cmd/task.yaml
@@ -3,10 +3,12 @@ summary: test the test command as though running in CI.
 environment:
   CRAFT_BUILD_ENVIRONMENT/managed: ""
   CRAFT_BUILD_ENVIRONMENT/destructive: host
+  CMDLINE/managed: ""
+  CMDLINE/destructive: --destructive-mode
   CI: "1"
 
 execute: |
-  testcraft test tests/spread/my-suite/my-task
+  testcraft test tests/spread/my-suite/my-task $CMDLINE
 
 restore: |
   testcraft clean

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -151,7 +151,7 @@ def test_run_spread(
     testing_service.run_spread(tmp_path)
     assert mock_run.mock_calls == [
         mock.call(
-            ["spread", "-v", testspec],
+            ["spread", testspec],
             check=True,
             stdout=mock.ANY,
             stderr=mock.ANY,


### PR DESCRIPTION
When invoking the `test` command, don't run spread in verbose
mode to reduce output noise.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
