### PR TITLE
feat: "support" existing fetch-service sessions

### DIFF
--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -95,8 +95,8 @@ class NetInfo:
         gw = self._gateway
         return f"http://{session.session_id}:{session.token}@{gw}:{port}/"
 
-    @property
-    def env(self) -> dict[str, str]:
+    @staticmethod
+    def env() -> dict[str, str]:
         """Environment variables to use for the proxy."""
         return {
             # Have go download directly from repositories

--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -429,13 +429,17 @@ class ProviderService(base.AppService):
             f"Running managed {self._app.name} in managed {build_info.build_base} instance for platform {build_info.platform!r}"
         )
 
+        active_fetch_service = self._services.get_class("fetch").is_active(
+            enable_command_line=enable_fetch_service
+        )
+
         with self.instance(
             build_info=build_info,
             work_dir=self._work_dir,
-            clean_existing=enable_fetch_service,
+            clean_existing=active_fetch_service,
         ) as instance:
-            if enable_fetch_service:
-                fetch_env = self._services.get("fetch").create_session(instance)
+            if active_fetch_service:
+                fetch_env = self._services.get("fetch").configure_instance(instance)
                 env.update(fetch_env)
 
             session_env = self._services.get("proxy").configure_instance(instance)
@@ -456,5 +460,5 @@ class ProviderService(base.AppService):
                     f"Failed to run {self._app.name} in instance"
                 ) from exc
             finally:
-                if enable_fetch_service:
-                    self._services.get("fetch").teardown_session()
+                if active_fetch_service:
+                    self._services.get("fetch").teardown_instance()

