### PR TITLE
fix(models): sort the set of invalid platform names

### DIFF
--- a/craft_application/models/platforms.py
+++ b/craft_application/models/platforms.py
@@ -18,7 +18,7 @@
 import enum
 import re
 from collections.abc import Iterable, Mapping
-from typing import Annotated, ClassVar, get_args
+from typing import Annotated, ClassVar, cast, get_args
 
 import craft_platforms
 import pydantic
@@ -54,7 +54,9 @@ PlatformName = Annotated[
         title="Platform name",
         description="The name of this platform. May not contain '/'",
         examples=["riscv64", "my-special-platform"],
-        json_schema_extra={"not": {"enum": list(RESERVED_PLATFORM_NAMES)}},
+        json_schema_extra={
+            "not": {"enum": cast(pydantic.JsonValue, sorted(RESERVED_PLATFORM_NAMES))}
+        },
     ),
 ]
 PlatformNameAdapter = pydantic.TypeAdapter[str](PlatformName)

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,16 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+6.0.1 (2025-11-19)
+------------------
+
+Models
+======
+
+- The list of invalid platform names for the JSON schema is now sorted.
+
+For a complete list of commits, check out the `6.0.1`_ release on GitHub.
+
 6.0.0 (2025-11-17)
 ------------------
 
@@ -1140,3 +1150,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _5.10.3: https://github.com/canonical/craft-application/releases/tag/5.10.3
 .. _5.11.0: https://github.com/canonical/craft-application/releases/tag/5.11.0
 .. _6.0.0: https://github.com/canonical/craft-application/releases/tag/6.0.0
+.. _6.0.1: https://github.com/canonical/craft-application/releases/tag/6.0.1


### PR DESCRIPTION
Otherwise the iteration order is undefined, which makes for spurious failures over time if the generated schema is compared against stored schemas.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
