### PR TITLE
docs: fix changelog entry for 6.4.0

### DIFF
--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -21,7 +21,7 @@ Changelog
 Services
 ========
 
-- In a user-written part, upcoming base names can no longer contain forward slashes
+- In a user-written part, part names can no longer contain forward slashes
   (/) for bases starting with Ubuntu 26.04.
 - The FetchService now supports registering callbacks to provide secrets during fetch-service
   session creation.

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -21,8 +21,8 @@ Changelog
 Services
 ========
 
-- In a user-written part, part names can no longer contain forward slashes
-  (/) for bases starting with Ubuntu 26.04.
+- Starting with the Ubuntu 26.04 LTS base, a user-written part name can no longer
+  contain a forward slash (/).
 - The FetchService now supports registering callbacks to provide secrets during fetch-service
   session creation.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Follow up to #1067.

I think the changelog should be expressing this:


**valid:**

```yaml
base: ubuntu@24.04
parts:
  my/part:
    plugin: nil
```

**invalid:**

```yaml
base: ubuntu@26.04
parts:
  my/part:
    plugin: nil
```