### PR TITLE
fix(lifecycle): don't rebuild on test file changes

### DIFF
--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -225,6 +225,12 @@ class LifecycleService(base.AppService):
         emit.debug(f"Project vars: {self._project_vars}")
         emit.debug(f"Adopting part: {self._project.adopt_info}")
 
+        source_ignore_patterns = [
+            *self._app.source_ignore_patterns,
+            "spread.yaml",
+            "spread"
+        ]
+
         try:
             return LifecycleManager(
                 {"parts": self._project.parts},
@@ -232,7 +238,7 @@ class LifecycleService(base.AppService):
                 arch=build_for,
                 cache_dir=self._cache_dir,
                 work_dir=self._work_dir,
-                ignore_local_sources=self._app.source_ignore_patterns,
+                ignore_local_sources=source_ignore_patterns,
                 parallel_build_count=util.get_parallel_build_count(self._app.name),
                 project_vars_part_name=self._project.adopt_info,
                 project_vars=self._project_vars,

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -288,6 +288,13 @@ def test_init_parts_error(
         service.setup()
 
     assert exc_info.value.args == expected.args
+    assert mock_lifecycle.mock_calls[0].kwargs["ignore_local_sources"] == [
+        "*.snap",
+        "*.charm",
+        "*.starcraft",
+        "spread.yaml",
+        "spread",
+    ]
 
 
 def test_init_with_feature_package_repositories(


### PR DESCRIPTION
Add spread files to the list of files ignored by the lifecycle manager
when checking if a part source is outdated. This allows changes in test
files without repulling the part when using local sources.

Fixes #756

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
