### PR TITLE
fix(PackageService): normalize paths returned by the pack method

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -400,6 +400,11 @@ class PackCommand(LifecycleCommand):
                 _launch_shell()
             raise
 
+        # Normalize paths to the packaged artifacts to be relative to the
+        # project root. Paths outside of the project directory are removed
+        # from the list.
+        packages = self._normalize_paths(packages, root=self._app.project_dir)
+
         if parsed_args.fetch_service_policy and packages:
             self._services.fetch.create_project_manifest(packages)
 
@@ -421,6 +426,17 @@ class PackCommand(LifecycleCommand):
 
         if shell_after:
             _launch_shell()
+
+    @staticmethod
+    def _normalize_paths(
+        packages: list[pathlib.Path], root: pathlib.Path
+    ) -> list[pathlib.Path]:
+        normalized = []
+        for package in packages:
+            path = package.resolve()
+            if root in path.parents:
+                normalized.append(path.relative_to(root))
+        return normalized
 
     @override
     def _run(

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -28,6 +28,7 @@ Fixes
 
 - Improve test result messages.
 - ``InitService`` no longer leaves empty files if rendering template fails.
+- Normalize the list of artifacts packed in ``PackageService``.
 
 For a complete list of commits, check out the `5.3.0`_ release on GitHub.
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -813,3 +813,20 @@ def test_run_post_prime_managed_mode(
     command.run(parsed_args)
 
     mocked_run_post_prime_steps.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("root", "paths", "result"),
+    [
+        ("/", ["/foo"], ["foo"]),
+        ("/foo", ["/foo/bar", "/foo/baz"], ["bar", "baz"]),
+        ("/foo", ["relative"], []),
+        ("/foo", ["/not/inside/foo"], []),
+        ("/foo", ["/foo/bar", "/not/inside/foo"], ["bar"]),
+    ],
+)
+def test_normalize_paths(root, paths, result):
+    normalized_path = PackCommand._normalize_paths(
+        [pathlib.Path(p) for p in paths], root=pathlib.Path(root)
+    )
+    assert normalized_path == [pathlib.Path(p) for p in result]


### PR DESCRIPTION
The `pack` method is implemented in the application's `PackageService`
and returns a list of packed files to the command runner. Instead of
relying on the application returning resolved filesystem paths, let the
caller normalize them and discard invalid results in the process.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
