### PR TITLE
feat(linter): add linter service framework

### DIFF
--- a/craft_application/commands/__init__.py
+++ b/craft_application/commands/__init__.py
@@ -18,6 +18,7 @@
 from .base import AppCommand, ExtensibleCommand
 from . import lifecycle
 from .init import InitCommand
+from .lint import LintCommand
 from .lifecycle import get_lifecycle_command_group, LifecycleCommand, TestCommand
 from .other import get_other_command_group
 from .remote import RemoteBuild  # Not part of the default commands.
@@ -26,6 +27,7 @@ __all__ = [
     "AppCommand",
     "ExtensibleCommand",
     "InitCommand",
+    "LintCommand",
     "RemoteBuild",
     "lifecycle",
     "LifecycleCommand",

--- a/craft_application/commands/lint.py
+++ b/craft_application/commands/lint.py
@@ -1,0 +1,101 @@
+# This file is part of craft-application.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Public CLI command to run the linter service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from craft_cli import emit
+
+from craft_application.commands import base
+from craft_application.lint.types import LintContext, Stage
+
+if TYPE_CHECKING:
+    import argparse
+
+
+class LintCommand(base.AppCommand):
+    """Run project linters."""
+
+    name = "lint"
+    help_msg = "Run linters against the project (pre) or artifacts (post)."
+    overview = "Run linters against the project (pre) or artifacts (post)."
+
+    def fill_parser(self, parser: argparse.ArgumentParser) -> None:
+        """Add command-line arguments for lint configuration."""
+        parser.add_argument(
+            "--stage",
+            choices=[Stage.PRE.value, Stage.POST.value],
+            default=Stage.PRE.value,
+            help="When to lint: 'pre' = source tree, 'post' = built artifacts.",
+        )
+        parser.add_argument(
+            "--lint-ignore",
+            action="append",
+            dest="lint_ignores",
+            default=[],
+            metavar="RULE",
+            help=(
+                "Ignore rule of the form 'linter:id' (ignore id everywhere) or "
+                "'linter:id=glob' (ignore id when filename matches glob). May repeat."
+            ),
+        )
+        parser.add_argument(
+            "--lint-ignore-file",
+            action="append",
+            type=Path,
+            dest="lint_ignore_files",
+            default=[],
+            metavar="PATH",
+            help=("Path to YAML ignore file. May repeat. CLI rules take precedence."),
+        )
+
+    def run(self, parsed_args: argparse.Namespace) -> int | None:
+        """Execute lint for the requested stage and return the exit code."""
+        services = self._services
+
+        # Resolve project dir
+        project_service = services.get("project")
+        project_dir: Path = project_service.resolve_project_file_path().parent
+
+        artifact_dirs: list[Path] = []
+        if parsed_args.stage == Stage.POST.value:
+            lifecycle = services.get("lifecycle")
+            artifact_dirs = [lifecycle.prime_dir]
+
+        ctx = LintContext(project_dir=project_dir, artifact_dirs=artifact_dirs)
+
+        linter = services.get("linter")
+        linter.load_ignore_config(
+            project_dir=project_dir,
+            cli_ignores=list(parsed_args.lint_ignores or []),
+            cli_ignore_files=list(parsed_args.lint_ignore_files or []),
+        )
+        # Consume the generator to populate the issues for summary
+        for _ in linter.run(Stage(parsed_args.stage), ctx):
+            pass
+
+        code = int(linter.summary())
+
+        if code == 0:
+            emit.message("lint: OK")
+        elif code == 1:
+            emit.message("lint: WARN")
+        else:
+            emit.message("lint: ERROR")
+        return code

--- a/craft_application/commands/other.py
+++ b/craft_application/commands/other.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from craft_cli import CommandGroup, emit
 
 from . import InitCommand, base
+from .lint import LintCommand
 
 if TYPE_CHECKING:  # pragma: no cover
     import argparse
@@ -29,6 +30,7 @@ def get_other_command_group() -> CommandGroup:
     """Return the lifecycle related command group."""
     commands: list[type[base.AppCommand]] = [
         InitCommand,
+        LintCommand,
         VersionCommand,
     ]
 

--- a/craft_application/lint/__init__.py
+++ b/craft_application/lint/__init__.py
@@ -1,0 +1,42 @@
+# This file is part of craft-application.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Linter framework public API surface."""
+
+from __future__ import annotations
+
+from .types import (
+    ExitCode,
+    IgnoreConfig,
+    IgnoreSpec,
+    LintContext,
+    LinterIssue,
+    Severity,
+    Stage,
+    should_ignore,
+)
+from .base import AbstractLinter
+
+__all__ = [
+    "ExitCode",
+    "IgnoreConfig",
+    "IgnoreSpec",
+    "LintContext",
+    "LinterIssue",
+    "Severity",
+    "Stage",
+    "should_ignore",
+    "AbstractLinter",
+]

--- a/craft_application/lint/base.py
+++ b/craft_application/lint/base.py
@@ -1,0 +1,42 @@
+# This file is part of craft-application.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Abstract base for linters used by the linter service."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterable
+
+    from .types import LintContext, LinterIssue, Stage
+
+
+class AbstractLinter(ABC):
+    """Base class for all linters.
+
+    Linters should set:
+      - name: stable identifier (used in ignore config)
+      - stage: Stage.PRE or Stage.POST
+    """
+
+    name: str
+    stage: Stage
+
+    @abstractmethod
+    def run(self, ctx: LintContext) -> Iterable[LinterIssue]:
+        """Execute the linter and yield issues."""

--- a/craft_application/lint/linters/__init__.py
+++ b/craft_application/lint/linters/__init__.py
@@ -1,0 +1,20 @@
+# This file is part of craft-application.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Namespace for built-in linters.
+
+Empty by default; applications may provide their own linters in-tree and
+import them explicitly where appropriate.
+"""

--- a/craft_application/lint/types.py
+++ b/craft_application/lint/types.py
@@ -1,0 +1,110 @@
+# This file is part of craft-application.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Types and helpers for the linter service.
+
+Note: this module name intentionally overlaps with the stdlib ``types`` module.
+We only import it within the package; to avoid confusion with external imports,
+downstream users should prefer explicit imports from ``craft_application.lint``.
+"""
+
+from __future__ import annotations
+
+# ruff: noqa: A005  # module name shadows stdlib 'types'
+from dataclasses import dataclass
+from enum import Enum
+from fnmatch import fnmatch
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pathlib import Path
+
+
+class Stage(str, Enum):
+    """Lifecycle stage for linting."""
+
+    PRE = "pre"
+    POST = "post"
+
+
+class Severity(str, Enum):
+    """Severity level for linter issues."""
+
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+class ExitCode(int, Enum):
+    """Exit codes summarising lint results."""
+
+    OK = 0
+    WARN = 1
+    ERROR = 2
+
+
+@dataclass(frozen=True, slots=True)
+class LintContext:
+    """Stage-agnostic environment for linters.
+
+    - project_dir: the source tree on disk
+    - artifact_dirs: list of directories with built artifacts (may be empty in pre-stage)
+    """
+
+    project_dir: Path
+    artifact_dirs: list[Path]
+
+
+@dataclass(frozen=True, slots=True)
+class LinterIssue:
+    """Single issue reported by a linter."""
+
+    id: str
+    message: str
+    severity: Severity
+    filename: str
+    url: str = ""
+
+
+@dataclass(slots=True)
+class IgnoreSpec:
+    """Suppression rules for one linter.
+
+    - ids: "*" to ignore every issue, or a set of issue ids
+    - by_filename: map of issue id -> set of filename globs
+    """
+
+    ids: str | set[str]
+    by_filename: dict[str, set[str]]
+
+
+# Map of linter.name -> IgnoreSpec
+IgnoreConfig = dict[str, IgnoreSpec]
+
+
+def should_ignore(linter_name: str, issue: LinterIssue, cfg: IgnoreConfig) -> bool:
+    """Return True when `issue` is covered by the user's ignore rules.
+
+    Uses issue id and optional shell-style filename globs per the approved design.
+    """
+    spec = cfg.get(linter_name)
+    if not spec:
+        return False
+    if spec.ids == "*":
+        return True
+    if isinstance(spec.ids, set) and issue.id in spec.ids:
+        return True
+    globs = spec.by_filename.get(issue.id, set()) or set()
+    return any(fnmatch(issue.filename, g) for g in globs)

--- a/craft_application/services/__init__.py
+++ b/craft_application/services/__init__.py
@@ -28,6 +28,7 @@ from craft_application.services.proxy import ProxyService
 from craft_application.services.remotebuild import RemoteBuildService
 from craft_application.services.request import RequestService
 from craft_application.services.state import StateService
+from craft_application.services.linter import LinterService
 
 # ServiceFactory must be imported after the actual services
 from craft_application.services.service_factory import ServiceFactory
@@ -47,4 +48,5 @@ __all__ = [
     "ServiceFactory",
     "StateService",
     "TestingService",
+    "LinterService",
 ]

--- a/craft_application/services/linter.py
+++ b/craft_application/services/linter.py
@@ -1,0 +1,268 @@
+# This file is part of craft-application.
+#
+# Copyright 2025 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Orchestrates linter registration, ignore config and execution."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable, Iterator
+from typing import TYPE_CHECKING, Any, cast
+
+from craft_cli import emit
+
+from craft_application import util
+from craft_application.lint.types import (
+    ExitCode,
+    IgnoreConfig,
+    IgnoreSpec,
+    LintContext,
+    LinterIssue,
+    Severity,
+    Stage,
+    should_ignore,
+)
+from craft_application.services import base
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from craft_application.application import AppMetadata
+    from craft_application.lint.base import AbstractLinter
+    from craft_application.services.service_factory import ServiceFactory
+
+
+class LinterService(base.AppService):
+    """Orchestrates linter registration, ignore config and execution."""
+
+    _class_registry: dict[Stage, list[type[AbstractLinter]]] = {
+        Stage.PRE: [],
+        Stage.POST: [],
+    }
+
+    def __init__(self, app: AppMetadata, services: ServiceFactory) -> None:
+        super().__init__(app, services)
+        self._ignore_cfg: IgnoreConfig = {}
+        self._issues: list[LinterIssue] = []
+
+    @classmethod
+    def register(cls, linter_cls: type[AbstractLinter]) -> None:
+        """Register a linter class for use by the service."""
+        if inspect.isabstract(linter_cls):
+            return
+        stage = getattr(linter_cls, "stage", None)
+        name = getattr(linter_cls, "name", None)
+        if not isinstance(stage, Stage) or not isinstance(name, str) or not name:
+            raise ValueError(
+                f"Invalid linter class {linter_cls!r}: missing/invalid name or stage"
+            )
+        emit.debug(f"Registering linter {name!r} for stage {stage.value}")
+        cls._class_registry[stage].append(linter_cls)
+
+    @classmethod
+    def build_ignore_config(
+        cls,
+        project_dir: Path,
+        cli_ignores: list[str] | None = None,
+        cli_ignore_files: list[Path] | None = None,
+    ) -> IgnoreConfig:
+        """Merge ignore config from standard file(s) and CLI rules."""
+        config: IgnoreConfig = {}
+        file_cfg = cls._load_ignore_file(project_dir)
+        if file_cfg:
+            cls._merge_into(config, file_cfg)
+        if cli_ignore_files:
+            for extra in cli_ignore_files:
+                if extra and extra.exists():
+                    data = util.safe_yaml_load(extra.read_text())
+                    if isinstance(data, dict):
+                        cls._merge_into(
+                            config,
+                            cls._normalize_ignore_config(cast(dict[str, Any], data)),
+                        )
+        if cli_ignores:
+            cls._merge_into(config, cls._parse_cli_ignores(cli_ignores))
+        return config
+
+    def load_ignore_config(
+        self,
+        project_dir: Path,
+        cli_ignores: list[str] | None = None,
+        cli_ignore_files: list[Path] | None = None,
+    ) -> IgnoreConfig:
+        """Load and cache ignore config, merging CLI rules if any."""
+        self._ignore_cfg = self.__class__.build_ignore_config(
+            project_dir, cli_ignores, cli_ignore_files
+        )
+        return self._ignore_cfg
+
+    @staticmethod
+    def _load_ignore_file(project_dir: Path) -> IgnoreConfig:
+        """Load ignore config from a standard location in the project dir, if any."""
+        candidates = [
+            project_dir / "craft-lint.yaml",
+            project_dir / ".craft-lint.yaml",
+            project_dir / ".craft" / "lintignore.yaml",
+        ]
+        for p in candidates:
+            if p.exists():
+                emit.debug(f"Loading linter ignore config from {p}")
+                data = util.safe_yaml_load(p.read_text())
+                if not isinstance(data, dict):
+                    emit.debug(
+                        "Lint ignore config is not a mapping; ignoring this file."
+                    )
+                    return {}
+                return LinterService._normalize_ignore_config(
+                    cast(dict[str, Any], data)
+                )
+        return {}
+
+    @staticmethod
+    def _normalize_ignore_config(raw: dict[str, Any]) -> IgnoreConfig:
+        """Normalize raw YAML data into IgnoreConfig structure."""
+        cfg: IgnoreConfig = {}
+        for linter_name, spec in raw.items():
+            if not isinstance(spec, dict):
+                continue
+            spec_dict = cast(dict[str, Any], spec)
+            ids_raw = cast(str | list[str] | set[str] | None, spec_dict.get("ids"))
+            by_filename_raw = cast(
+                dict[str, list[str] | set[str]] | None, spec_dict.get("by_filename")
+            )
+
+            if ids_raw == "*":
+                norm_ids: str | set[str] = "*"
+            else:
+                norm_ids = set(cast(Iterable[str], ids_raw or []))
+
+            norm_by_fname: dict[str, set[str]] = {}
+            for issue_id, globs in (by_filename_raw or {}).items():
+                norm_by_fname[str(issue_id)] = set(cast(Iterable[str], globs or []))
+            cfg[str(linter_name)] = IgnoreSpec(ids=norm_ids, by_filename=norm_by_fname)
+        return cfg
+
+    @staticmethod
+    def _parse_cli_ignores(rules: list[str]) -> IgnoreConfig:
+        """Parse CLI rules like 'linter:id' or 'linter:id=glob' into IgnoreConfig."""
+        result: IgnoreConfig = {}
+        for rule in rules:
+            if not rule:
+                continue
+
+            try:
+                linter_name, remainder = rule.split(":", 1)
+            except ValueError:
+                continue
+
+            if "=" in remainder:
+                issue_id, glob = remainder.split("=", 1)
+                spec = result.setdefault(
+                    linter_name, IgnoreSpec(ids=set(), by_filename={})
+                )
+
+                spec.by_filename.setdefault(issue_id, set()).add(glob)
+            else:
+                issue_id = remainder
+                spec = result.setdefault(
+                    linter_name, IgnoreSpec(ids=set(), by_filename={})
+                )
+                if isinstance(spec.ids, set):
+                    spec.ids.add(issue_id)
+                else:
+                    pass
+        return result
+
+    @staticmethod
+    def _merge_into(base_cfg: IgnoreConfig, overlay: IgnoreConfig) -> None:
+        """Merge overlay rules into base config, with overlay taking precedence."""
+        for linter_name, over_spec in overlay.items():
+            if linter_name not in base_cfg:
+                base_cfg[linter_name] = IgnoreSpec(
+                    ids=set() if over_spec.ids != "*" else "*",
+                    by_filename={k: set(v) for k, v in over_spec.by_filename.items()},
+                )
+                if over_spec.ids == "*":
+                    continue
+                if isinstance(over_spec.ids, set):
+                    base_cfg[linter_name].ids = set(over_spec.ids)
+                continue
+            base_spec = base_cfg[linter_name]
+
+            if over_spec.ids == "*":
+                base_spec.ids = "*"
+                base_spec.by_filename.clear()
+            elif isinstance(over_spec.ids, set):
+                if base_spec.ids != "*":
+                    if not isinstance(base_spec.ids, set):
+                        base_spec.ids = set()
+                    base_spec.ids.update(over_spec.ids)
+            for issue_id, globs in over_spec.by_filename.items():
+                base_spec.by_filename.setdefault(issue_id, set()).update(globs)
+
+    def pre_filter_linters(
+        self,
+        stage: Stage,
+        ctx: LintContext,  # noqa: ARG002 (reserved for future use)
+        candidates: list[type[AbstractLinter]] | None = None,
+    ) -> list[type[AbstractLinter]]:
+        """App-specific selection hook."""
+        registry = type(self)._class_registry  # noqa: SLF001
+        return list(candidates or registry.get(stage, []))
+
+    def post_filter_issues(
+        self,
+        linter: AbstractLinter,  # noqa: ARG002 (reserved for future use)
+        issues: Iterable[LinterIssue],
+        ctx: LintContext,  # noqa: ARG002 (reserved for future use)
+    ) -> Iterator[LinterIssue]:
+        """App-specific filtering hook."""
+        yield from issues
+
+    def run(
+        self,
+        stage: Stage,
+        ctx: LintContext,
+    ) -> Iterator[LinterIssue]:
+        """Run linters for a stage, streaming non-suppressed issues."""
+        self._issues.clear()
+        registry = type(self)._class_registry  # noqa: SLF001
+        selected = self.pre_filter_linters(stage, ctx, registry.get(stage, []))
+        for cls in selected:
+            linter = cls()
+            raw_issues = linter.run(ctx)
+
+            user_filtered = (
+                issue
+                for issue in raw_issues
+                if not should_ignore(linter.name, issue, self._ignore_cfg)
+            )
+            filtered = self.post_filter_issues(linter, user_filtered, ctx)
+            for issue in filtered:
+                self._issues.append(issue)
+                yield issue
+
+    def summary(self) -> ExitCode:
+        """Summarize results as an ExitCode based on highest severity."""
+        if any(i.severity == Severity.ERROR for i in self._issues):
+            return ExitCode.ERROR
+        if any(i.severity == Severity.WARNING for i in self._issues):
+            return ExitCode.WARN
+        return ExitCode.OK
+
+    @property
+    def issues(self) -> list[LinterIssue]:
+        """Return a copy of issues collected during the last run."""
+        return list(self._issues)

--- a/craft_application/services/service_factory.py
+++ b/craft_application/services/service_factory.py
@@ -44,6 +44,7 @@ _DEFAULT_SERVICES = {
     "fetch": "FetchService",
     "init": "InitService",
     "lifecycle": "LifecycleService",
+    "package": "PackageService",
     "project": "ProjectService",
     "provider": "ProviderService",
     "proxy": "ProxyService",
@@ -51,6 +52,7 @@ _DEFAULT_SERVICES = {
     "request": "RequestService",
     "state": "StateService",
     "testing": "TestingService",
+    "linter": "LinterService",
 }
 _CAMEL_TO_PYTHON_CASE_REGEX = re.compile(r"(?<!^)(?=[A-Z])")
 
@@ -87,6 +89,7 @@ class ServiceFactory:
         request: services.RequestService
         state: services.StateService
         testing: services.TestingService
+        linter: services.LinterService
 
     def __init__(
         self,
@@ -250,6 +253,11 @@ class ServiceFactory:
     ) -> type[services.TestingService]: ...
     @overload
     @classmethod
+    def get_class(
+        cls, name: Literal["linter", "LinterService", "LinterClass"]
+    ) -> type[services.LinterService]: ...
+    @overload
+    @classmethod
     def get_class(cls, name: str) -> type[services.AppService]: ...
     @classmethod
     def get_class(cls, name: str) -> type[services.AppService]:
@@ -299,6 +307,8 @@ class ServiceFactory:
     def get(self, service: Literal["state"]) -> services.StateService: ...
     @overload
     def get(self, service: Literal["testing"]) -> services.TestingService: ...
+    @overload
+    def get(self, service: Literal["linter"]) -> services.LinterService: ...
     @overload
     def get(self, service: str) -> services.AppService: ...
     def get(self, service: str) -> services.AppService:

--- a/tests/unit/services/test_linter_service.py
+++ b/tests/unit/services/test_linter_service.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from craft_application.application import AppMetadata
+from craft_application.lint.base import AbstractLinter
+from craft_application.lint.types import LintContext, LinterIssue, Severity, Stage
+from craft_application.services.linter import LinterService
+from craft_application.services.service_factory import ServiceFactory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _DummyPreLinter(AbstractLinter):
+    name = "dummy.pre"
+    stage = Stage.PRE
+
+    def run(self, ctx: LintContext):
+        yield LinterIssue(
+            id="D001",
+            message="dummy warning",
+            severity=Severity.WARNING,
+            filename=str(ctx.project_dir / "README.md"),
+        )
+
+
+def _make_ctx(tmp_path: Path) -> LintContext:
+    return LintContext(project_dir=tmp_path, artifact_dirs=[])
+
+
+@pytest.fixture(autouse=True)
+def _reset_linter_registry() -> None:
+    """Clear class-level linter registry before each test to avoid leakage."""
+    try:
+        LinterService._class_registry[Stage.PRE].clear()  # type: ignore[attr-defined]
+        LinterService._class_registry[Stage.POST].clear()  # type: ignore[attr-defined]
+    except Exception:  # noqa: S110, BLE001
+        pass
+
+
+def test_register_and_run_warning(tmp_path: Path) -> None:
+    LinterService.register(_DummyPreLinter)
+    app = AppMetadata(name="craft_application")
+    factory = ServiceFactory(app)
+    svc = LinterService(app=app, services=factory)
+    ctx = _make_ctx(tmp_path)
+
+    issues = list(svc.run(Stage.PRE, ctx))
+    assert len(issues) == 1
+    assert issues[0].id == "D001"
+    assert int(svc.summary()) == 1  # WARN
+
+
+def test_ignore_by_id_cli(tmp_path: Path) -> None:
+    app = AppMetadata(name="craft_application")
+    factory = ServiceFactory(app)
+    svc = LinterService(app=app, services=factory)
+    ctx = _make_ctx(tmp_path)
+
+    svc.load_ignore_config(project_dir=tmp_path, cli_ignores=["dummy.pre:D001"])
+    issues = list(svc.run(Stage.PRE, ctx))
+    assert issues == []
+    assert int(svc.summary()) == 0  # OK
+
+
+def test_ignore_by_glob_yaml(tmp_path: Path) -> None:
+    yaml = tmp_path / "craft-lint.yaml"
+    yaml.write_text(
+        """
+dummy.pre:
+  by_filename:
+    D001: ["*/README.*"]
+"""
+    )
+
+    app = AppMetadata(name="craft_application")
+    factory = ServiceFactory(app)
+    svc = LinterService(app=app, services=factory)
+    ctx = _make_ctx(tmp_path)
+
+    svc.load_ignore_config(project_dir=tmp_path)
+    issues = list(svc.run(Stage.PRE, ctx))
+    assert issues == []
+    assert int(svc.summary()) == 0
+
+
+def test_post_filter_hook_drops_issue(tmp_path: Path) -> None:
+    class Policy(LinterService):
+        def post_filter_issues(self, linter: AbstractLinter, issues, ctx):  # type: ignore[override]
+            return (i for i in issues if i.id != "D001")
+
+    app = AppMetadata(name="craft_application")
+    factory = ServiceFactory(app)
+    svc = Policy(app=app, services=factory)
+    ctx = _make_ctx(tmp_path)
+
+    issues = list(svc.run(Stage.PRE, ctx))
+    assert issues == []
+    assert int(svc.summary()) == 0


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Closes #782 
This PR introduces a shared Linter Service to craft-application so downstream apps (Snapcraft, Charmcraft) can add and run linters consistently.

The design of the Linter Service is as discussed in #782 