### PR TITLE
feat(ProjectService): ban `/` in user-provided part names

### DIFF
--- a/craft_application/_const.py
+++ b/craft_application/_const.py
@@ -34,6 +34,7 @@ BASES_ALLOW_SLASH_IN_PART_NAME = (
     "ubuntu@24.04",
     "ubuntu@24.10",
     "ubuntu@25.04",
+    "ubuntu@25.10",
     "centos@7",
     "almalinux@9",
 )

--- a/craft_application/_const.py
+++ b/craft_application/_const.py
@@ -20,3 +20,26 @@ CRAFT_DEBUG_ENV = "CRAFT_DEBUG"
 
 CRAFT_STATE_DIR_ENV = "CRAFT_STATE_DIR"
 """The environment variable for setting the state service's directory."""
+
+BASES_ALLOW_SLASH_IN_PART_NAME = (
+    "core",
+    "core18",
+    "core20",
+    "core22",
+    "core24",
+    "ubuntu@16.04",
+    "ubuntu@18.04",
+    "ubuntu@20.04",
+    "ubuntu@22.04",
+    "ubuntu@24.04",
+    "ubuntu@24.10",
+    "ubuntu@25.04",
+    "centos@7",
+    "almalinux@9",
+)
+"""Bases that allow the user to have a `/` character in part names.
+
+These are essentially the list of "legacy" bases from before we banned the / character
+in part names. Note that this does not apply to application-provided parts, but rather
+exclusively to user-provided parts.
+"""

--- a/craft_application/models/project.py
+++ b/craft_application/models/project.py
@@ -110,6 +110,7 @@ def _validate_part(part: dict[str, Any]) -> dict[str, Any]:
     return part
 
 
+PartName = Annotated[str, pydantic.Field(pattern=r"^[^/]*$")]
 Part = Annotated[dict[str, Any], pydantic.BeforeValidator(_validate_part)]
 
 
@@ -189,7 +190,7 @@ class Project(base.CraftBaseModel):
     )
 
     # parts are handled by craft-parts
