### PR TITLE
feat(ProjectService): make the ProjectService compatible with multi-base

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -77,6 +77,7 @@ class AppMetadata:
     ConfigModel: type[_config.ConfigModel] = _config.ConfigModel
 
     ProjectClass: type[models.Project] = models.Project
+    supports_multi_base: bool = False
 
     def __post_init__(self) -> None:
         setter = super().__setattr__

--- a/craft_application/models/platforms.py
+++ b/craft_application/models/platforms.py
@@ -51,7 +51,7 @@ class Platform(base.CraftBaseModel):
     build_for: SingleEntryList[str] | str = pydantic.Field(
         examples=[
             "amd64",
-            ["arm64", "riscv64"],
+            ["riscv64"],
         ]
     )
     """Target architecture for the build.

--- a/craft_application/services/buildplan.py
+++ b/craft_application/services/buildplan.py
@@ -41,6 +41,8 @@ class BuildPlanService(base.AppService):
     def set_platforms(self, *platform: str) -> None:
         """Set the platforms for the build plan."""
         self.__platforms = list(platform)
+        # Reset cached plan
+        self.__plan = None
 
     def set_build_fors(
         self, *build_for: craft_platforms.DebianArchitecture | str
@@ -50,6 +52,7 @@ class BuildPlanService(base.AppService):
             "all" if target == "all" else craft_platforms.DebianArchitecture(target)
             for target in build_for
         ]
+        # Reset cached plan
         self.__plan = None
 
     @final

--- a/craft_application/services/buildplan.py
+++ b/craft_application/services/buildplan.py
@@ -50,6 +50,7 @@ class BuildPlanService(base.AppService):
             "all" if target == "all" else craft_platforms.DebianArchitecture(target)
             for target in build_for
         ]
+        self.__plan = None
 
     @final
     def plan(self) -> Sequence[craft_platforms.BuildInfo]:

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -300,10 +300,10 @@ class ProjectService(base.AppService):
                     if base:
                         multi_base_platforms.add(name)
         if multi_base_platforms:
-            invalid_platforms_str = ",".join(repr(p) for p in multi_base_platforms)
+            invalid_platforms_str = ", ".join(repr(p) for p in multi_base_platforms)
             raise errors.CraftValidationError(
                 f"{self._app.name.title()} does not support multi-base platforms",
-                resolution=f"Remove multi-base structure from platforms: {invalid_platforms_str}",
+                resolution=f"Remove multi-base structure from these platforms: {invalid_platforms_str}",
                 logpath_report=False,
                 retcode=os.EX_DATAERR,
             )
@@ -562,7 +562,7 @@ class ProjectService(base.AppService):
         """Convert a build-on value to a valid internal value.
 
         :param architecture: A valid build-for architecture as a string
-        :returns: The architecture as a DebianArchitecture or the special case string "all"
+        :returns: The architecture as a DebianArchitecture
         :raises: CraftValidationError if the given value is not valid for build-for.
         """
         # Convert distro@series:architecture to just the architecture.

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -470,6 +470,7 @@ class ProjectService(base.AppService):
         project = self._preprocess(
             build_for=build_for, build_on=build_on, platform=platform
         )
+        project["platforms"] = platforms
         self._expand_environment(
             project,
             build_on=craft_platforms.DebianArchitecture(build_on),

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -72,7 +72,7 @@ class ProjectService(base.AppService):
         if self.is_configured:
             raise RuntimeError("Project is already configured.")
 
-        platforms = self.get_platforms().copy()
+        platforms = self.get_platforms()
         # This is needed if a child class doesn't necessarily vectorise all platforms
         # in get_platforms. This is needed for charmcraft's multi-platforms.
         if None in platforms.values():
@@ -262,7 +262,7 @@ class ProjectService(base.AppService):
         be defined by extensions, etc.
         """
         if self.__platforms:
-            return self.__platforms.copy()
+            return copy.deepcopy(self.__platforms)
         raw_project = self.get_raw()
         if "platforms" not in raw_project:
             return self._app_render_legacy_platforms()
@@ -275,12 +275,15 @@ class ProjectService(base.AppService):
                 file_name=self.project_file_name,
             ) from None
         self._validate_multi_base(self.__platforms)