--- a/spread.yaml
+++ b/spread.yaml
@@ -127,6 +127,9 @@ prepare: |
   sudo snap install --dangerous --classic tests/spread/*.snap
   sudo snap alias testcraft.partitioncraft partitioncraft
 
+  # Initialize LXD; some tests need it ready *before* testcraft is called
+  lxd init --auto
+
 restore-each: |
   testcraft clean || true
 

--- a/tests/integration/services/test_fetch.py
+++ b/tests/integration/services/test_fetch.py
@@ -18,11 +18,13 @@
 import contextlib
 import io
 import json
+import os
 import pathlib
 import shutil
 import socket
 import textwrap
 from functools import cache
+from typing import Any
 from unittest import mock
 
 import craft_platforms
@@ -30,7 +32,11 @@ import craft_providers
 import pytest
 from craft_application import errors, fetch, services, util
 from craft_application.application import DEFAULT_CLI_LOGGERS
-from craft_application.services.fetch import _PROJECT_MANIFEST_MANAGED_PATH
+from craft_application.services.fetch import (
+    _PROJECT_MANIFEST_MANAGED_PATH,
+    EXTERNAL_FETCH_SERVICE_ENV_VAR,
+    PROXY_CERT_ENV_VAR,
+)
 from craft_cli import EmitterMode, emit
 
 
@@ -272,7 +278,7 @@ def lxd_instance(snap_safe_tmp_path, provider_service):
 
 
 @pytest.mark.slow
-def test_build_instance_integration(
+def test_build_instance_integration_managed_fetch_service(
     app_service,
     lxd_instance,
     tmp_path,
@@ -281,16 +287,106 @@ def test_build_instance_integration(
     manifest_data_dir,
     capsys,
 ):
+    """Test the scenario where the craft-application owns/spawns the fetch-service."""
+
+    # Configure the services, run commands in the instance
+    report = _perform_instance_test(
+        app_service,
+        lxd_instance,
+        tmp_path,
+        monkeypatch,
+        manifest_data_dir,
+    )
+
+    # Check the session report ("raw" fetch-service output)
+    _check_session_report(report)
+
+    # Check the project manifest json file (created from the report)
+    _check_manifest(tmp_path, fake_project)
+
+    # Basic checks on log output
+    _check_log(capsys)
+
+
+@pytest.mark.slow
+def test_build_instance_integration_external_fetch_service(
+    app_service,
+    lxd_instance,
+    tmp_path,
+    monkeypatch,
+    fake_project,
+    manifest_data_dir,
+    capsys,
+    request,
+):
+    """Test the scenario where the craft-application uses an existing fetch-service session."""
+    # spawn a fetch-service and create a session "externally"
+    session_data = _create_external_session(lxd_instance, monkeypatch, request)
+
+    # This is the 'trigger' that tells the FetchService to use an external session
+    assert os.getenv(EXTERNAL_FETCH_SERVICE_ENV_VAR) == "1"
+
+    # Configure the services, run commands in the instance
+    report = _perform_instance_test(
+        app_service,
+        lxd_instance,
+        tmp_path,
+        monkeypatch,
+        manifest_data_dir,
+    )
+    # The report dict is empty because in this scenario the service is *not* tearing
+    # down the session
+    assert len(report) == 0
+
+    # Tear down the session and get the report, "externally"
+    report = _teardown_external_session(monkeypatch, session_data)
+    # Basic verifications on the report
+    _check_session_report(report)
+
+    # Note that we can't check the manifest here, it doesn't exist (the session is not
+    # ours to delete).
+
+    # Basic verifications on the log output
+    _check_log(capsys)
+
+
+def _create_external_session(lxd_instance, monkeypatch, request) -> fetch.SessionData:
+    fetch_process, proxy_cert = fetch.start_service()
+
+    assert fetch_process is not None
+    request.addfinalizer(lambda: fetch.stop_service(fetch_process))
+
+    session = fetch.create_session(strict=False)
+    gateway = fetch._get_gateway(lxd_instance)
+
+    # Environment variables that signal we should use an existing session.
+    monkeypatch.setenv(EXTERNAL_FETCH_SERVICE_ENV_VAR, "1")
+    monkeypatch.setenv(PROXY_CERT_ENV_VAR, str(proxy_cert))
+    proxy_port = fetch._DEFAULT_CONFIG.proxy
+    url = f"http://{session.session_id}:{session.token}@{gateway}:{proxy_port}/"
+    monkeypatch.setenv("http_proxy", url)
+
+    return session
+
+
+def _teardown_external_session(monkeypatch, session_data) -> dict[str, Any]:
+    monkeypatch.delenv("http_proxy")
+    return fetch.teardown_session(session_data)
+
+
+def _perform_instance_test(
+    app_service, lxd_instance, tmp_path, monkeypatch, manifest_data_dir
+) -> dict[str, Any]:
     emit.init(EmitterMode.BRIEF, "testcraft", "hi", streaming_brief=True)
     util.setup_loggers(*DEFAULT_CLI_LOGGERS)
     monkeypatch.chdir(tmp_path)
 
     app_service.setup()
-
-    fetch_env = app_service.create_session(lxd_instance)
+    fetch_env = app_service.configure_instance(lxd_instance)
     proxy_env = app_service._services.get("proxy").configure_instance(lxd_instance)
     env = fetch_env | proxy_env
 
+    report = {}
     try:
         # Install the hello Ubuntu package.
         lxd_instance.execute_run(
@@ -318,8 +414,12 @@ def test_build_instance_integration(
         )
 
     finally:
-        report = app_service.teardown_session()
+        report.update(app_service.teardown_instance())
 
+    return report
+
+
+def _check_session_report(report) -> None:
     artifacts_and_types: list[tuple[str, str]] = []
 
     for artifact in report["artifacts"]:
@@ -334,6 +434,8 @@ def test_build_instance_integration(
     # Check that the fetching of the "craft-application" wheel went through the inspector.
     assert ("craft-application", "application/x.python.wheel") in artifacts_and_types
 
+
+def _check_manifest(tmp_path, fake_project) -> None:
     manifest_path = (
         tmp_path / f"{fake_project.name}_{fake_project.version}_64-bit-pc.json"
     )
@@ -356,6 +458,8 @@ def test_build_instance_integration(
     assert dependencies["craft-application"]["type"] == "application/x.python.wheel"
     assert dependencies["craft-application"]["component-version"] == "3.0.0"
 
+
+def _check_log(capsys) -> None:
     # Note: the messages don't show up as
     # 'Configuring fetch-service integration :: Installing certificate' noqa: ERA001 (commented-out code)
     # because streaming-brief is disabled in non-terminal runs.

--- a/tests/spread/testcraft/fetch-service-external/task.yaml
+++ b/tests/spread/testcraft/fetch-service-external/task.yaml
@@ -1,0 +1,97 @@
+summary: Testcraft can use an external fetch service session
+
+priority: 100
+
+prepare: |
+  snap install --candidate fetch-service
+
+  # Some of these values match the current defaults used by the fetch-service, but we
+  # set them here too to protect against changes in those defaults
+  snap set fetch-service control.auth="craft:craft"
+  snap set fetch-service control.port=9999
+  snap set fetch-service proxy.port=9988
+  snap set fetch-service permissive=true
+  snap set fetch-service log.file="from-testcraft.log"
+  snap start fetch-service
+
+  # Give the service some time to start
+  sleep 5
+  # Make sure the service is up
+  curl -f http://localhost:9999/status
+
+  # Create a fetch-service session
+  curl -f -X POST -d '{"policy": "strict"}' http://craft:craft@localhost:9999/session --output session.json
+  session_id=$(jq -r .id session.json)
+  token=$(jq -r .token session.json)
+
+  # This assumes that the lxd network is lxdbr0
+  host_ip=$(ip -f inet addr show lxdbr0 | sed -En -e 's/.*inet ([0-9.]+).*/\1/p')
+
+  # Save the proxy url so that the 'execute' step can access it.
+  echo "http://${session_id}:${token}@${host_ip}:9988" > session_proxy_url.txt
+
+execute: |
+  # Configure testcraft to use the external session
+  export CRAFT_USE_EXTERNAL_FETCH_SERVICE=1
+
+  # Check that the fetch-service's certificate is there, use it
+  test -f /var/snap/fetch-service/current/local-ca.crt
+  export CRAFT_PROXY_CERT=/var/snap/fetch-service/current/local-ca.crt
+
+  # Set http_proxy and https_proxy variables to the value saved during 'prepare'
+  export http_proxy=$(cat session_proxy_url.txt)
+  export https_proxy=$(cat session_proxy_url.txt)
+
+  # The current implementation is bugged: when setting up the lxd instance snapd is
+  # configured to use the proxy but it doesn't (can't) recognize the fetch-service
+  # signature because we don't inject the certificate.
+  expected_error='cannot install system snap "snapd": Post "https://api.snapcraft.io/v2/snaps/refresh": tls: failed to verify certificate: x509: certificate signed by unknown authority'
+
+  # The pack fails because the feature needs some work still (see issue #839):
+  # - During setup of the craft-providers lxd instance, we need to:
+  #   - do a full apt update (remove apt lists cache)
+  #   - push the certificate file and update-ca-certificates
+  # - We also need to *not* use a base-instance when doing fetch-service-enabled packs
+  #   (both kinds), because this session config can't be persisted in the instance.
+  # - If we do a full apt update during setup, we can stop doing one in the ProxyService.
+  #   (in fact today we *must*, because of a fetch-service bug with "double apt updates")
+  testcraft pack --verbosity=debug 2>&1 | MATCH "$expected_error"
+  # Remove this once the above issue^ is fixed
+  exit 0;
+
+  test -f fetch-service*.testcraft
+
+  # Clear proxy variables, otherwise the curl calls themselves will try to use the
+  # proxy that we're about to teardown.
+  unset http_proxy
+  unset https_proxy
+
+  # Revoke the session token
+  session_id=$(jq -r .id session.json)
+  token=$(jq -r .token session.json)
+  curl -sf -X DELETE -d "{\"token\": \"${token}\"}" "http://localhost:9999/session/${session_id}/token"
+
+  # Get the session report
+  curl -sf "http://craft:craft@localhost:9999/session/${session_id}" | tee session_report.json
+
+  # Delete the session
+  curl -sf -X DELETE "http://craft:craft@localhost:9999/session/${session_id}"
+  # Delete session resources
+  curl -sf -X DELETE "http://craft:craft@localhost:9999/resources/${session_id}"
+
+  # Smoke-checks to verify that the 'hello' deb went through the fetch service
+  jq -r '(.artifacts[].metadata | select(.name=="hello")).type' session_report.json | MATCH "application/vnd.debian.binary-package"
+
+restore: |
+  testcraft clean
+  rm -f fetch-service*.testcraft
+  snap remove --purge fetch-service
+
+debug: |
+  logfile=/var/snap/fetch-service/current/from-testcraft.log
+  if [ -f ${logfile} ]; then
+    echo "fetch-service log output:"
+    cat ${logfile}
+  else
+    echo "fetch-service logfile does not exist."
+  fi

