### PR TITLE
fix(testing): verify craft backend type

### DIFF
--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -255,7 +255,7 @@ class SpreadYaml(SpreadBaseModel):
     ) -> dict[str, SpreadBackend]:
         backends: dict[str, SpreadBackend] = {}
         for name, backend in simple.items():
-            if name == "craft":
+            if name == "craft" and (not backend.type or backend.type == "craft"):
                 craft_backend.systems = SpreadBackend.systems_from_craft(
                     backend.systems
                 )

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -255,6 +255,7 @@ class SpreadYaml(SpreadBaseModel):
     ) -> dict[str, SpreadBackend]:
         backends: dict[str, SpreadBackend] = {}
         for name, backend in simple.items():
+            # Spread assumes the backend name as the type when it's not explicitly declared.
             if name == "craft" and (not backend.type or backend.type == "craft"):
                 craft_backend.systems = SpreadBackend.systems_from_craft(
                     backend.systems

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,15 @@
 Changelog
 *********
 
+5.6.2 (2025-MM-DD)
+------------------
+
+Fixes
+=====
+
+- Check the craft backend type before testing. The type must be ``craft`` to
+  allow the backend to be dynamically processed.
+
 5.6.1 (2025-07-28)
 ------------------
 

--- a/tests/spread/testcraft/test-cmd/spread.yaml
+++ b/tests/spread/testcraft/test-cmd/spread.yaml
@@ -2,7 +2,7 @@ project: test-cmd
 
 backends:
   craft:
-    type: adhoc
+    type: craft
     allocate: "false"
     systems:
       - ubuntu-24.04:


### PR DESCRIPTION
Also check if the craft backend has type "craft" before processing
it and convert to the real spread backend type.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