-    parts: dict[str, Part] = pydantic.Field(
+    parts: dict[PartName | str, Part] = pydantic.Field(
         description="The self-contained software pieces needed to create the final artifact.",
         examples=[
             textwrap.dedent(

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -490,7 +490,7 @@ class ProjectService(base.AppService):
 
         Applications may override this if needed.
         """
-        base = project_dict.get("base", project_dict.get("build-base"))
+        base = project_dict.get("build-base", project_dict.get("base"))
         if base in _const.BASES_ALLOW_SLASH_IN_PART_NAME:
             return
 

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -32,9 +32,11 @@ from distro_support.errors import (
     UnknownVersionError,
 )
 
-from craft_application import errors, grammar, util
+from craft_application import _const, errors, grammar, util
+from craft_application.errors import CraftValidationError
 from craft_application.models import Platform
 from craft_application.models.grammar import GrammarAwareProject
+from craft_application.models.project import PartName
 
 from . import base
 
@@ -479,6 +481,39 @@ class ProjectService(base.AppService):
         self.update_project_environment(info)
         craft_parts.expand_environment(project_data, info=info)
 
+    def _validate_user_provided_part_names(self, project_dict: dict[str, Any]) -> None:
+        """Validate that user-provided part names meet our standards.
+
+        This must be done through the project service rather than through the model
+        because we allow the application to add app-provided part names in
+        ``_app_preprocess_project``.
+
+        Applications may override this if needed.
+        """
+        base = project_dict.get("base", project_dict.get("build-base"))
+        if base in _const.BASES_ALLOW_SLASH_IN_PART_NAME:
+            return
+
+        part_names = project_dict.get("parts", {}).keys()
+        name_adapter: pydantic.TypeAdapter[PartName] = pydantic.TypeAdapter(PartName)
+        invalid_part_names: list[str] = []
+        for name in part_names:
+            try:
+                name_adapter.validate_python(name)
+            except pydantic.ValidationError:  # noqa: PERF203 (More than 1 is unlikely)
+                invalid_part_names.append(name)
+
+        if invalid_part_names:
+            names_str = ", ".join(invalid_part_names)
+            raise CraftValidationError(
+                message=f"Invalid part names: {names_str}",
+                details="Part names may not contain the '/' character.",
+                resolution="Rename invalid parts.",
+                logpath_report=False,
+                reportable=False,
+                retcode=os.EX_DATAERR,
+            )
+
     @final
     def _preprocess(
         self,
@@ -502,6 +537,7 @@ class ProjectService(base.AppService):
         """
         project = self.get_raw()
         GrammarAwareProject.validate_grammar(project)
+        self._validate_user_provided_part_names(project)
         self._app_preprocess_project(
             project, build_on=build_on, build_for=build_for, platform=platform
         )

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -21,7 +21,7 @@ Changelog
 Services
 ========
 
-- The Project service prohibits user-provided parts that contain a ``/`` character
+- In a user-written part, upcoming base names can no longer contain forward slashes (/).
   for future bases. This does not apply to current stable bases.
 
 For a complete list of commits, check out the `6.4.0`_ release on GitHub.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -21,8 +21,8 @@ Changelog
 Services
 ========
 
-- In a user-written part, upcoming base names can no longer contain forward slashes (/).
-  for future bases. This does not apply to current stable bases.
+- In a user-written part, upcoming base names can no longer contain forward slashes
+  (/) for bases starting with Ubuntu 26.04.
 
 For a complete list of commits, check out the `6.4.0`_ release on GitHub.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,17 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+6.4.0 (unreleased)
+------------------
+
+Services
+========
+
+- The Project service prohibits user-provided parts that contain a ``/`` character
+  for future bases. This does not apply to current stable bases.
+
+For a complete list of commits, check out the `6.4.0`_ release on GitHub.
+
 6.3.1 (2026-04-09)
 ------------------
 
@@ -1289,3 +1300,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _6.2.2: https://github.com/canonical/craft-application/releases/tag/6.2.2
 .. _6.3.0: https://github.com/canonical/craft-application/releases/tag/6.3.0
 .. _6.3.1: https://github.com/canonical/craft-application/releases/tag/6.3.1
+.. _6.4.0: https://github.com/canonical/craft-application/releases/tag/6.4.0

--- a/docs/reference/services/project.rst
+++ b/docs/reference/services/project.rst
@@ -97,5 +97,5 @@ API documentation
 
 .. autoclass:: ProjectService
     :members:
-    :private-members: _app_preprocess_project,_app_render_legacy_platforms,_preprocess
+    :private-members: _app_preprocess_project,_app_render_legacy_platforms,_preprocess,_validate_user_provided_part_names
     :undoc-members:

--- a/tests/integration/services/invalid_project_files/testcraft-bad-part-name.error
+++ b/tests/integration/services/invalid_project_files/testcraft-bad-part-name.error
@@ -1,0 +1,1 @@
+Invalid part names: illegal/part/name

--- a/tests/integration/services/invalid_project_files/testcraft-bad-part-name.yaml
+++ b/tests/integration/services/invalid_project_files/testcraft-bad-part-name.yaml
@@ -1,0 +1,15 @@
+name: testy-mctestface
+version: 0.1
+summary: A test project.
+description: |
+  A project with an invalid part name.
+platforms:
+  all:
+    build-on: [amd64, arm64, armhf, i386, ppc64el, riscv64, s390x]
+    build-for: [all]
+
+base: ubuntu@25.10
+
+parts:
+  illegal/part/name:
+    plugin: nil

--- a/tests/integration/services/invalid_project_files/testcraft-bad-part-name.yaml
+++ b/tests/integration/services/invalid_project_files/testcraft-bad-part-name.yaml
@@ -8,7 +8,7 @@ platforms:
     build-on: [amd64, arm64, armhf, i386, ppc64el, riscv64, s390x]
     build-for: [all]
 
-base: ubuntu@25.10
+base: ubuntu@26.04
 
 parts:
   illegal/part/name:

--- a/tests/integration/services/project_files/testcraft-full.out
+++ b/tests/integration/services/project_files/testcraft-full.out
@@ -65,3 +65,5 @@ parts:
         owner: 456
         group: 456
         mode: "666"
+  legacy/part/name:
+    plugin: nil

--- a/tests/integration/services/project_files/testcraft-full.yaml
+++ b/tests/integration/services/project_files/testcraft-full.yaml
@@ -65,3 +65,5 @@ parts:
         owner: 456
         group: 456
         mode: "666"
+  legacy/part/name:  # This part name should be allowed on Ubuntu 24.04 and older.
+    plugin: nil

--- a/tests/integration/services/test_project.py
+++ b/tests/integration/services/test_project.py
@@ -15,13 +15,18 @@
 
 import pathlib
 import shutil
+import textwrap
+from typing import Any
 
 import craft_platforms
 import pytest
+from craft_application.errors import CraftValidationError
 from craft_application.services.project import ProjectService
 from craft_application.util import yaml
+from typing_extensions import override
 
 PROJECT_FILES_PATH = pathlib.Path(__file__).parent / "project_files"
+INVALID_PROJECT_FILES_PATH = pathlib.Path(__file__).parent / "invalid_project_files"
 
 
 @pytest.fixture
@@ -113,3 +118,79 @@ def test_load_grammar_project(
         expected = yaml.safe_yaml_load(f)
 
     assert project.marshal() == expected
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(path, id=path.name)
+        for path in INVALID_PROJECT_FILES_PATH.glob("testcraft-*.yaml")
+    ]
+)
+def invalid_project_file(
+    project_path: pathlib.Path, app_metadata, request: pytest.FixtureRequest
+):
+    project_file = project_path / f"{app_metadata.name}.yaml"
+    shutil.copyfile(request.param, project_file)
+    return request.param
+
+
+def test_load_invalid_project(
+    service: ProjectService, invalid_project_file: pathlib.Path
+):
+    error_file = invalid_project_file.with_suffix(".error")
+    error_regex = error_file.read_text().rstrip()
+
+    service.configure(platform=None, build_for=None)
+
+    with pytest.raises(CraftValidationError, match=error_regex):
+        service.get()
+
+
+class PartInjectingProjectService(ProjectService):
+    """A ProjectService that injects an app-only part name into the project."""
+
+    @override
+    @staticmethod
+    def _app_preprocess_project(
+        project: dict[str, Any],
+        *,
+        build_on: str,
+        build_for: str,
+        platform: str,
+    ) -> None:
+        project.setdefault("parts", {})["mycraft/some-part"] = {"plugin": "nil"}
+
+
+@pytest.mark.parametrize("base", ["ubuntu@24.04", "ubuntu@26.04", "unknown@base"])
+def test_inject_app_only_part(
+    tmp_path, app_metadata, fake_services, in_project_path: pathlib.Path, base: str
+):
+    """Test that the app can add a part that contains a name that a user cannot."""
+    project_path = tmp_path / f"{app_metadata.name}.yaml"
+    project_path.write_text(
+        textwrap.dedent(
+            f"""\
+            name: my-project
+            adopt-info: my-part
+            platforms:
+              riscv64:
+            base: {base}
+            parts:
+              my-part:
+                plugin: nil
+            """
+        )
+    )
+
+    service = PartInjectingProjectService(
+        app_metadata,
+        fake_services,
+        project_dir=tmp_path,
+    )
+    service.setup()
+    service.configure(platform=None, build_for=None)
+
+    project = service.get()
+
+    assert "my-part" in project.parts
+    assert "mycraft/some-part" in project.parts

--- a/tests/integration/services/test_project.py
+++ b/tests/integration/services/test_project.py
@@ -149,8 +149,8 @@ def test_load_invalid_project(
 class PartInjectingProjectService(ProjectService):
     """A ProjectService that injects an app-only part name into the project."""
 
-    @override
     @staticmethod
+    @override
     def _app_preprocess_project(
         project: dict[str, Any],
         *,

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -26,8 +26,9 @@ import craft_platforms
 import freezegun
 import pytest
 import pytest_mock
-from craft_application import errors, models, util
+from craft_application import _const, errors, models, util
 from craft_application.application import AppMetadata
+from craft_application.errors import CraftValidationError
 from craft_application.services.project import ProjectService
 from craft_application.services.service_factory import ServiceFactory
 from craft_parts import ProjectVar, ProjectVarInfo
@@ -1117,4 +1118,79 @@ def test_render_for_validates_pro_project(
     if expect_called:
         mock_validate.assert_called_once_with(pro_services, project)
     else:
-        mock_validate.assert_not_called()
+        mock_validate.asserot_called()
+
+
+SAMPLE_VALID_PART_NAMES = ["my-part", "yourpart", "our_part", "a part name with spaces"]
+SAMPLE_INVALID_USER_PART_NAMES = ["a/part/name/with/slashes"]
+SAMPLE_STRICT_PART_NAME_BASES = [
+    "ubuntu@25.10",
+    "ubuntu@26.04",
+    "ubuntu@26.10",
+    "debian@unstable",
+    "unknown-base@forever",
+]
+
+
+@pytest.mark.parametrize("base", _const.BASES_ALLOW_SLASH_IN_PART_NAME)
+@pytest.mark.parametrize(
+    "part_name", [*SAMPLE_VALID_PART_NAMES, *SAMPLE_INVALID_USER_PART_NAMES]
+)
+def test_part_names_on_legacy_base(
+    real_project_service: ProjectService, base: str | None, part_name: str
+):
+    """Test that bases such as Ubuntu 24.04 still allow a / in a part name."""
+
+    project_dict: dict[str, Any] = {
+        "base": base,
+        "parts": {part_name: {"plugin": "nil"}},
+    }
+
+    real_project_service._validate_user_provided_part_names(project_dict)
+
+    # And we expect the same with only a build-base
+    project_dict["build-base"] = project_dict.pop("base")
+
+    real_project_service._validate_user_provided_part_names(project_dict)
+
+
+@pytest.mark.parametrize("base", SAMPLE_STRICT_PART_NAME_BASES)
+@pytest.mark.parametrize("part_name", SAMPLE_VALID_PART_NAMES)
+def test_valid_part_names_on_future_base(
+    real_project_service: ProjectService, base: str | None, part_name: str
+):
+    """Test that future bases disallow the / character in user-provided part names."""
+
+    project_dict: dict[str, Any] = {
+        "base": base,
+        "parts": {part_name: {"plugin": "nil"}},
+    }
+
+    real_project_service._validate_user_provided_part_names(project_dict)
+
+    # And we expect the same with only a build-base
+    project_dict["build-base"] = project_dict.pop("base")
+
+    real_project_service._validate_user_provided_part_names(project_dict)
+
+
+@pytest.mark.parametrize("base", SAMPLE_STRICT_PART_NAME_BASES)
+@pytest.mark.parametrize("part_name", SAMPLE_INVALID_USER_PART_NAMES)
+def test_invalid_part_names_on_future_base(
+    real_project_service: ProjectService, base: str | None, part_name: str
+):
+    """Test that future bases disallow the / character in user-provided part names."""
+
+    project_dict: dict[str, Any] = {
+        "base": base,
+        "parts": {part_name: {"plugin": "nil"}},
+    }
+
+    with pytest.raises(CraftValidationError, match=re.escape(part_name)):
+        real_project_service._validate_user_provided_part_names(project_dict)
+
+    # And we expect the same with only a build-base
+    project_dict["build-base"] = project_dict.pop("base")
+
+    with pytest.raises(CraftValidationError, match=re.escape(part_name)):
+        real_project_service._validate_user_provided_part_names(project_dict)

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -1118,7 +1118,7 @@ def test_render_for_validates_pro_project(
     if expect_called:
         mock_validate.assert_called_once_with(pro_services, project)
     else:
-        mock_validate.asserot_called()
+        mock_validate.assert_not_called()
 
 
 SAMPLE_VALID_PART_NAMES = ["my-part", "yourpart", "our_part", "a part name with spaces"]

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -1124,7 +1124,6 @@ def test_render_for_validates_pro_project(
 SAMPLE_VALID_PART_NAMES = ["my-part", "yourpart", "our_part", "a part name with spaces"]
 SAMPLE_INVALID_USER_PART_NAMES = ["a/part/name/with/slashes"]
 SAMPLE_STRICT_PART_NAME_BASES = [
-    "ubuntu@25.10",
     "ubuntu@26.04",
     "ubuntu@26.10",
     "debian@unstable",


### PR DESCRIPTION
Includes an exception for current stable bases.

CRAFT-4880

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
