### PR TITLE
fix(ProviderService): forward the parallel build count vars

### DIFF
--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -46,7 +46,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from craft_application.services import ServiceFactory
 
 
-DEFAULT_FORWARD_ENVIRONMENT_VARIABLES: Iterable[str] = ()
+DEFAULT_FORWARD_ENVIRONMENT_VARIABLES: Iterable[str] = (
+    "CRAFT_PARALLEL_BUILD_COUNT",
+    "CRAFT_MAX_PARALLEL_BUILD_COUNT",
+)
 
 _REQUESTED_SNAPS: dict[str, Snap] = {}
 """Additional snaps to be installed using provider."""

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,14 +4,14 @@
 Changelog
 *********
 
-5.2.1 (2025-05-21)
+5.2.1 (2025-05-23)
 ------------------
 
 Services
 ========
 
-- `CRAFT_PARALLEL_BUILD_COUNT` and `CRAFT_MAX_PARALLEL_BUILD_COUNT` are now forwarded
-  to managed instances.
+- ``CRAFT_PARALLEL_BUILD_COUNT`` and ``CRAFT_MAX_PARALLEL_BUILD_COUNT`` are now
+  forwarded to managed instances.
 
 For a complete list of commits, check out the `5.2.1`_ release on GitHub.
 
@@ -761,3 +761,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _5.0.4: https://github.com/canonical/craft-application/releases/tag/5.0.4
 .. _5.1.0: https://github.com/canonical/craft-application/releases/tag/5.1.0
 .. _5.2.0: https://github.com/canonical/craft-application/releases/tag/5.2.0
+.. _5.2.1: https://github.com/canonical/craft-application/releases/tag/5.2.1

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 *********
 
+5.2.1 (2025-05-21)
+------------------
+
+Services
+========
+
+- `CRAFT_PARALLEL_BUILD_COUNT` and `CRAFT_MAX_PARALLEL_BUILD_COUNT` are now forwarded
+  to managed instances.
+
+For a complete list of commits, check out the `5.2.1`_ release on GitHub.
+
 5.2.0 (2025-04-25)
 ------------------
 


### PR DESCRIPTION
These were supposed to have been forwarded by default but never were.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
