### PR TITLE
ci: run spread tests on hotfix branches

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - hotfix/*
 
 jobs:
   snap-build:


### PR DESCRIPTION
This fixes the need for admin override to create hotfix branches.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
