### PR TITLE
feat!(models/Project): make summary and description fields mandatory

### DIFF
--- a/craft_application/models/constraints.py
+++ b/craft_application/models/constraints.py
@@ -145,7 +145,7 @@ SummaryStr = Annotated[
     pydantic.Field(
         max_length=78,
         title="Summary",
-        description="A short description of the project.",
+        description="A short description of the project. Maximum length 78 characters.",
         examples=[
             "Linux for Human Beings",
             "The cross-platform desktop application for JupyterLab",

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -118,10 +118,9 @@ class Project(base.CraftBaseModel):
     name: ProjectName
     title: ProjectTitle | None = None
     version: VersionStr | None = None
-    summary: SummaryStr | None = None
+    summary: SummaryStr
 
-    description: str | None = pydantic.Field(
-        default=None,
+    description: str = pydantic.Field(
         description="The full description of the project.",
     )
     """The full description of the project.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -4,6 +4,17 @@
 Changelog
 *********
 
+6.0.0 (unreleased)
+------------------
+
+Breaking changes
+================
+
+Models
+~~~~~~
+
+- The ``summary`` and ``description`` fields on the ``Project`` model are now mandatory.
+
 5.10.3 (2025-09-22)
 -------------------
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Crafts that need these to be optional will have to make the change themselves.