### PR TITLE
chore!: remove Application.run_managed 

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -21,7 +21,6 @@ import importlib
 import os
 import pathlib
 import signal
-import subprocess
 import sys
 import traceback
 import warnings
@@ -33,7 +32,6 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, cast, final
 import annotated_types
 import craft_cli
 import craft_platforms
-import craft_providers
 from platformdirs import user_cache_path
 
 from craft_application import _config, commands, errors, models, util
@@ -417,76 +415,25 @@ class Application:
         """Shortcut to tell whether we're running in managed mode."""
         return self.services.get_class("provider").is_managed()
 
-    def run_managed(self, platform: str | None, build_for: str | None) -> None:
-        """Run the application in a managed instance."""
-        build_planner = self.services.get("build_plan")
-        if platform:
-            build_planner.set_platforms(platform)
-        if build_for:
-            build_planner.set_build_fors(build_for)
-        plan = build_planner.plan()
-
-        if not plan:
-            raise errors.EmptyBuildPlanError
-
+    def _run_managed(self, platform: str | None, build_for: str | None) -> None:
+        """Run the each build in the build plan in managed mode."""
         if self._enable_fetch_service:
             self.services.get("fetch").set_policy(self._fetch_service_policy)
 
-        extra_args: dict[str, Any] = {}
+        build_plan_service = self.services.get("build_plan")
+        if platform:
+            build_plan_service.set_platforms(platform)
+        if build_for:
+            build_plan_service.set_build_fors(build_for)
+        plan = build_plan_service.plan()
+        if not plan:
+            raise errors.EmptyBuildPlanError
+
+        provider = self.services.get("provider")
         for build_info in plan:
