### PR TITLE
fix(provider): bump compatibility tag

### DIFF
--- a/craft_application/services/provider.py
+++ b/craft_application/services/provider.py
@@ -88,6 +88,11 @@ class ProviderService(base.AppService):
             artifact=None, resources=None
         )
 
+    @property
+    def compatibility_tag(self) -> str:
+        """Get craft-application's suffix for the compatibility tag."""
+        return ".1"
+
     @classmethod
     def is_managed(cls) -> bool:
         """Determine whether we're running in managed mode."""
@@ -219,7 +224,7 @@ class ProviderService(base.AppService):
             self.packages.extend(["gpg", "dirmngr"])
         return base_class(
             alias=alias,  # type: ignore[arg-type]
-            compatibility_tag=f"{self._app.name}-{base_class.compatibility_tag}",
+            compatibility_tag=f"{self._app.name}-{base_class.compatibility_tag}{self.compatibility_tag}",
             hostname=instance_name,
             snaps=self.snaps,
             environment=self.environment,

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 *********
 
+5.6.5 (2025-08-20)
+------------------
+
+Services
+========
+
+- Prevent the reuse of instances created before the State service by
+  updating the Provider service's compatibility tag.
+
+For a complete list of commits, check out the `5.6.5`_ release on GitHub.
+
 5.6.4 (2025-08-15)
 ------------------
 
@@ -895,3 +906,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _5.6.0: https://github.com/canonical/craft-application/releases/tag/5.6.0
 .. _5.6.1: https://github.com/canonical/craft-application/releases/tag/5.6.1
 .. _5.6.2: https://github.com/canonical/craft-application/releases/tag/5.6.2
+.. _5.6.5: https://github.com/canonical/craft-application/releases/tag/5.6.5

--- a/tests/unit/services/test_provider.py
+++ b/tests/unit/services/test_provider.py
@@ -580,7 +580,10 @@ def test_get_base_buildd(
 
     check.is_instance(base, base_class)
     check.equal(base.alias, alias)
-    check.equal(base.compatibility_tag, f"testcraft-{base_class.compatibility_tag}")
+    check.equal(
+        base.compatibility_tag,
+        f"testcraft-{base_class.compatibility_tag}{provider_service.compatibility_tag}",
+    )
     check.equal(base._environment, environment)
 
     # Verify that the two packages we care about in order to support Craft Archives


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Bumps the compatibility tag in craft-application to prevent the reuse of instances created before the State service by updating the Provider service’s compatibility tag.