### PR TITLE
fix(init): exit parent template dir context after using it

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -7,6 +7,12 @@ Changelog
 5.7.0 (2025-MM-DD)
 ------------------
 
+Commands
+========
+
+- ``InitCommand`` now keeps the parent template directory context alive while it's in
+  use.
+
 Services
 ========
 

--- a/tests/integration/commands/test_init.py
+++ b/tests/integration/commands/test_init.py
@@ -33,9 +33,8 @@ def mock_parent_template_dir(tmp_path, mocker):
     """Mock the parent template directory."""
     mocker.patch.object(
         InitCommand,
-        "parent_template_dir",
-        pathlib.Path(tmp_path) / "templates",
-    )
+        "template_dir_parent",
+    ).return_value.__enter__.return_value = pathlib.Path(tmp_path) / "templates"
 
 
 @pytest.fixture


### PR DESCRIPTION
The directory isn't guaranteed to exist after the context manager exits.

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

There were some unrelated lint/test failures.