### PR TITLE
fix: mark Application._set_global_environment as deprecated

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -702,7 +702,17 @@ class Application:
         return pvars
 
     def _set_global_environment(self, info: craft_parts.ProjectInfo) -> None:
-        """Populate the ProjectInfo's global environment."""
+        """Populate the ProjectInfo's global environment.
+
+        DEPRECATED: This method is deprecated and is not called by default.
+        Use ``ProjectService.update_project_environment`` instead.
+        """
+        warnings.warn(
+            "Application._set_global_environment is deprecated and not called by "
+            "default. Use ProjectService.update_project_environment instead.",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
         info.global_environment.update(
             {
                 "CRAFT_PROJECT_VERSION": info.get_project_var("version", raw_read=True),

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -12,6 +12,8 @@ Application
 
 - Fix an issue where the fetch-service would fail to find the network used
   by LXD containers.
+- ``_set_global_environment`` method marked as deprecated for removal in the next
+  major release.
 
 Commands
 ========


### PR DESCRIPTION
I should have removed this in 5.0 but overlooked it, so we're stuck with it until the next major release. It's essentially dead code though.

Removal PR for 6.0 is at https://github.com/canonical/craft-application/pull/762

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