-            env = {
-                "CRAFT_PLATFORM": build_info.platform,
-                "CRAFT_VERBOSITY_LEVEL": craft_cli.emit.get_mode().name,
-            }
-
-            extra_args["env"] = env
-
-            craft_cli.emit.debug(
-                f"Running {self.app.name}:{build_info.platform} in {build_info.build_for} instance..."
+            provider.run_managed(
+                build_info, enable_fetch_service=bool(self._fetch_service_policy)
             )
-            instance_path = pathlib.PosixPath("/root/project")
-            active_fetch_service = self.services.get("fetch").is_active(
-                enable_command_line=self._enable_fetch_service
-            )
-
-            with self.services.provider.instance(
-                build_info,
-                work_dir=self._work_dir,
-                clean_existing=self._enable_fetch_service,
-                use_base_instance=not active_fetch_service,
-            ) as instance:
-                if self._enable_fetch_service:
-                    fetch_env = self.services.fetch.create_session(instance)
-                    env.update(fetch_env)
-
-                if self.app.enable_pro_support:
-                    self.services.provider.configure_instance_with_pro(instance)
-
-                session_env = self.services.get("proxy").configure_instance(instance)
-                env.update(session_env)
-
-                cmd = [self.app.name, *sys.argv[1:]]
-                craft_cli.emit.debug(
-                    f"Executing {cmd} in instance location {instance_path} with {extra_args}."
-                )
-                try:
-                    with craft_cli.emit.pause():
-                        instance.execute_run(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                            cmd,
-                            cwd=instance_path,
-                            check=True,
-                            **extra_args,
-                        )
-                except subprocess.CalledProcessError as exc:
-                    raise craft_providers.ProviderError(
-                        f"Failed to execute {self.app.name} in instance."
-                    ) from exc
-                finally:
-                    if self._enable_fetch_service:
-                        self.services.fetch.teardown_session()
-
-        if self._enable_fetch_service:
-            self.services.fetch.shutdown(force=True)
 
     def configure(self, global_args: dict[str, Any]) -> None:
         """Configure the application using any global arguments."""
@@ -670,7 +617,7 @@ class Application:
             return_code = dispatcher.run() or os.EX_OK
         elif not self.is_managed():
             # command runs in inner instance, but this is the outer instance
-            self.run_managed(platform, build_for)
+            self._run_managed(platform, build_for)
             return_code = os.EX_OK
         else:
             # command runs in inner instance

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -664,7 +664,7 @@ class Application:
         self._configure_services(provider_name)
 
         return_code = 1  # General error
-        if not command.run_managed(parsed_args):
+        if not command.runs_managed(parsed_args):
             # command runs in the outer instance
             craft_cli.emit.debug(f"Running {self.app.name} {command.name} on host")
             return_code = dispatcher.run() or os.EX_OK

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -416,7 +416,7 @@ class Application:
         return self.services.get_class("provider").is_managed()
 
     def _run_managed(self, platform: str | None, build_for: str | None) -> None:
-        """Run the each build in the build plan in managed mode."""
+        """Run each build in the build plan in managed mode."""
         if self._enable_fetch_service:
             self.services.get("fetch").set_policy(self._fetch_service_policy)
 

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -91,7 +91,7 @@ class AppCommand(BaseCommand):
         """
         return self.always_load_project
 
-    def run_managed(
+    def runs_managed(
         self,
         parsed_args: argparse.Namespace,  # noqa: ARG002 (the unused argument is for subclasses)
     ) -> bool:
@@ -101,6 +101,21 @@ class AppCommand(BaseCommand):
         including by inspecting the arguments in ``parsed_args``.
         """
         return False
+
+    def run_managed(
+        self,
+        parsed_args: argparse.Namespace,
+    ) -> bool:
+        """Whether this command should run in managed mode.
+
+        Deprecated in favor of runs_managed.
+        """
+        warnings.warn(
+            "AppCommand.run_managed is deprecated. Use 'runs_managed' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.runs_managed(parsed_args)
 
     def provider_name(
         self,
@@ -128,7 +143,7 @@ class AppCommand(BaseCommand):
 
         :deprecated: and unused.
         """
-        if not self.run_managed(parsed_args):
+        if not self.runs_managed(parsed_args):
             raise RuntimeError("Unmanaged commands should not be run in managed mode.")
         cmd_name = self._app.name
         verbosity = emit.get_mode().name.lower()

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -19,6 +19,18 @@ Changelog
 7.0.0 (unreleased)
 ------------------
 
+Application
+===========
+
+- ``Application.run_managed`` is now a private function,
+  :py:meth:`Application._run_managed <craft_application.Application._run_managed>`.
+  Apps that need to run a managed instance should use
+  :py:meth:`ProviderService.run_managed
+  <craft_application.services.ProviderService.run_managed>` instead.
+- :py:meth:`Application._run_managed <craft_application.Application._run_managed>`
+  now calls :py:meth:`ProviderService.run_managed
+  <craft_application.services.ProviderService.run_managed>`.
+
 Commands
 ========
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,19 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+
+7.0.0 (unreleased)
+------------------
+
+Commands
+========
+
+- :py:meth:`~craft_application.commands.AppCommand.run_managed` is deprecated
+  in favor of :py:meth:`~craft_application.commands.AppCommand.runs_managed`.
+
+For a complete list of commits, check out the `7.0.0`_ release on GitHub.
+
+
 6.4.0 (2026-04-23)
 ------------------
 
@@ -1303,3 +1316,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _6.3.0: https://github.com/canonical/craft-application/releases/tag/6.3.0
 .. _6.3.1: https://github.com/canonical/craft-application/releases/tag/6.3.1
 .. _6.4.0: https://github.com/canonical/craft-application/releases/tag/6.4.0
+.. _7.0.0: https://github.com/canonical/craft-application/releases/tag/7.0.0

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from unittest import mock
 
 import pytest
@@ -27,14 +28,14 @@ from typing_extensions import override
 @pytest.fixture
 def fake_command(app_metadata, fake_services):
     class FakeCommand(base.AppCommand):
-        _run_managed = True
+        _runs_managed = True
         name = "fake"
         help_msg = "Help!"
         overview = "It's an overview."
 
         @override
-        def run_managed(self, parsed_args: argparse.Namespace) -> bool:
-            return self._run_managed
+        def runs_managed(self, parsed_args: argparse.Namespace) -> bool:
+            return self._runs_managed
 
     return FakeCommand(
         {
@@ -45,7 +46,7 @@ def fake_command(app_metadata, fake_services):
 
 
 def test_get_managed_cmd_unmanaged(fake_command):
-    fake_command._run_managed = False
+    fake_command._runs_managed = False
 
     with pytest.raises(RuntimeError):
         fake_command.get_managed_cmd(argparse.Namespace())
@@ -62,6 +63,17 @@ def test_get_managed_cmd(fake_command, verbosity, app_metadata):
         f"--verbosity={verbosity.name.lower()}",
         "fake",
     ]
+
+
+def test_run_managed_deprecated(fake_command):
+    expected = re.escape(
+        "AppCommand.run_managed is deprecated. Use 'runs_managed' instead."
+    )
+
+    with pytest.deprecated_call(match=expected):
+        result = fake_command.run_managed(argparse.Namespace())
+
+    assert result is fake_command.runs_managed(argparse.Namespace())
 
 
 def test_without_config(emitter):

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -99,13 +99,13 @@ def get_fake_command_class(parent_cls, managed):
     """Create a fully described fake command based on a partial class."""
 
     class FakeCommand(parent_cls):
-        _run_managed = managed
+        _runs_managed = managed
         name = "fake"
         help_msg = "help"
         overview = "overview"
 
-        def run_managed(self, parsed_args: argparse.Namespace) -> bool:
-            return self._run_managed
+        def runs_managed(self, parsed_args: argparse.Namespace) -> bool:
+            return self._runs_managed
 
     return FakeCommand
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -278,10 +278,20 @@ def test_log_path(monkeypatch, app, provider_managed, expected):
     assert actual == expected
 
 
+@pytest.mark.parametrize(
+    ("fetch_service_policy", "enable_fetch_service"),
+    [
+        ("strict", True),
+        (None, False),
+    ],
+)
 @pytest.mark.usefixtures("platform_independent_project")
-def test_run_managed_success(app, fake_host_architecture):
+def test_run_managed_success(
+    app, fake_host_architecture, fetch_service_policy, enable_fetch_service
+):
     mock_provider = mock.MagicMock(spec_set=services.ProviderService)
     app.services._services["provider"] = mock_provider
+    app._fetch_service_policy = fetch_service_policy
 
     app._run_managed("platform-independent", None)
 
@@ -292,7 +302,7 @@ def test_run_managed_success(app, fake_host_architecture):
             build_for="all",
             build_base=mock.ANY,
         ),
-        enable_fetch_service=True,
+        enable_fetch_service=enable_fetch_service,
     )
 
 
@@ -326,9 +336,17 @@ def test_configure_services_pro_services(
     assert calls["provider"]["pro_services"] is pro_services
 
 
-def test_run_managed_multiple(mocker, app):
+@pytest.mark.parametrize(
+    ("fetch_service_policy", "enable_fetch_service"),
+    [
+        ("strict", True),
+        (None, False),
+    ],
+)
+def test_run_managed_multiple(mocker, app, fetch_service_policy, enable_fetch_service):
     mock_provider = mock.MagicMock(spec_set=services.ProviderService)
     app.services._services["provider"] = mock_provider
+    app._fetch_service_policy = fetch_service_policy
     fake_builds = [
         craft_platforms.BuildInfo(
             platform="platform-a",
@@ -352,8 +370,8 @@ def test_run_managed_multiple(mocker, app):
     assert mock_provider.run_managed.call_count == 2
     mock_provider.run_managed.assert_has_calls(
         [
-            mock.call(fake_builds[0], enable_fetch_service=True),
-            mock.call(fake_builds[1], enable_fetch_service=True),
+            mock.call(fake_builds[0], enable_fetch_service=enable_fetch_service),
+            mock.call(fake_builds[1], enable_fetch_service=enable_fetch_service),
         ]
     )
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -21,7 +21,6 @@ import importlib.metadata
 import logging
 import pathlib
 import re
-import subprocess
 import sys
 from textwrap import dedent
 from unittest import mock
@@ -53,7 +52,6 @@ from craft_application.util import (
 )
 from craft_cli import CraftError, emit
 from craft_parts.plugins.plugins import PluginType
-from craft_providers import lxd
 
 from tests.conftest import FakeApplication
 
@@ -281,53 +279,32 @@ def test_log_path(monkeypatch, app, provider_managed, expected):
 
 
 @pytest.mark.usefixtures("platform_independent_project")
-def test_run_managed_success(mocker, app, fake_host_architecture):
+def test_run_managed_success(app, fake_host_architecture):
     mock_provider = mock.MagicMock(spec_set=services.ProviderService)
     app.services._services["provider"] = mock_provider
-    mock_pause = mocker.spy(craft_cli.emit, "pause")
 
-    app.run_managed("platform-independent", None)
+    app._run_managed("platform-independent", None)
 
-    mock_provider.instance.assert_called_once_with(
+    mock_provider.run_managed.assert_called_once_with(
         craft_platforms.BuildInfo(
             platform="platform-independent",
             build_on=fake_host_architecture,
             build_for="all",
             build_base=mock.ANY,
         ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
+        enable_fetch_service=True,
     )
-    mock_pause.assert_called_once_with()
 
 
-def test_run_managed_failure(app, fake_project):
+def test_run_managed_failure(app):
     mock_provider = mock.MagicMock(spec_set=services.ProviderService)
-    instance = mock_provider.instance.return_value.__enter__.return_value
-    instance.execute_run.side_effect = subprocess.CalledProcessError(1, [])
+    mock_provider.run_managed.side_effect = craft_providers.ProviderError(
+        "Failed to run testcraft in instance"
+    )
     app.services._services["provider"] = mock_provider
-    app.project = fake_project
 
-    with pytest.raises(craft_providers.ProviderError) as exc_info:
-        app.run_managed(None, get_host_architecture())
-
-    assert exc_info.value.brief == "Failed to execute testcraft in instance."
-
-
-@pytest.mark.parametrize("app_metadata", [{"enable_pro_support": True}], indirect=True)
-def test_run_managed_configure_pro(mocker, app, fake_project):
-    """Ensure that configure_instance_with_pro is called during run_managed."""
-    mock_provider = mocker.MagicMock(spec_set=services.ProviderService)
-    app.services.provider = mock_provider
-    mock_instance = mocker.MagicMock(spec=lxd.LXDInstance)
-    mock_provider.instance.return_value.__enter__.return_value = mock_instance
-    app.project = fake_project
-    app._pro_services = ProServices(["esm-apps"])
-
-    app.run_managed(None, get_host_architecture())
-
-    mock_provider.configure_instance_with_pro.assert_called_once_with(mock_instance)
+    with pytest.raises(craft_providers.ProviderError):
+        app._run_managed(None, get_host_architecture())
 
 
 @pytest.mark.parametrize(
@@ -349,25 +326,36 @@ def test_configure_services_pro_services(
     assert calls["provider"]["pro_services"] is pro_services
 
 
-def test_run_managed_multiple(app, fake_host_architecture):
+def test_run_managed_multiple(mocker, app):
     mock_provider = mock.MagicMock(spec_set=services.ProviderService)
     app.services._services["provider"] = mock_provider
-
-    app.run_managed(None, None)
-
-    mock_provider.instance.assert_called_with(
+    fake_builds = [
         craft_platforms.BuildInfo(
-            platform=mock.ANY,
-            build_on=fake_host_architecture,
-            build_for=mock.ANY,
-            build_base=mock.ANY,
+            platform="platform-a",
+            build_on=craft_platforms.DebianArchitecture.AMD64,
+            build_for=craft_platforms.DebianArchitecture.AMD64,
+            build_base=craft_platforms.DistroBase("ubuntu", "26.04"),
         ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
+        craft_platforms.BuildInfo(
+            platform="platform-b",
+            build_on=craft_platforms.DebianArchitecture.AMD64,
+            build_for=craft_platforms.DebianArchitecture.RISCV64,
+            build_base=craft_platforms.DistroBase("ubuntu", "26.04"),
+        ),
+    ]
+    mocker.patch.object(
+        app.services.get("build_plan"), "plan", return_value=fake_builds
     )
 
-    assert len(mock_provider.instance.mock_calls) > 1
+    app._run_managed(None, None)
+
+    assert mock_provider.run_managed.call_count == 2
+    mock_provider.run_managed.assert_has_calls(
+        [
+            mock.call(fake_builds[0], enable_fetch_service=True),
+            mock.call(fake_builds[1], enable_fetch_service=True),
+        ]
+    )
 
 
 @pytest.mark.parametrize("build_for", craft_platforms.DebianArchitecture)
@@ -376,22 +364,20 @@ def test_run_managed_specified_arch(app, fake_host_architecture, build_for):
     app.services._services["provider"] = mock_provider
 
     try:
-        app.run_managed(None, build_for)
+        app._run_managed(None, build_for)
     except errors.EmptyBuildPlanError:
         pytest.skip(
             reason=f"build-for {build_for} has no build-on {fake_host_architecture}"
         )
 
-    mock_provider.instance.assert_called_with(
+    mock_provider.run_managed.assert_called_with(
         craft_platforms.BuildInfo(
             platform=mock.ANY,
             build_on=fake_host_architecture,
             build_for=build_for,
             build_base=mock.ANY,
         ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
+        enable_fetch_service=True,
     )
 
 
@@ -400,22 +386,20 @@ def test_run_managed_specified_platform(app, fake_platform, fake_host_architectu
     app.services._services["provider"] = mock_provider
 
     try:
-        app.run_managed(fake_platform, None)
+        app._run_managed(fake_platform, None)
     except errors.EmptyBuildPlanError:
         pytest.skip(
             reason=f"Platform {fake_platform} has no builds on {fake_host_architecture}"
         )
 
-    mock_provider.instance.assert_called_once_with(
+    mock_provider.run_managed.assert_called_once_with(
         craft_platforms.BuildInfo(
             platform=fake_platform,
             build_on=fake_host_architecture,
             build_for=mock.ANY,
             build_base=mock.ANY,
         ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
+        enable_fetch_service=True,
     )
 
 
@@ -424,7 +408,7 @@ def test_run_managed_empty_plan(mocker, app):
     mocker.patch.object(build_plan_service, "plan", return_value=[])
 
     with pytest.raises(errors.EmptyBuildPlanError):
-        app.run_managed(None, None)
+        app._run_managed(None, None)
 
 
 @pytest.mark.parametrize(
@@ -732,7 +716,9 @@ def test_run_success_managed_inside_managed(
     mocker.patch.object(
         mock_dispatcher, "parsed_args", return_value={"platform": "foo"}
     )
-    app.run_managed = mock.Mock()
+    mock_provider_run_managed = mocker.patch.object(
+        app.services.get("provider"), "run_managed"
+    )
     mock_dispatcher.run.return_value = return_code
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
@@ -740,7 +726,7 @@ def test_run_success_managed_inside_managed(
 
     check.equal(app.run(), return_code or 0)
     with check:
-        app.run_managed.assert_not_called()
+        mock_provider_run_managed.assert_not_called()
     with check:
         mock_dispatcher.run.assert_called_once_with()
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

This PR cleans up cruft leftover from previous refactors related to the overloaded term `run_managed`.

Commit 1:
- Adds a new property, `AppCommand.runs_managed`.
- Deprecates `AppCommand.run_managed` in favor of the new property.

Commit 2:
- Removes the public `Application.run_managed()` function.
- Adds a new private function, `Application._run_managed()`, that now calls `ProviderService.run_managed()`.



Fixes #1062 
(CRAFT-5150)