### PR TITLE
fix(test): fix fetch service integration test for changed string

### DIFF
--- a/tests/integration/services/test_fetch.py
+++ b/tests/integration/services/test_fetch.py
@@ -198,11 +198,12 @@ def test_service_logging(app_service, mocker, tmp_path, monkeypatch, mock_instan
     lines = logfile.read_text().splitlines()
     create = discard = 0
     for line in lines:
-        if "creating session" in line:
+        if "create permissive session" in line:
             create += 1
         if "discarding session" in line:
             discard += 1
-    assert create == discard == expected
+    assert create == expected
+    assert discard == expected
 
 
 # Bash script to setup the build instance before the actual testing.


### PR DESCRIPTION
The fetch service had a load-bearing string change.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Linting issues are fixed in #803