### PR TITLE
feat(test): support debug and debug-each

### DIFF
--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -50,8 +50,10 @@ class CraftSpreadBackend(SpreadBase):
     systems: list[str | dict[str, CraftSpreadSystem | None]]
     prepare: str | None = None
     restore: str | None = None
+    debug: str | None = None
     prepare_each: str | None = None
     restore_each: str | None = None
+    debug_each: str | None = None
 
 
 class CraftSpreadSuite(SpreadBase):
@@ -62,8 +64,10 @@ class CraftSpreadSuite(SpreadBase):
     environment: dict[str, str] | None = None
     prepare: str | None = None
     restore: str | None = None
+    debug: str | None = None
     prepare_each: str | None = None
     restore_each: str | None = None
+    debug_each: str | None = None
     kill_timeout: str | None = None
 
 
@@ -81,8 +85,10 @@ class CraftSpreadYaml(SpreadBase):
     exclude: list[str] | None = None
     prepare: str | None = None
     restore: str | None = None
+    debug: str | None = None
     prepare_each: str | None = None
     restore_each: str | None = None
+    debug_each: str | None = None
     kill_timeout: str | None = None
 
 
@@ -129,8 +135,10 @@ class SpreadBackend(SpreadBaseModel):
     )
     prepare: str | None = None
     restore: str | None = None
+    debug: str | None = None
     prepare_each: str | None = None
     restore_each: str | None = None
+    debug_each: str | None = None
 
     @classmethod
     def from_craft(cls, simple: CraftSpreadBackend) -> Self:
@@ -142,8 +150,10 @@ class SpreadBackend(SpreadBaseModel):
             systems=cls.systems_from_craft(simple.systems),
             prepare=simple.prepare,
             restore=simple.restore,
+            debug=simple.debug,
             prepare_each=simple.prepare_each,
             restore_each=simple.restore_each,
+            debug_each=simple.debug_each,
         )
 
     @staticmethod
@@ -174,6 +184,8 @@ class SpreadSuite(SpreadBaseModel):
     restore: str | None
     prepare_each: str | None
     restore_each: str | None
+    debug: str | None = None
+    debug_each: str | None = None
     kill_timeout: str | None = None
 
     @classmethod
@@ -188,6 +200,8 @@ class SpreadSuite(SpreadBaseModel):
             prepare_each=simple.prepare_each,
             restore_each=simple.restore_each,
             kill_timeout=simple.kill_timeout,
+            debug=simple.debug,
+            debug_each=simple.debug_each,
         )
 
 
@@ -204,6 +218,8 @@ class SpreadYaml(SpreadBaseModel):
     restore: str | None
     prepare_each: str | None
     restore_each: str | None
+    debug: str | None = None
+    debug_each: str | None = None
     kill_timeout: str | None = None
     reroot: str | None = None
 
@@ -242,6 +258,8 @@ class SpreadYaml(SpreadBaseModel):
             prepare_each=simple.prepare_each,
             restore_each=simple.restore_each,
             kill_timeout=simple.kill_timeout or None,
+            debug=simple.debug,
+            debug_each=simple.debug_each,
             reroot="..",
         )
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -13,6 +13,11 @@ Configuration
 - Add an ``idle_time`` configuration option that sets the Provider service's idle
   timer duration.
 
+Models
+======
+
+- Support ``debug`` and ``debug-each`` in all locations in the ``spread.yaml`` model.
+
 Services
 ========
 

--- a/tests/unit/models/test_spread.py
+++ b/tests/unit/models/test_spread.py
@@ -49,6 +49,22 @@ backends:
     type: craft
     systems:
       - ubuntu-24.04:
+  other:
+    type: adhoc
+    systems:
+      - ubuntu-24.04:
+    prepare: |
+      echo Preparing backend
+    restore: |
+      echo Restoring backend
+    debug: |
+      echo Debugging backend
+    prepare-each: |
+      echo Preparing-each on backend
+    restore-each: |
+      echo Restoring-each on backend
+    debug-each: |
+      echo Debugging-each on backend
 
 suites:
   spread/general/:
@@ -59,6 +75,27 @@ suites:
       snap install $CRAFT_ARTIFACT --dangerous
     restore: |
       snap remove my-snap --purge
+    debug: |
+      echo Debugging suite
+    prepare-each: |
+      echo Preparing-each on suite
+    restore-each: |
+      echo Restoring-each on suite
+    debug-each: |
+      echo Debugging-each on suite
+
+prepare: |
+  echo Preparing project
+restore: |
+  echo Restoring project
+debug: |
+  echo Debugging project
+prepare-each: |
+  echo Preparing-each on project
+restore-each: |
+  echo Restoring-each on project
+debug-each: |
+  echo Debugging-each on project
 
 exclude:
   - .git
