### PR TITLE
fix(StateService): add g+rwx to the state dir

### DIFF
--- a/craft_application/services/state.py
+++ b/craft_application/services/state.py
@@ -159,10 +159,18 @@ class StateService(base.AppService):
         # give LXD access to the state directory when running as root
         if os.geteuid() == 0 and isinstance(instance, craft_providers.lxd.LXDInstance):
             craft_cli.emit.debug(
-                f"Adding o+rwx permissions to {str(self._state_dir)!r}."
+                f"Adding go+rwx permissions to {str(self._state_dir)!r}."
             )
             mode = self._state_dir.stat().st_mode
-            new_mode = mode | stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
+            new_mode = (
+                mode
+                | stat.S_IRGRP
+                | stat.S_IWGRP
+                | stat.S_IXGRP
+                | stat.S_IROTH
+                | stat.S_IWOTH
+                | stat.S_IXOTH
+            )
             self._state_dir.chmod(new_mode)
 
         instance.mount(host_source=self._state_dir, target=self._managed_state_dir)
@@ -387,6 +395,11 @@ class StateService(base.AppService):
 
         try:
             file_path.write_text(raw_data)
+        # specific handling for permission errors as they are the most likely error to occur
+        except PermissionError as err:
+            raise errors.StateServiceError(
+                f"Can't save state file {str(file_path)!r} due to insufficient permissions."
+            ) from err
         except OSError as err:
             raise errors.StateServiceError(
                 f"Can't save state file {str(file_path)!r}."

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 *********
 
+5.6.2 (2025-08-01)
+------------------
+
+Services
+========
+
+- Fix a bug where the State service had insufficient permissions to write
+  to the state directory.
+
+For a complete list of commits, check out the `5.6.2`_ release on GitHub.
+
 5.6.1 (2025-07-28)
 ------------------
 
@@ -866,3 +877,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _5.5.0: https://github.com/canonical/craft-application/releases/tag/5.5.0
 .. _5.6.0: https://github.com/canonical/craft-application/releases/tag/5.6.0
 .. _5.6.1: https://github.com/canonical/craft-application/releases/tag/5.6.1
+.. _5.6.2: https://github.com/canonical/craft-application/releases/tag/5.6.2


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Gives the group read/write permission to state dir, when running with LXD as root.

This is needed due to https://github.com/canonical/craft-providers/pull/780, which sets uid and gid mapping separately.

Tested in https://github.com/canonical/craft-application/pull/835