--- a/tests/spread/testcraft/fetch-service-external/testcraft.yaml
+++ b/tests/spread/testcraft/fetch-service-external/testcraft.yaml
@@ -1,0 +1,15 @@
+name: fetch-service-external
+summary: test summary
+version: "0.1"
+
+base: ubuntu@24.04
+platforms:
+  platform-independent:
+    build-on: [amd64, arm64, ppc64el, s390x, riscv64]
+    build-for: [all]
+
+parts:
+  my-test:
+    plugin: nil
+    stage-packages:
+      - hello

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -889,10 +889,13 @@ def test_run_managed(
 ):
     mock_fetch = mock.MagicMock()
     mock_proxy = mock.MagicMock()
-    mock_fetch.create_session.return_value = {"fetch_env_key": "fetch_env_value"}
+    mock_fetch.configure_instance.return_value = {"fetch_env_key": "fetch_env_value"}
     mock_proxy.configure_instance.return_value = {"proxy_env_key": "proxy_env_value"}
     fake_services.register("fetch", mock.Mock(return_value=mock_fetch))
     fake_services.register("proxy", mock.Mock(return_value=mock_proxy))
+    fake_services.get_class(
+        "fetch"
+    ).is_active.return_value = fetch  # # pyright: ignore[reportFunctionMemberAccess]
     monkeypatch.setattr("sys.argv", ["[unused]", "pack", "--verbose"])
     instance_context = (
         mock_provider.launched_environment.return_value.__enter__.return_value
@@ -915,6 +918,6 @@ def test_run_managed(
     )
 
     if fetch:
-        mock_fetch.create_session.assert_called_once_with(instance_context)
-        mock_fetch.teardown_session.assert_called_once_with()
+        mock_fetch.configure_instance.assert_called_once_with(instance_context)
+        mock_fetch.teardown_instance.assert_called_once_with()
     mock_proxy.configure_instance.assert_called_once_with(instance_context)

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "craft-providers"
-version = "2.3.0"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
@@ -654,9 +654,9 @@ dependencies = [
     { name = "requests" },
     { name = "requests-unixsocket2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/d9/5c9195dbd410c978ef8f7172ddef7ab86d10f501560ee49dcdae1497e8f4/craft_providers-2.3.0.tar.gz", hash = "sha256:8b9f60d587d118e35e6cf0c28ffffafe5c8e40e3e6c49da3b171a3d18a070ffa", size = 190942, upload-time = "2025-05-09T13:47:13.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/82/3f642247778502c9f87e2d370bfc9da8cf2bdf4ca846548b0b7f7f2d23fc/craft_providers-2.4.0.tar.gz", hash = "sha256:7944c7e559f4cdb74220b2f19dcf7b84e566d6284550d67dd041b24106da355b", size = 274922, upload-time = "2025-07-14T18:19:39.946Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/38/d685644a31f1aa4cc5805a99b9cd40c9b481dffdadc1f39e9a3429f8ec44/craft_providers-2.3.0-py2.py3-none-any.whl", hash = "sha256:fc539d0d675286cd596ba3534364da80696f38ef63241a9c059283d8ccae531c", size = 104402, upload-time = "2025-05-09T13:47:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/35/d585f953999099f682a4458f1339fcada7efa85a81ec18333a4caa8b1b89/craft_providers-2.4.0-py2.py3-none-any.whl", hash = "sha256:05415bce7412b533bd49362d05972a52434c8c138cef47d4e90eab40002c8f9d", size = 104800, upload-time = "2025-07-14T18:19:37.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit does "half" of the work needed to support packing with pre-existing sessions that are managed by someone else. It introduces support for the CRAFT_USE_EXTERNAL_FETCH_SERVICE and CRAFT_PROXY_CERT environment variables and adds a spread test exposing the current issue: we must configure fetch-service items early in a managed instance's lifetime.

As such, the feature is not ready for use but this changeset is a step in the direction of completeness.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
