### PR TITLE
fix(test): fix version test

### DIFF
--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -63,4 +63,4 @@ def test_version_with_tags():
     version = craft_application.__version__
 
     # match on 'X.Y.Z.post<commits since tag>+g<hash>'
-    assert re.fullmatch(r"\d+\.\d+\.\d+\.post\d+\+g[0-9a-f]+", version)
+    assert re.fullmatch(r"\d+\.\d+\.\d+(\.post\d+\+g[0-9a-f]+)?", version)


### PR DESCRIPTION
This fixes the version test when we happen to be on a release-tagged commit, which causes TICS to break upon release.

Example breakage: https://github.com/canonical/craft-application/actions/runs/16997173027/job/48190559434

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
