### PR TITLE
fix(application)!: drop unused set_global_environment

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -701,14 +701,6 @@ class Application:
             pvars[var] = str(yaml_data.get(var, ""))
         return pvars
 
-    def _set_global_environment(self, info: craft_parts.ProjectInfo) -> None:
-        """Populate the ProjectInfo's global environment."""
-        info.global_environment.update(
-            {
-                "CRAFT_PROJECT_VERSION": info.get_project_var("version", raw_read=True),
-            }
-        )
-
     def _setup_logging(self) -> None:
         """Initialize the logging system."""
         # Set the logging level to DEBUG for all craft-libraries. This is OK even if

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -12,6 +12,8 @@ Application
 
 - Fix an issue where the fetch-service would fail to find the network used
   by LXD containers.
+- Remove the unused ``_set_global_environment()`` function. This function has
+  been replaced by ``update_project_environment()`` in the Project service.
 
 Commands
 ========


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

`application._set_global_environment()` was replaced by `services.project.update_project_environment()` but the now unused function still persists in craft-application. 