### PR TITLE
chore: prepare for Python 3.14

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -16,9 +16,9 @@ jobs:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
       fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
-      fast-test-python-versions: '["3.10", "3.12"]'
+      fast-test-python-versions: '["3.10", "3.12", "3.14", "3.14+freethreaded"]'
       slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04"]'
-      slow-test-python-versions: '["3.10", "3.12"]'
+      slow-test-python-versions: '["3.10", "3.12", "3.14", "3.14+freethreaded"]'
       lowest-python-platform: ubuntu-22.04
       lowest-python-version: "3.10"
       use-lxd: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",


### PR DESCRIPTION
This adds both Python 3.14 and the experimental free-threaded build to CI. Note that this doesn't currently work as PyO3 does not yet support python 3.14.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
