### PR TITLE
feat: add a mechanism to add fetch-service secrets

### DIFF
--- a/craft_application/fetch.py
+++ b/craft_application/fetch.py
@@ -39,6 +39,12 @@ from craft_application.util import retry
 logger = logging.getLogger(__name__)
 
 
+SessionSecret = dict[str, Any]
+"""Type representing a secret for a fetch-service session. We could use concrete models
+ here but we want to be able to support new, arbitrary secret types without needing
+ to update this code and re-release craft-application and any craft tools using this."""
+
+
 @dataclass(frozen=True)
 class FetchServiceConfig:
     """Dataclass for the ports that a fetch-service instance uses."""
@@ -222,14 +228,22 @@ def stop_service(fetch_process: subprocess.Popen[str]) -> None:
         fetch_process.kill()
 
 
-def create_session(*, strict: bool, timeout: float = 5.0) -> SessionData:
+def create_session(
+    *, strict: bool, timeout: float = 5.0, secrets: list[SessionSecret] | None = None
+) -> SessionData:
     """Create a new fetch-service session.
 
     :param strict: Whether the created session should be strict.
     :param timeout: Maximum time to wait for the response from the fetch-service
+    :param secrets: Any secrets to be added to the session.
     :return: a SessionData object containing the session's id and token.
     """
-    json = {"policy": "strict" if strict else "permissive"}
+    json: dict[str, Any] = {"policy": "strict" if strict else "permissive"}
+
+    if secrets:
+        emit.debug(f"Adding {len(secrets)} secret(s) to session creation request.")
+        json["secrets"] = secrets
+
     data = _service_request("post", "session", json=json, timeout=timeout).json()
 
     return SessionData.unmarshal(data=data)

--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -59,6 +59,21 @@ def _use_external_session() -> bool:
     return os.getenv(EXTERNAL_FETCH_SERVICE_ENV_VAR) == "1"
 
 
+class SecretCallback(typing.Protocol):
+    """Type representing a function that might generate a secret."""
+
+    def __call__(
+        self, app: AppMetadata, **kwargs: typing.Any
+    ) -> list[fetch.SessionSecret]:
+        """Return a list of session secrets for a new session.
+
+        The only guaranteed parameter is `app`. The `kwargs` exist to allow us to extend
+        the parameters in the future, and implementations of this protocol should check the
+        available parameters at runtime.
+        """
+        ...
+
+
 class FetchService(base.AppService):
     """Service class that handles communication with the fetch-service.
 
@@ -78,6 +93,8 @@ class FetchService(base.AppService):
     _session_data: fetch.SessionData | None
     _instance: craft_providers.Executor | None
     _proxy_cert: pathlib.Path | None
+
+    _secret_callbacks: typing.ClassVar[list[SecretCallback]] = []
 
     def __init__(
         self,
@@ -165,6 +182,11 @@ class FetchService(base.AppService):
             raise errors.CraftError(brief)
         return enable_command_line or _use_external_session()
 
+    @classmethod
+    def register_secret_callback(cls, callback: SecretCallback) -> None:
+        """Register a callback to provide secrets to the fetch-service."""
+        cls._secret_callbacks.append(callback)
+
     def configure_instance(self, instance: craft_providers.Executor) -> dict[str, str]:
         """Configure an instance for use with the fetch-service.
 
@@ -213,7 +235,10 @@ class FetchService(base.AppService):
         os.environ[PROVIDERS_SUPPRESS_UPGRADE_VAR] = "1"
 
         strict_session = self._session_policy == "strict"
-        self._session_data = fetch.create_session(strict=strict_session)
+        secrets = self._get_secrets()
+        self._session_data = fetch.create_session(
+            strict=strict_session, secrets=secrets
+        )
         self._instance = instance
         net_info = fetch.NetInfo(instance, self._session_data)
         self._services.get("proxy").configure(self._proxy_cert, net_info.http_proxy)
@@ -317,3 +342,9 @@ class FetchService(base.AppService):
             for line in text.splitlines():
                 display(line)
             display("This build will fail on 'strict' fetch-service sessions.")
+
+    def _get_secrets(self) -> list[dict[str, str]]:
+        secrets: list[fetch.SessionSecret] = []
+        for callback in self._secret_callbacks:
+            secrets.extend(callback(self._app))
+        return secrets

--- a/craft_application/services/fetch.py
+++ b/craft_application/services/fetch.py
@@ -343,7 +343,7 @@ class FetchService(base.AppService):
                 display(line)
             display("This build will fail on 'strict' fetch-service sessions.")
 
