### PR TITLE
fix(craft-test): enable spread tests with 26.04 backends

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,15 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+6.1.2 (2026-MM-DD)
+------------------
+
+Bug fixes
+=========
+
+- The ``test`` command can now run tests with an Ubuntu 26.04 backend, using daily
+  images.
+
 6.1.1 (2026-01-27)
 ------------------
 

--- a/spread/.extension
+++ b/spread/.extension
@@ -11,6 +11,10 @@ allocate-lxd-vm(){
   DISK="${DISK:-20}"
   CPU="${CPU:-4}"
   MEM="${MEM:-8}"
+  # Allow early testing on 26.04
+  if [[ "$SERIES" == "26.04" && "$DISTRO" == "ubuntu" ]]; then
+    DISTRO="ubuntu-daily"
+  fi
 
   cloud_config="$(mktemp)"
   sed "s|SPREAD_PASSWORD|$SPREAD_PASSWORD|g" "${SCRIPTDIR}/cloud-config.yaml" > "$cloud_config"


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

The `ubuntu-26.04` backend cannot parse into a LXD backend because `ubuntu:26.04` doesn't yet exist - users instead must use `ubuntu-daily:26.04` for such images.

This PR adds a temporary workaround to get us able to test on 26.04, but a larger task will be necessary for arriving at a long-term solution.