### PR TITLE
fix(ProxyService): check if apt is available before configuring

### DIFF
--- a/craft_application/services/proxy.py
+++ b/craft_application/services/proxy.py
@@ -118,6 +118,18 @@ class ProxyService(base.AppService):
             )
 
     def _configure_apt(self, instance: craft_providers.Executor) -> None:
+        """Configure the proxy for apt.
+
+        This function is a no-op on systems without apt.
+        """
+        try:
+            self._execute_run(instance, ["test", "-d", "/etc/apt"])
+        except subprocess.CalledProcessError:
+            emit.debug(
+                "Not configuring the proxy for apt because apt isn't available in the instance."
+            )
+            return
+
         emit.progress("Configuring Apt")
         apt_config = f'Acquire::http::Proxy "{self.__http_proxy}";\n'
         apt_config += f'Acquire::https::Proxy "{self.__http_proxy}";\n'


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Fixes a bug where the proxy service would configure the proxy for apt, even if apt isn't available.

Follow-up from https://github.com/canonical/craft-application/pull/823#discussion_r2231392840