-        return self.__platforms
+        return copy.deepcopy(self.__platforms)
 
     def _validate_multi_base(
         self, platforms: dict[str, craft_platforms.PlatformDict]
     ) -> None:
         """Ensure that the given platforms are not multi-base.
+
+        An application that supports multi-base platforms entries can override this
+        method to do any validation of multi-base platforms it may need.
 
         :param platforms: The platforms mapping to ensure is multi-base.
         :raises: CraftValidationError if the app does not support multi-base and one

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-import io
+import copy
 import os
 import pathlib
 import shutil
@@ -37,6 +37,7 @@ import pytest
 from craft_application import application, errors, git, launchpad, models, services
 from craft_application.services import service_factory
 from craft_application.services.fetch import FetchService
+from craft_application.services.project import ProjectService
 from craft_application.util import yaml
 from craft_cli import EmitterMode, emit
 from jinja2 import FileSystemLoader
@@ -69,9 +70,8 @@ platforms:
   risky:
     build-on: [amd64, arm64, ppc64el, riscv64, s390x]
     build-for: [riscv64]
-  s390x:
+  s390x:  # Test with build-on only
     build-on: [amd64, arm64, armhf, i386, ppc64el, riscv64, s390x]
-    build-for: [s390x]
 
 contact: author@project.org
 issues: https://github.com/canonical/craft-application/issues
@@ -93,28 +93,32 @@ parts:
         "ppc64el",
         "risky",
         "s390x",
-    ]
+    ],
+    scope="session",
 )
 def fake_platform(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
 @pytest.fixture
-def platform_independent_project(fake_project_file, fake_project):
+def platform_independent_project(fake_project_file, fake_project_dict):
     """Turn the fake project into a platform-independent project.
 
     This is needed because `build-for: [all]` implies a single platform. So
     """
-    fake_project.platforms = {
+    old_platforms = fake_project_dict["platforms"]
+    fake_project_dict["platforms"] = {
         "platform-independent": {
             "build-on": [str(arch) for arch in craft_platforms.DebianArchitecture],
             "build-for": ["all"],
         }
     }
-    fake_project_file.write_text(fake_project.to_yaml_string())
+    fake_project_file.write_text(yaml.dump_yaml(fake_project_dict))
+    yield
+    fake_project_dict["platforms"] = old_platforms
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fake_project_yaml():
     current_base = craft_platforms.DistroBase.from_linux_distribution(
         distro.LinuxDistribution(
@@ -134,10 +138,16 @@ def fake_project_file(in_project_path, fake_project_yaml):
     return project_file
 
 
+@pytest.fixture(scope="module")
+def fake_project_dict(fake_project_yaml: str):
+    return yaml.safe_yaml_load(fake_project_yaml)
+
+
 @pytest.fixture
-def fake_project(fake_project_yaml) -> models.Project:
-    with io.StringIO(fake_project_yaml) as project_io:
-        return models.Project.unmarshal(yaml.safe_yaml_load(project_io))
+def fake_project(fake_project_dict) -> models.Project:
+    project = copy.deepcopy(fake_project_dict)
+    ProjectService._preprocess_platforms(project["platforms"])
+    return models.Project.unmarshal(project)
 
 
 @pytest.fixture(
@@ -300,13 +310,13 @@ def emitter_verbosity(request):
 
 
 @pytest.fixture
-def fake_project_service_class(fake_project) -> type[services.ProjectService]:
+def fake_project_service_class(fake_project_dict) -> type[services.ProjectService]:
     class FakeProjectService(services.ProjectService):
         # This is a final method, but we're overriding it here for convenience when
         # doing internal testing.
         @override
         def _load_raw_project(self):  # type: ignore[reportIncompatibleMethodOverride]
-            return fake_project.marshal()
+            return fake_project_dict
 
         # Don't care if the project file exists during this testing.
         # Silencing B019 because we're replicating an inherited method.
@@ -427,7 +437,6 @@ def fake_services(
     request: pytest.FixtureRequest,
     tmp_path,
     app_metadata,
-    fake_project,
     fake_lifecycle_service_class,
     fake_package_service_class,
     fake_project_service_class,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,7 @@ def app_metadata(fake_config_model) -> craft_application.AppMetadata:
             source_ignore_patterns=["*.snap", "*.charm", "*.starcraft"],
             docs_url="www.testcraft.example/docs/{version}",
             ConfigModel=fake_config_model,
+            supports_multi_base=True,
         )
 
 

--- a/tests/unit/services/test_buildplan.py
+++ b/tests/unit/services/test_buildplan.py
@@ -651,3 +651,33 @@ def test_create_build_plan_filters_to_empty(build_plan_service: BuildPlanService
         )
         == []
     )
+
+
+def test_set_platforms_resets_cached_plan(mocker, build_plan_service: BuildPlanService):
+    build_plan_service.plan()
+    mock_creator = mocker.patch.object(build_plan_service, "create_build_plan")
+    build_plan_service.set_platforms("zero", "mind the gap")
+    mock_creator.assert_not_called()
+    build_plan_service.plan()
+    build_plan_service.plan()  # This time it should keep the cache.
+    mock_creator.assert_called_once_with(
+        platforms=["zero", "mind the gap"],
+        build_for=None,
+        build_on=[craft_platforms.DebianArchitecture.from_host()],
+    )
+
+
+def test_set_build_fors_resets_cached_plan(
+    mocker, build_plan_service: BuildPlanService
+):
+    build_plan_service.plan()
+    mock_creator = mocker.patch.object(build_plan_service, "create_build_plan")
+    build_plan_service.set_build_fors("riscv64")
+    mock_creator.assert_not_called()
+    build_plan_service.plan()
+    build_plan_service.plan()  # This time it should keep the cache.
+    mock_creator.assert_called_once_with(
+        platforms=None,
+        build_for=["riscv64"],
+        build_on=[craft_platforms.DebianArchitecture.from_host()],
+    )

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -226,7 +226,14 @@ def test_get_platforms(
 ):
     real_project_service._load_raw_project = lambda: {"platforms": platforms}  # type: ignore  # noqa: PGH003
 
-    assert real_project_service.get_platforms() == expected
+    first_platforms = real_project_service.get_platforms()
+
+    assert first_platforms == expected
+
+    # Mutating this should not affect future calls.
+    assert "foo" not in first_platforms
+    first_platforms["foo"] = {"build-on": [], "build-for": []}
+    assert "foo" not in real_project_service.get_platforms()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -67,6 +67,14 @@ def real_project_service(fake_services: ServiceFactory):
             )
             for platform in [None, "noble", "jammy"]
         ),
+        *(
+            pytest.param(
+                {"amd64": {"build-on": ["amd64", "arm64", "riscv64", "s390x"]}},
+                "amd64",
+                id="implicit-build-for-{platform}",
+            )
+            for platform in [None, "amd64"]
+        ),
     ],
 )
 def test_configure_success_self_select(
@@ -163,6 +171,16 @@ def test_load_raw_project_invalid(
                 id=f"vectorise-{arch}",
             )
             for arch in craft_platforms.DebianArchitecture
+        ),
+        pytest.param(
+            {"s390x": {"build-on": ["amd64", "arm64", "riscv64", "s390x"]}},
+            {
+                "s390x": {
+                    "build-on": ["amd64", "arm64", "riscv64", "s390x"],
+                    "build-for": ["s390x"],
+                }
+            },
+            id="implicit-build-for",
         ),
         pytest.param(
             {"ppc64el": {"build-on": ["amd64", "riscv64"]}},

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -71,7 +71,7 @@ def real_project_service(fake_services: ServiceFactory):
             pytest.param(
                 {"amd64": {"build-on": ["amd64", "arm64", "riscv64", "s390x"]}},
                 "amd64",
-                id="implicit-build-for-{platform}",
+                id=f"implicit-build-for-{platform}",
             )
             for platform in [None, "amd64"]
         ),


### PR DESCRIPTION
This modifies the ProjectService such that it's compatible with multi-base platforms definitions. AppMetadata gets a flag to register whether the app supports multi-base platforms (defaulting to False). If a user uses multi-base platforms when an app doesn't support it, they get an error message to that effect.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
