### PR TITLE
feat(TestCommand): pack and test all packable platforms

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -87,7 +87,7 @@ class _BaseLifecycleCommand(base.ExtensibleCommand):
 
     @override
     def provider_name(self, parsed_args: argparse.Namespace) -> str | None:
-        return "lxd" if parsed_args.use_lxd else None
+        return "lxd" if getattr(parsed_args, "use_lxd", None) else None
 
     def _run_manager_for_build_plan(self, fetch_service_policy: str | None) -> None:
         """Run this command in managed mode, iterating over the generated build plan."""
@@ -411,7 +411,7 @@ class PackCommand(LifecycleCommand):
 
         packages = self._relativize_paths(packages, root=pathlib.Path())
 
-        if parsed_args.fetch_service_policy and packages:
+        if getattr(parsed_args, "fetch_service_policy", None) and packages:
             self._services.fetch.create_project_manifest(packages)
 
         if not packages:

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -156,14 +156,9 @@ class LifecycleService(base.AppService):
             raise errors.EmptyBuildPlanError
         return plan[0]
 
-    def _validate_build_plan(
-        self, build_info: craft_platforms.BuildInfo | None = None
-    ) -> None:
+    def _validate_build_plan(self) -> None:
         """Validate that the build plan is usable for a lifecycle run."""
-        if build_info is None:
-            plan = self._services.get("build_plan").plan()
-        else:
-            plan = [build_info]
+        plan = self._services.get("build_plan").plan()
         match len(plan):
             case 0:
                 raise errors.EmptyBuildPlanError
@@ -286,19 +281,16 @@ class LifecycleService(base.AppService):
         self,
         step_name: str | None,
         part_names: list[str] | None = None,
-        *,
-        build_info: craft_platforms.BuildInfo | None = None,
     ) -> None:
         """Run the lifecycle manager for the parts.
 
         :param step_name: The name of the target step (defaults to running the
             entire lifecycle)
         :param part_names: Which parts to build (defaults to all parts)
-        :param build_info: A specific build item to run.
         """
         target_step = _get_step(step_name) if step_name else None
 
-        self._validate_build_plan(build_info=build_info)
+        self._validate_build_plan()
 
         try:
             if self._project.package_repositories:

--- a/craft_application/services/package.py
+++ b/craft_application/services/package.py
@@ -72,9 +72,15 @@ class PackageService(base.AppService):
             value={k: str(v) for k, v in resources.items()} if resources else None,
         )
 
-    def read_state(self) -> models.PackState:
-        """Read the packaging state."""
-        platform = self._services.get("build_plan").plan()[0].platform
+    def read_state(self, platform: str | None = None) -> models.PackState:
+        """Read the packaging state.
+
+        :param platform: The name of the platform to read. If not provided, uses the
+            first platform in the build plan.
+        :returns: A PackState object containing the artifact and resources.
+        """
+        if platform is None:
+            platform = self._services.get("build_plan").plan()[0].platform
         state_service = self._services.get("state")
 
         artifact = cast(str | None, state_service.get("artifact", platform))

--- a/spread.yaml
+++ b/spread.yaml
@@ -21,8 +21,8 @@ backends:
       - ubuntu-24.04-64:
           image: ubuntu-2404-64
           workers: 4
-          memory: 2G
-          storage: 10G
+          memory: 4G
+          storage: 20G
   # lxd:  # Disabled due to https://github.com/canonical/spread/issues/215
   #   systems:
   #     - ubuntu-24.04

--- a/spread.yaml
+++ b/spread.yaml
@@ -127,6 +127,9 @@ prepare: |
   sudo snap install --dangerous --classic tests/spread/*.snap
   sudo snap alias testcraft.partitioncraft partitioncraft
 
+restore-each: |
+  testcraft clean || true
+
 suites:
   tests/spread/testcraft/:
     summary: Tests for testcraft core functionality

--- a/tests/spread/testcraft/test-cmd/task.yaml
+++ b/tests/spread/testcraft/test-cmd/task.yaml
@@ -1,18 +1,14 @@
 summary: test the test command as though running in CI.
 
 environment:
-  CRAFT_BUILD_ENVIRONMENT/managed: ""
-  CRAFT_BUILD_ENVIRONMENT/destructive: host
-  CMDLINE/managed: ""
-  CMDLINE/destructive: --destructive-mode
   CI: "1"
 
 execute: |
-  CRAFT_VERBOSITY_LEVEL=verbose testcraft test $CMDLINE 2> test_out.log
+  CRAFT_VERBOSITY_LEVEL=TRACE testcraft test 2>&1 | tee test_out.log
   grep -q "platform 'a'" test_out.log
   grep -q "platform 'b'" test_out.log
-  testcraft test tests/spread/my-suite/my-task $CMDLINE
-  testcraft test other:...:tests/spread/my-suite/my-task $CMDLINE 2>&1 | MATCH "No matches"
+  testcraft test tests/spread/my-suite/my-task
+  testcraft test other:...:tests/spread/my-suite/my-task 2>&1 | MATCH "No matches"
 
 restore: |
   testcraft clean

--- a/tests/spread/testcraft/test-cmd/task.yaml
+++ b/tests/spread/testcraft/test-cmd/task.yaml
@@ -8,9 +8,12 @@ environment:
   CI: "1"
 
 execute: |
-  testcraft test $CMDLINE
+  CRAFT_VERBOSITY_LEVEL=verbose testcraft test $CMDLINE 2> test_out.log
+  grep -q "platform 'a'" test_out.log
+  grep -q "platform 'b'" test_out.log
   testcraft test tests/spread/my-suite/my-task $CMDLINE
   testcraft test other:...:tests/spread/my-suite/my-task $CMDLINE 2>&1 | MATCH "No matches"
 
 restore: |
   testcraft clean
+  rm -f test_out.log

--- a/tests/spread/testcraft/test-cmd/task.yaml
+++ b/tests/spread/testcraft/test-cmd/task.yaml
@@ -7,10 +7,12 @@ execute: |
   CRAFT_VERBOSITY_LEVEL=TRACE testcraft test 2>&1 | tee test_out.log
   grep -q "platform 'a'" test_out.log
   grep -q "platform 'b'" test_out.log
-  testcraft test tests/spread/my-suite/my-task
+  CRAFT_VERBOSITY_LEVEL=verbose testcraft test tests/spread/my-suite/my-task 2>&1 | tee retest_out.log
+  grep -q 'Already packed: test-test-0.1-a.testcraft' retest_out.log
+  grep -q 'Already packed: test-test-0.1-b.testcraft' retest_out.log
   testcraft test other:...:tests/spread/my-suite/my-task 2>&1 | MATCH "No matches"
 
 restore: |
   rm -f *.testcraft
   testcraft clean
-  rm -f test_out.log
+  rm -f test_out.log retest_out.log

--- a/tests/spread/testcraft/test-cmd/testcraft.yaml
+++ b/tests/spread/testcraft/test-cmd/testcraft.yaml
@@ -4,9 +4,12 @@ version: "0.1"
 
 base: ubuntu@24.04
 platforms:
-  platform-independent:
+  a:
     build-on: [amd64, arm64, ppc64el, s390x, riscv64]
-    build-for: [all]
+    build-for: [amd64]
+  b:
+    build-on: [amd64, arm64, ppc64el, s390x, riscv64]
+    build-for: [amd64]
 
 parts:
   my-test:


### PR DESCRIPTION
This changes the test command to pack and test all packable platforms. Note that it is out of scope as to whether the tests are valid to run. For example, a cross-compiled riscv64 binary might not be executable if tested on an amd64 machine, but we will still be running the tests, which will likely fail.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