@@ -87,48 +124,65 @@ def test_spread_yaml_from_craft_spread():
         resources={"my-resource": pathlib.Path("resource")},
     )
 
-    assert spread == model.SpreadYaml(
-        project="craft-test",
-        environment={
-            "SUDO_USER": "",
-            "SUDO_UID": "",
-            "LANG": "C.UTF-8",
-            "LANGUAGE": "en",
-            "PROJECT_PATH": "/root/proj",
-            "CRAFT_ARTIFACT": "$PROJECT_PATH/artifact",
-            "CRAFT_RESOURCE_MY_RESOURCE": "$PROJECT_PATH/resource",
-        },
-        backends={
-            "craft": model.SpreadBackend(
-                type="type",
-                allocate="allocate",
-                discard="discard",
-                systems=[{"ubuntu-24.04": model.SpreadSystem(workers=1)}],
-                prepare="prepare",
-                restore="restore",
-                prepare_each="prepare_each",
-                restore_each="restore each",
-            )
-        },
-        suites={
-            "spread/general/": model.SpreadSuite(
-                summary="General integration tests",
-                systems=[],
-                environment={"FOO": "bar"},
-                prepare="snap install $CRAFT_ARTIFACT --dangerous\n",
-                restore="snap remove my-snap --purge\n",
-                prepare_each=None,
-                restore_each=None,
-            )
-        },
-        exclude=[".git"],
-        path="/root/proj",
-        kill_timeout="1h",
-        reroot="..",
-        prepare=None,
-        restore=None,
-        prepare_each=None,
-        restore_each=None,
+    assert (
+        spread.marshal()
+        == model.SpreadYaml(
+            project="craft-test",
+            environment={
+                "SUDO_USER": "",
+                "SUDO_UID": "",
+                "LANG": "C.UTF-8",
+                "LANGUAGE": "en",
+                "PROJECT_PATH": "/root/proj",
+                "CRAFT_ARTIFACT": "$PROJECT_PATH/artifact",
+                "CRAFT_RESOURCE_MY_RESOURCE": "$PROJECT_PATH/resource",
+            },
+            backends={
+                "craft": model.SpreadBackend(
+                    type="type",
+                    allocate="allocate",
+                    discard="discard",
+                    systems=[{"ubuntu-24.04": model.SpreadSystem(workers=1)}],
+                    prepare="prepare",
+                    restore="restore",
+                    prepare_each="prepare_each",
+                    restore_each="restore each",
+                ),
+                "other": model.SpreadBackend(
+                    type="adhoc",
+                    systems=[{"ubuntu-24.04": model.SpreadSystem(workers=1)}],
+                    prepare="echo Preparing backend\n",
+                    restore="echo Restoring backend\n",
+                    debug="echo Debugging backend\n",
+                    prepare_each="echo Preparing-each on backend\n",
+                    restore_each="echo Restoring-each on backend\n",
+                    debug_each="echo Debugging-each on backend\n",
+                ),
+            },
+            suites={
+                "spread/general/": model.SpreadSuite(
+                    summary="General integration tests",
+                    systems=[],
+                    environment={"FOO": "bar"},
+                    prepare="snap install $CRAFT_ARTIFACT --dangerous\n",
+                    restore="snap remove my-snap --purge\n",
+                    debug="echo Debugging suite\n",
+                    prepare_each="echo Preparing-each on suite\n",
+                    restore_each="echo Restoring-each on suite\n",
+                    debug_each="echo Debugging-each on suite\n",
+                )
+            },
+            exclude=[".git"],
+            path="/root/proj",
+            kill_timeout="1h",
+            reroot="..",
+            prepare="echo Preparing project\n",
+            restore="echo Restoring project\n",
+            debug="echo Debugging project\n",
+            prepare_each="echo Preparing-each on project\n",
+            restore_each="echo Restoring-each on project\n",
+            debug_each="echo Debugging-each on project\n",
+        ).marshal()
     )
 
 


### PR DESCRIPTION
From the spread readme:

> In addition to preparing and restoring scripts, debug and debug-each scripts may also be defined in the same places. These are only run when other scripts fail, and their purpose is to display further information which might be helpful when trying to understand what went wrong.

So debug and debug-each are now supported everywhere prepare and prepare-each are supported.

CRAFT-4708

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
