### PR TITLE
Use en_US. "initialising" -> "Initializing"

### DIFF
--- a/craft_application/commands/init.py
+++ b/craft_application/commands/init.py
@@ -57,7 +57,7 @@ class InitCommand(base.AppCommand):
     common = True
 
     default_profile = "simple"
-    """The default profile to use when initialising a project."""
+    """The default profile to use when initializing a project."""
 
     def fill_parser(self, parser: argparse.ArgumentParser) -> None:
         """Specify command's specific parameters."""
@@ -122,7 +122,7 @@ class InitCommand(base.AppCommand):
             project_dir=project_dir, template_dir=template_dir
         )
 
-        craft_cli.emit.progress("Initialising project.")
+        craft_cli.emit.progress("Initializing project.")
         self._services.init.initialise_project(
             project_dir=project_dir,
             project_name=project_name,

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -377,7 +377,7 @@ class FetchServiceError(CraftError):
 
 
 class InitError(CraftError):
-    """Errors related to initialising a project."""
+    """Errors related to initializing a project."""
 
 
 class ArtifactCreationError(CraftError):

--- a/craft_application/services/init.py
+++ b/craft_application/services/init.py
@@ -86,7 +86,7 @@ class InitService(base.AppService):
         """Initialise a new project from a template.
 
         If a file already exists in the project directory, it is not overwritten.
-        Use `check_for_existing_files()` to see if this will occur before initialising
+        Use `check_for_existing_files()` to see if this will occur before initializing
         the project.
 
         :param project_dir: The directory to initialise the project in.
@@ -94,7 +94,7 @@ class InitService(base.AppService):
         :param template_dir: The directory containing the templates.
         """
         emit.debug(
-            f"Initialising project {project_name!r} in {str(project_dir)!r} from "
+            f"Initializing project {project_name!r} in {str(project_dir)!r} from "
             f"template in {str(template_dir)!r}."
         )
         environment = self._get_templates_environment(template_dir)

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -200,7 +200,7 @@ class LifecycleService(base.AppService):
         An application may override this method if needed if the lifecycle
         manager needs to be called differently.
         """
-        emit.debug(f"Initialising lifecycle manager in {self._work_dir}")
+        emit.debug(f"Initializing lifecycle manager in {self._work_dir}")
         emit.trace(f"Lifecycle: {repr(self)}")
 
         project_service = self._services.get("project")
@@ -302,7 +302,7 @@ class LifecycleService(base.AppService):
             else:
                 actions = []
 
-            emit.progress("Initialising lifecycle")
+            emit.progress("Initializing lifecycle")
             self._exec(actions)
 
         except PartsError as err:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -737,7 +737,7 @@ Application
 Commands
 ========
 
-- Adds an ``init`` command for initialising new projects.
+- Adds an ``init`` command for initializing new projects.
 - Lifecycle commands are ordered in the sequence they run rather than
   alphabetically in help messages.
 - Preserves order of ``CommandGroups`` defined by the application.
@@ -747,7 +747,7 @@ Commands
 Services
 ========
 
-- Adds an ``InitService`` for initialising new projects.
+- Adds an ``InitService`` for initializing new projects.
 
 For a complete list of commits, check out the `4.4.0`_ release on GitHub.
 


### PR DESCRIPTION
- [No ] Have you followed the guidelines for contributing?
- [No ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [No ] Have you successfully run `make lint && make test`?
- [No ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
Unfortunately, snapcraft command lines such as "snapcraft pack" write to the console en_GB words instead of en_US words.
E.g. "Initialising lifecycle"