### PR TITLE
fix(ci): install correct dependencies in the release workflow

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -13,8 +13,10 @@ jobs:
   source-wheel:
     runs-on: [self-hosted]
     steps:
-      - name: Install uv
-        run: sudo snap install --classic astral-uv
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic astral-uv
+          sudo apt install python3-venv
       - name: Checkout
         uses: actions/checkout@v4
       - name: Fetch tag annotations


### PR DESCRIPTION
Fixes this breakage: https://github.com/canonical/craft-application/actions/runs/16006147236/job/45154058058

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
