### PR TITLE
fix: raise error on duplicate keys in processed dicts

### DIFF
--- a/craft_application/grammar.py
+++ b/craft_application/grammar.py
@@ -104,8 +104,8 @@ def post_process_grammar(
     key: str,
     processed_grammar: list[Any],
     part_yaml_data: dict[str, Any],
-) -> list[Any]:
-    """Post-process primitives returnes by the grammar processor.
+) -> list[Any] | dict[str, str] | None:
+    """Post-process primitives returns by the grammar processor.
 
     Special cases:
     - scalar values should return as a single object, not in a list.
@@ -115,11 +115,11 @@ def post_process_grammar(
     """
     if processor.variant == Variant.FOR_VARIANT:
         if key in _DICT_ONLY_VALUES:
-            return merge_processed_dict(processed_grammar, part_yaml_data)  # type: ignore[assignment]
+            return merge_processed_dict(processed_grammar, part_yaml_data)
         if key not in _NON_SCALAR_VALUES:
-            return processed_grammar[0] if processed_grammar else None  # type: ignore[assignment]
+            return processed_grammar[0] if processed_grammar else None
     elif key not in _NON_SCALAR_VALUES or key in _DICT_ONLY_VALUES:
-        return processed_grammar[0] if processed_grammar else None  # type: ignore[assignment]
+        return processed_grammar[0] if processed_grammar else None
     return processed_grammar
 
 

--- a/craft_application/grammar.py
+++ b/craft_application/grammar.py
@@ -106,11 +106,11 @@ def post_process_grammar(
     processed_grammar: list[Any],
     part_yaml_data: dict[str, Any],
 ) -> list[Any] | dict[str, str] | None:
-    """Post-process primitives returns by the grammar processor.
+    """Post-process primitives returned by the grammar processor.
 
     Special cases:
-    - scalar values should return as a single object, not in a list.
-    - dict values should return as a dict, not in a list.
+    - Scalar values should be returned as a single object instead of a list.
+    - Dict values should be returned as a dict instead of a list.
 
     :returns: the post-processed primitives
     """

--- a/craft_application/grammar.py
+++ b/craft_application/grammar.py
@@ -92,13 +92,18 @@ def process_part(
                 f"Invalid grammar syntax while processing '{key}' in '{part_yaml_data}': {e}"
             ) from e
 
-        part_yaml_data[key] = post_process_grammar(processor, key, processed_grammar)
+        part_yaml_data[key] = post_process_grammar(
+            processor, key, processed_grammar, part_yaml_data
+        )
 
     return part_yaml_data
 
 
 def post_process_grammar(
-    processor: GrammarProcessor, key: str, processed_grammar: list[Any]
+    processor: GrammarProcessor,
+    key: str,
+    processed_grammar: list[Any],
+    part_yaml_data: dict[str, Any],
 ) -> list[Any]:
     """Post-process primitives returnes by the grammar processor.
 
@@ -110,7 +115,7 @@ def post_process_grammar(
     """
     if processor.variant == Variant.FOR_VARIANT:
         if key in _DICT_ONLY_VALUES:
-            return merge_processed_dict(processed_grammar)  # type: ignore[assignment]
+            return merge_processed_dict(processed_grammar, part_yaml_data)  # type: ignore[assignment]
         if key not in _NON_SCALAR_VALUES:
             return processed_grammar[0] if processed_grammar else None  # type: ignore[assignment]
     elif key not in _NON_SCALAR_VALUES or key in _DICT_ONLY_VALUES:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,16 @@
 Changelog
 *********
 
+5.10.2 (2025-MM-DD)
+-------------------
+
+Application
+===========
+
+- Fail on duplicated keys in dictionnaries in the project file after the grammar
+  resolution.
+
+
 5.10.1 (2025-09-12)
 -------------------
 
@@ -1038,3 +1048,5 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _5.8.0: https://github.com/canonical/craft-application/releases/tag/5.8.0
 .. _5.9.0: https://github.com/canonical/craft-application/releases/tag/5.9.0
 .. _5.9.1: https://github.com/canonical/craft-application/releases/tag/5.9.1
+.. _5.10.0: https://github.com/canonical/craft-application/releases/tag/5.10.0
+.. _5.10.1: https://github.com/canonical/craft-application/releases/tag/5.10.1

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -10,7 +10,7 @@ Changelog
 Application
 ===========
 
-- Fail on duplicated keys in dictionnaries in the project file after the grammar
+- Fail on duplicated keys in dictionaries in the project file after the grammar
   resolution.
 
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -10,8 +10,8 @@ Changelog
 Application
 ===========
 
-- Fail on duplicated keys in dictionaries in the project file after the grammar
-  resolution.
+- If keys are duplicated in a project file's dictionaries after the grammar is
+  resolved, an error will be raised.
 
 
 5.10.1 (2025-09-12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "annotated-types>=0.6.0",
     "craft-archives>=2.2.0",
     "craft-cli>=3.2.0",
-    "craft-grammar>=2.2.0",
+    "craft-grammar @ git+https://github.com/canonical/craft-grammar.git@main",
     "craft-parts>=2.21.0",
     "craft-platforms>=0.6.0",
     "craft-providers>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "annotated-types>=0.6.0",
     "craft-archives>=2.2.0",
     "craft-cli>=3.2.0",
-    "craft-grammar @ git+https://github.com/canonical/craft-grammar.git@main",
+    "craft-grammar>=2.3.0",
     "craft-parts>=2.21.0",
     "craft-platforms>=0.6.0",
     "craft-providers>=3.0.0",

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -739,17 +739,20 @@ def test_render_for_grammar_dict_duplicate_keys(
                     "for risky": {
                         "a": "b",
                         "c": "d",
-                    }
-                },
-                {
-                    "for s390x": {
                         "e": "f",
                     }
                 },
                 {
+                    "for s390x": {
+                        "g": "h",
+                    }
+                },
+                {
                     "for any": {
-                        # This conflicts with key from the the first section
+                        "foo": "bar",
+                        # The following keys conflicts with keys from the the first section
                         "a": "g",
+                        "c": "i",
                     }
                 },
             ],
@@ -758,7 +761,8 @@ def test_render_for_grammar_dict_duplicate_keys(
     mocker.patch.object(real_project_service, "_preprocess", return_value=project_data)
 
     with pytest.raises(
-        errors.CraftValidationError, match="Duplicate keys in processed dict 'a' in"
+        errors.CraftValidationError,
+        match=r"Duplicate keys in processed dict \[(?:'c', 'a'|'a', 'c')\] in",
     ):
         real_project_service.render_for(
             build_for="arm64",

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -719,6 +719,51 @@ def test_render_for_grammar(
 
 
 @pytest.mark.parametrize(
+    ("app_metadata"),
+    [{"enable_for_grammar": False}],
+    indirect=["app_metadata"],
+)
+@pytest.mark.usefixtures("fake_project_file")
+def test_render_for_grammar_dict(
+    real_project_service: ProjectService,
+    fake_project_dict,
+    mocker,
+    app_metadata,
+):
+    project_data = copy.deepcopy(fake_project_dict)
+    project_data["parts"] = {
+        "part1": {
+            "plugin": "nil",
+            "organize": [
+                {
+                    "for risky": {
+                        "a": "b",
+                        "c": "d",
+                    }
+                },
+                {
+                    "for s390x": {
+                        "a": "e",
+                    }
+                },
+                {
+                    "for any": {
+                        "f": "g",
+                    }
+                },
+            ],
+        },
+    }
+    mocker.patch.object(real_project_service, "_preprocess", return_value=project_data)
+
+    result = real_project_service.render_for(
+        build_for="arm64", build_on="riscv64", platform="risky"
+    )
+
+    assert result.parts["part1"]["organize"] == {"a": "b", "c": "d", "f": "g"}
+
+
+@pytest.mark.parametrize(
     "build_for", [*(arch.value for arch in craft_platforms.DebianArchitecture), "all"]
 )
 @pytest.mark.usefixtures("fake_project_file")

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ requires-dist = [
     { name = "annotated-types", specifier = ">=0.6.0" },
     { name = "craft-archives", specifier = ">=2.2.0" },
     { name = "craft-cli", specifier = ">=3.2.0" },
-    { name = "craft-grammar", specifier = ">=2.2.0" },
+    { name = "craft-grammar", git = "https://github.com/canonical/craft-grammar.git?rev=main" },
     { name = "craft-parts", specifier = ">=2.21.0" },
     { name = "craft-platforms", specifier = ">=0.6.0" },
     { name = "craft-providers", specifier = ">=3.0.0" },
@@ -593,15 +593,11 @@ wheels = [
 
 [[package]]
 name = "craft-grammar"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2.2.0.post8+g9b70aa6"
+source = { git = "https://github.com/canonical/craft-grammar.git?rev=main#9b70aa6360d7ec92f0334f711eae073291ace7f9" }
 dependencies = [
     { name = "overrides" },
     { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/aa/70b1e455d01268de803711385bd4111596a18a2183baeb18ea40ad857401/craft_grammar-2.2.0.tar.gz", hash = "sha256:e91f65c6c9d0f08a2783a9fcf946ece80888cee3c85f4120df204f08cef1d486", size = 146191, upload-time = "2025-08-26T16:14:54.117Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/60/d7dbb8ccf3188793c4d36576a1efec5e18e656c8fb290ffe0fad1da932e1/craft_grammar-2.2.0-py3-none-any.whl", hash = "sha256:be910b3eb8452812cc976ccbce1ca52e7a407c44823e51bcf4a99dec2a2cb544", size = 27167, upload-time = "2025-08-26T16:14:52.613Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ requires-dist = [
     { name = "annotated-types", specifier = ">=0.6.0" },
     { name = "craft-archives", specifier = ">=2.2.0" },
     { name = "craft-cli", specifier = ">=3.2.0" },
-    { name = "craft-grammar", git = "https://github.com/canonical/craft-grammar.git?rev=main" },
+    { name = "craft-grammar", specifier = ">=2.3.0" },
     { name = "craft-parts", specifier = ">=2.21.0" },
     { name = "craft-platforms", specifier = ">=0.6.0" },
     { name = "craft-providers", specifier = ">=3.0.0" },
@@ -593,11 +593,15 @@ wheels = [
 
 [[package]]
 name = "craft-grammar"
-version = "2.2.0.post8+g9b70aa6"
-source = { git = "https://github.com/canonical/craft-grammar.git?rev=main#9b70aa6360d7ec92f0334f711eae073291ace7f9" }
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "overrides" },
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/35/584fc928bffd1346c4b9c55170cbe4c09f89ec185d0d9d7e2626f876e80d/craft_grammar-2.3.0.tar.gz", hash = "sha256:0b7ae3aa595f0f3d1f82ed2e696c99b35283c18a60c7a68840bc185bd123e4d8", size = 147552, upload-time = "2025-09-19T15:51:16.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/ce/0edcd8a0b0ab73f43bb5197e7f61d2be0c0fd129451936659353553f5037/craft_grammar-2.3.0-py3-none-any.whl", hash = "sha256:4a709037a7a2bdbc8362ef97645dfb86d4c67eac31058482704cba074f49507b", size = 27772, upload-time = "2025-09-19T15:51:14.794Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Fixes https://github.com/canonical/craft-grammar/issues/124
CRAFT-4743