### PR TITLE
fix(testing): handle spread interactive shell

### DIFF
--- a/craft_application/services/testing.py
+++ b/craft_application/services/testing.py
@@ -186,7 +186,7 @@ class TestingService(base.AppService):
                 # until we implement a protocol to pause the emitter and handle
                 # terminal input and output inside an open_stream context. See
                 # https://github.com/canonical/craft-cli/issues/347
-                emit.debug("Interactive test selected, pause emitter to execute spread")
+                emit.debug("Pausing emitter for interactive spread shell")
                 with emit.pause():
                     subprocess.run(spread_command, check=True, cwd=spread_dir)
             else:

--- a/craft_application/services/testing.py
+++ b/craft_application/services/testing.py
@@ -186,6 +186,7 @@ class TestingService(base.AppService):
                 # until we implement a protocol to pause the emitter and handle
                 # terminal input and output inside an open_stream context. See
                 # https://github.com/canonical/craft-cli/issues/347
+                emit.debug("Interactive test selected, pause emitter to execute spread")
                 with emit.pause():
                     subprocess.run(spread_command, check=True, cwd=spread_dir)
             else:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -28,6 +28,8 @@ Fixes
 
 - Improve test result messages.
 - ``InitService`` no longer leaves empty files if rendering template fails.
+- Enable terminal output when testing with ``--debug``, ``--shell``, or
+  ``--shell-after`` parameters.
 
 For a complete list of commits, check out the `5.3.0`_ release on GitHub.
 

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -187,6 +187,13 @@ def test_run_spread_interactive(
     mock_emitter = mock.MagicMock(spec=craft_cli.messages.Emitter)
     mocker.patch.object(craft_application.services.testing, "emit", mock_emitter)
 
+    fake_host = craft_platforms.DistroBase(distribution="ubuntu", series="24.04")
+    mocker.patch.object(
+        craft_platforms.DistroBase,
+        "from_linux_distribution",
+        return_value=fake_host,
+    )
+
     testing_service.run_spread(
         tmp_path, shell=shell, shell_after=shell_after, debug=debug
     )

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -20,11 +20,13 @@ import stat
 from collections.abc import Collection
 from unittest import mock
 
+import craft_cli.messages
 import craft_platforms
 import distro
 import pytest
 from craft_cli import CraftError
 
+import craft_application.services.testing
 from craft_application import models
 from craft_application.services.testing import TestingService
 
@@ -158,3 +160,47 @@ def test_run_spread(
             cwd=tmp_path,
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    ("shell", "shell_after", "debug", "flags", "streams"),
+    [
+        (True, False, False, ["-shell"], {}),
+        (False, True, False, ["-shell-after"], {}),
+        (False, False, True, ["-debug"], {}),
+        (False, False, False, [], {"stdout": mock.ANY, "stderr": mock.ANY}),
+    ],
+)
+def test_run_spread_interactive(
+    tmp_path,
+    mocker,
+    testing_service: TestingService,
+    shell: bool,
+    shell_after: bool,
+    debug: bool,
+    flags: list[str],
+    streams: dict[str, any],
+):
+    mocker.patch("shutil.which", return_value="spread")
+    mock_run = mocker.patch("subprocess.run")
+    mock_emitter = mock.MagicMock(spec=craft_cli.messages.Emitter)
+    mocker.patch.object(craft_application.services.testing, "emit", mock_emitter)
+
+    testing_service.run_spread(
+        tmp_path, shell=shell, shell_after=shell_after, debug=debug
+    )
+    assert mock_run.mock_calls == [
+        mock.call(
+            ["spread", *flags, "craft:"],
+            check=True,
+            **streams,
+            cwd=tmp_path,
+        ),
+    ]
+
+    if shell or shell_after or debug:
+        mock_emitter.pause.assert_called()
+        mock_emitter.open_stream.assert_not_called()
+    else:
+        mock_emitter.pause.assert_not_called()
+        mock_emitter.open_stream.assert_called()

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -18,6 +18,7 @@
 import pathlib
 import stat
 from collections.abc import Collection
+from typing import Any
 from unittest import mock
 
 import craft_cli.messages
@@ -179,7 +180,7 @@ def test_run_spread_interactive(
     shell_after: bool,
     debug: bool,
     flags: list[str],
-    streams: dict[str, any],
+    streams: dict[str, Any],
 ):
     mocker.patch("shutil.which", return_value="spread")
     mock_run = mocker.patch("subprocess.run")

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -199,7 +199,7 @@ def test_run_spread_interactive(
     )
     assert mock_run.mock_calls == [
         mock.call(
-            ["spread", *flags, "craft:"],
+            ["spread", *flags, mock.ANY],
             check=True,
             **streams,
             cwd=tmp_path,


### PR DESCRIPTION
Pause the emitter and disable stream capture when running the test
command with `--shell`, `--shell-after` or `--debug`. This allows
terminal interaction with the spread shell, but the spread output is
not sent to the craft application log.
    
Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
