### PR TITLE
fix(testing): don't change the output artifact location

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -389,10 +389,12 @@ class PackCommand(LifecycleCommand):
             _launch_shell()
             return
 
+        output = parsed_args.output or pathlib.Path()
+
         emit.progress("Packing...")
         try:
             packages = self._services.package.pack(
-                self._services.lifecycle.prime_dir, parsed_args.output
+                self._services.lifecycle.prime_dir, output
             )
         except Exception as err:
             if debug:

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -526,6 +526,7 @@ class TestCommand(PackCommand):
             testing_service.validate_tests(parsed_args.test_path)
 
         parsed_args.output = pathlib.Path.cwd()
+        parsed_args.fetch_service_policy = None
 
         # Don't enter a shell during the packing step, but save those values
         # for the testing service.

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -482,10 +482,6 @@ class TestCommand(PackCommand):
 
         if parsed_args.test_path:
             testing_service.validate_tests(parsed_args.test_path)
-        # Output into the spread directory.
-        parsed_args.output = pathlib.Path.cwd() / "spread"
-        parsed_args.output.mkdir(exist_ok=True)
-        parsed_args.fetch_service_policy = None
 
         # Don't enter a shell during the packing step, but save those values
         # for the testing service.

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -389,12 +389,10 @@ class PackCommand(LifecycleCommand):
             _launch_shell()
             return
 
-        output = parsed_args.output or pathlib.Path()
-
         emit.progress("Packing...")
         try:
             packages = self._services.package.pack(
-                self._services.lifecycle.prime_dir, output
+                self._services.lifecycle.prime_dir, parsed_args.output
             )
         except Exception as err:
             if debug:
@@ -526,6 +524,8 @@ class TestCommand(PackCommand):
 
         if parsed_args.test_path:
             testing_service.validate_tests(parsed_args.test_path)
+
+        parsed_args.output = pathlib.Path.cwd()
 
         # Don't enter a shell during the packing step, but save those values
         # for the testing service.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -33,6 +33,7 @@ Fixes
 - Enable terminal output when testing with ``--debug``, ``--shell``, or
   ``--shell-after`` parameters.
 - Don't repull sources on test files changes.
+- Generate artifacts for testing in the project root directory.
 - Normalize the list of artifacts packed in ``PackageService`` to be relative
   to the project root directory.
 

--- a/tests/spread/testcraft/test-cmd/tests/spread/my-suite/my-task/task.yaml
+++ b/tests/spread/testcraft/test-cmd/tests/spread/my-suite/my-task/task.yaml
@@ -6,6 +6,7 @@ prepare: |
 execute: |
   echo Running the test
   env
+  test -f "$CRAFT_ARTIFACT"
 
 restore: |
   echo Restoring the test

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -64,9 +64,7 @@ def mock_services(monkeypatch, app_metadata, fake_project, project_path):
     services.ServiceFactory.register(
         "remote_build", mock.Mock(spec=services.RemoteBuildService)
     )
-    services.ServiceFactory.register(
-        "testing", mock.Mock(spec=services.TestingService)
-    )
+    services.ServiceFactory.register("testing", mock.Mock(spec=services.TestingService))
 
     def forgiving_is_subclass(child, parent):
         if not isinstance(child, type):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -64,6 +64,9 @@ def mock_services(monkeypatch, app_metadata, fake_project, project_path):
     services.ServiceFactory.register(
         "remote_build", mock.Mock(spec=services.RemoteBuildService)
     )
+    services.ServiceFactory.register(
+        "testing", mock.Mock(spec=services.TestingService)
+    )
 
     def forgiving_is_subclass(child, parent):
         if not isinstance(child, type):


### PR DESCRIPTION
When running the `test` command, create the output artifact in the
standard output location instead of moving it to the spread
subdirectory.

Fixes #752

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