-    def _get_secrets(self) -> list[dict[str, str]]:
+    def _get_secrets(self) -> list[fetch.SessionSecret]:
         secrets: list[fetch.SessionSecret] = []
         for callback in self._secret_callbacks:
             secrets.extend(callback(self._app))

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,7 +15,7 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
-6.4.0 (unreleased)
+6.4.0 (2026-04-23)
 ------------------
 
 Services

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,17 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+6.4.0 (unreleased)
+------------------
+
+Services
+========
+
+- The FetchService now supports registering callbacks to provide secrets during fetch-service
+  session creation.
+
+For a complete list of commits, check out the `6.4.0`_ release on GitHub.
+
 6.3.1 (2026-04-09)
 ------------------
 
@@ -1289,3 +1300,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _6.2.2: https://github.com/canonical/craft-application/releases/tag/6.2.2
 .. _6.3.0: https://github.com/canonical/craft-application/releases/tag/6.3.0
 .. _6.3.1: https://github.com/canonical/craft-application/releases/tag/6.3.1
+.. _6.4.0: https://github.com/canonical/craft-application/releases/tag/6.4.0

--- a/tests/unit/services/test_fetch.py
+++ b/tests/unit/services/test_fetch.py
@@ -30,6 +30,7 @@ import pathlib
 import re
 import textwrap
 from datetime import datetime
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -37,7 +38,7 @@ import craft_platforms
 import craft_providers
 import pytest
 import pytest_subprocess
-from craft_application import errors, fetch, services
+from craft_application import AppMetadata, errors, fetch, services
 from craft_application.services import fetch as service_module
 from craft_application.services.fetch import (
     EXTERNAL_FETCH_SERVICE_ENV_VAR,
@@ -52,7 +53,7 @@ from freezegun import freeze_time
 @pytest.fixture
 def fetch_service(app, fake_services, fake_project):
     return services.FetchService(
-        app,
+        app.app,
         fake_services,
     )
 
@@ -91,6 +92,43 @@ def test_create_session(fetch_service, mocker):
         proxy_cert, "http://id:token@test-gateway:13444/"
     )
     assert env == {"GOPROXY": "direct"}
+
+
+def test_create_session_with_secrets(fetch_service, mocker, request):
+    session_data = fetch.SessionData(id="id", token="token")  # noqa: S106
+    mocker.patch.object(fetch, "_get_gateway", return_value="test-gateway")
+    mocker.patch.object(services.ProxyService, "configure")
+    proxy_cert = pathlib.Path("test-cert.pem")
+    fetch_service._proxy_cert = proxy_cert
+
+    def create_secret(app: AppMetadata, **_kwargs: Any) -> list[fetch.SessionSecret]:
+        return [
+            {
+                "type": "basic-auth",
+                "url": "https://www.example-basic-auth.com:443/**",
+                "basic-credentials": f"{app.name}:deadbeef",
+            }
+        ]
+
+    request.addfinalizer(FetchService._secret_callbacks.clear)
+    FetchService.register_secret_callback(create_secret)
+
+    create_mock = mocker.patch.object(
+        fetch, "create_session", return_value=session_data
+    )
+
+    fetch_service.create_session(instance=MagicMock())
+
+    create_mock.assert_called_once_with(
+        strict=True,
+        secrets=[
+            {
+                "type": "basic-auth",
+                "url": "https://www.example-basic-auth.com:443/**",
+                "basic-credentials": "testcraft:deadbeef",
+            }
+        ],
+    )
 
 
 def test_create_session_not_setup(fetch_service):

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -178,6 +178,36 @@ def test_create_session(strict, expected_policy):
 
 
 @assert_requests
+def test_create_session_secrets():
+    secrets = [
+        {
+            "type": "macaroon",
+            "url": "https://www.example-macaroon:443/**",
+            "macaroon-credentials": "deadbeef",
+        },
+        # For the git repo returned by the resolve API
+        {
+            "type": "basic-auth",
+            "url": "https://www.example-basic-auth.com:443/**",
+            "basic-credentials": "user:deadbeef",
+        },
+    ]
+
+    responses.add(
+        responses.POST,
+        f"http://localhost:{CONTROL}/session",
+        json={"id": "my-session-id", "token": "my-session-token"},
+        status=200,
+        match=[
+            matchers.json_params_matcher({"policy": "strict", "secrets": secrets}),
+        ],
+    )
+
+    session_data = fetch.create_session(strict=True, secrets=secrets)
+    assert session_data.session_id == "my-session-id"
+
+
+@assert_requests
 def test_teardown_session():
     session_data = fetch.SessionData(id="my-session-id", token="my-session-token")  # noqa: S106
     default_timeout = 10.0


### PR DESCRIPTION
Applications and plugins can use FetchService.register_secret_callback() to register a callable that is triggered when we're about to create a new fetch-service session. This callable can then return secrets following the fetch-service's own API.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
