### PR TITLE
ci: switch test runs to free GitHub public runners

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,9 +15,9 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
       fast-test-python-versions: '["3.10", "3.12"]'
-      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
       slow-test-python-versions: '["3.10", "3.12"]'
       lowest-python-platform: '["jammy", "amd64"]'
       lowest-python-version: "3.10"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -21,3 +21,4 @@ jobs:
       slow-test-python-versions: '["3.10", "3.12"]'
       lowest-python-platform: '["jammy", "amd64"]'
       lowest-python-version: "3.10"
+      use-lxd: true

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,9 +15,9 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm64"]'
       fast-test-python-versions: '["3.10", "3.12"]'
-      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm64"]'
       slow-test-python-versions: '["3.10", "3.12"]'
       lowest-python-platform: '["jammy", "amd64"]'
       lowest-python-version: "3.10"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,9 +15,9 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm64"]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
       fast-test-python-versions: '["3.10", "3.12"]'
-      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm64"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
       slow-test-python-versions: '["3.10", "3.12"]'
       lowest-python-platform: '["jammy", "amd64"]'
       lowest-python-version: "3.10"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -15,9 +15,9 @@ jobs:
   test:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '[["jammy", "amd64"], ["noble", "amd64"]]'
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
       fast-test-python-versions: '["3.10", "3.12"]'
-      slow-test-platforms: '[["jammy", "amd64"], ["noble", "amd64"]]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
       slow-test-python-versions: '["3.10", "3.12"]'
       lowest-python-platform: '["jammy", "amd64"]'
       lowest-python-version: "3.10"

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -19,6 +19,6 @@ jobs:
       fast-test-python-versions: '["3.10", "3.12"]'
       slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
       slow-test-python-versions: '["3.10", "3.12"]'
-      lowest-python-platform: '["jammy", "amd64"]'
+      lowest-python-platform: ubuntu-22.04
       lowest-python-version: "3.10"
       use-lxd: true


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

This doesn't prevent us from using self-hosted runners for testing on other architectures, but our guidance is to use the free runners if possible.
