### PR TITLE
chore!: remove managed commands

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -21,19 +21,17 @@ import importlib
 import os
 import pathlib
 import signal
-import subprocess
 import sys
 import traceback
 import warnings
 from dataclasses import dataclass, field
 from functools import cached_property
 from importlib import metadata
-from typing import TYPE_CHECKING, Annotated, Any, Literal, cast, final
+from typing import TYPE_CHECKING, Annotated, Any, cast, final
 
 import annotated_types
 import craft_cli
 import craft_platforms
-import craft_providers
 from platformdirs import user_cache_path
 
 from craft_application import _config, commands, errors, models, util
@@ -195,11 +193,6 @@ class Application:
             self._work_dir = pathlib.Path("/root")
         else:
             self._work_dir = pathlib.Path.cwd()
-
-        # Whether the command execution should use the fetch-service
-        self._enable_fetch_service = False
-        # The kind of sessions that the fetch-service service should create
-        self._fetch_service_policy: Literal["strict", "permissive"] = "strict"
 
     @final
     def _load_plugins(self) -> None:
@@ -417,77 +410,6 @@ class Application:
         """Shortcut to tell whether we're running in managed mode."""
         return self.services.get_class("provider").is_managed()
 
-    def run_managed(self, platform: str | None, build_for: str | None) -> None:
-        """Run the application in a managed instance."""
-        build_planner = self.services.get("build_plan")
-        if platform:
-            build_planner.set_platforms(platform)
-        if build_for:
-            build_planner.set_build_fors(build_for)
-        plan = build_planner.plan()
-
-        if not plan:
-            raise errors.EmptyBuildPlanError
-
-        if self._enable_fetch_service:
-            self.services.get("fetch").set_policy(self._fetch_service_policy)
-
-        extra_args: dict[str, Any] = {}
-        for build_info in plan:
-            env = {
-                "CRAFT_PLATFORM": build_info.platform,
-                "CRAFT_VERBOSITY_LEVEL": craft_cli.emit.get_mode().name,
-            }
-
-            extra_args["env"] = env
-
-            craft_cli.emit.debug(
-                f"Running {self.app.name}:{build_info.platform} in {build_info.build_for} instance..."
-            )
-            instance_path = pathlib.PosixPath("/root/project")
-            active_fetch_service = self.services.get("fetch").is_active(
-                enable_command_line=self._enable_fetch_service
-            )
-
-            with self.services.provider.instance(
-                build_info,
-                work_dir=self._work_dir,
-                clean_existing=self._enable_fetch_service,
-                use_base_instance=not active_fetch_service,
-            ) as instance:
-                if self._enable_fetch_service:
-                    fetch_env = self.services.fetch.create_session(instance)
-                    env.update(fetch_env)
-
-                if self.app.enable_pro_support:
-                    self.services.provider.configure_instance_with_pro(instance)
-
-                session_env = self.services.get("proxy").configure_instance(instance)
-                env.update(session_env)
-
-                cmd = [self.app.name, *sys.argv[1:]]
-                craft_cli.emit.debug(
-                    f"Executing {cmd} in instance location {instance_path} with {extra_args}."
-                )
-                try:
-                    with craft_cli.emit.pause():
-                        instance.execute_run(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                            cmd,
-                            cwd=instance_path,
-                            check=True,
-                            **extra_args,
-                        )
-                except subprocess.CalledProcessError as exc:
-                    raise craft_providers.ProviderError(
-                        f"Failed to execute {self.app.name} in instance."
-                    ) from exc
-                finally:
-                    if self._enable_fetch_service:
-                        self.services.fetch.teardown_session()
-
-        if self._enable_fetch_service:
-            self.services.fetch.shutdown(force=True)
-
     def configure(self, global_args: dict[str, Any]) -> None:
         """Configure the application using any global arguments."""
 
@@ -611,11 +533,6 @@ class Application:
                     resolution="Ensure the path entered is correct.",
                 )
 
-        fetch_service_policy: str | None = getattr(args, "fetch_service_policy", None)
-        if fetch_service_policy:
-            self._enable_fetch_service = True
-            self._fetch_service_policy = fetch_service_policy  # type: ignore[assignment]
-
     def get_arg_or_config(self, parsed_args: argparse.Namespace, item: str) -> Any:  # noqa: ANN401
         """Get a configuration option that could be overridden by a command argument.
 
@@ -663,20 +580,8 @@ class Application:
         provider_name = command.provider_name(parsed_args)
         self._configure_services(provider_name)
 
-        return_code = 1  # General error
-        if not command.run_managed(parsed_args):
-            # command runs in the outer instance
-            craft_cli.emit.debug(f"Running {self.app.name} {command.name} on host")
-            return_code = dispatcher.run() or os.EX_OK
-        elif not self.is_managed():
-            # command runs in inner instance, but this is the outer instance
-            self.run_managed(platform, build_for)
-            return_code = os.EX_OK
-        else:
-            # command runs in inner instance
-            return_code = dispatcher.run() or 0
-
-        return return_code
+        craft_cli.emit.debug(f"Running '{self.app.name} {command.name}'.")
+        return dispatcher.run() or os.EX_OK
 
     def run(self) -> int:
         """Bootstrap and run the application."""

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -91,17 +91,6 @@ class AppCommand(BaseCommand):
         """
         return self.always_load_project
 
-    def run_managed(
-        self,
-        parsed_args: argparse.Namespace,  # noqa: ARG002 (the unused argument is for subclasses)
-    ) -> bool:
-        """Whether this command should run in managed mode.
-
-        Returns ``False`` by default. Subclasses can override this method to change this,
-        including by inspecting the arguments in ``parsed_args``.
-        """
-        return False
-
     def provider_name(
         self,
         parsed_args: argparse.Namespace,  # noqa: ARG002 (the unused argument is for subclasses)
@@ -112,27 +101,6 @@ class AppCommand(BaseCommand):
         including by inspecting the arguments in ``parsed_args``.
         """
         return None
-
-    def get_managed_cmd(
-        self,
-        parsed_args: argparse.Namespace,  # - Used by subclasses
-    ) -> list[str]:
-        """Get the command to run in managed mode.
-
-        :param parsed_args: The parsed arguments used.
-        :returns: A list of strings ready to be passed into a craft-providers executor.
-        :raises: ``RuntimeError`` if this command is not supposed to run managed.
-
-        Commands that have additional parameters to pass in managed mode should
-        override this method to include those parameters.
-
-        :deprecated: and unused.
-        """
-        if not self.run_managed(parsed_args):
-            raise RuntimeError("Unmanaged commands should not be run in managed mode.")
-        cmd_name = self._app.name
-        verbosity = emit.get_mode().name.lower()
-        return [cmd_name, f"--verbosity={verbosity}", self.name]
 
     @property
     def _project(self) -> Project:

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,26 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+
+7.0.0 (unreleased)
+------------------
+
+Application
+===========
+
+- ``Application._enable_fetch_service`` and ``Application._fetch_service_policy``
+   are removed.
+
+Commands
+========
+
+- ``AppCommand.run_managed()``, ``AppCommand.get_managed_cmd()``, and
+  ``Application.run_managed()`` are removed. Commands that need to run in a
+  managed instance should call :py:meth:`ProviderService.run_managed
+  <craft_application.services.ProviderService.run_managed>`.
+
+For a complete list of commits, check out the `7.0.0`_ release on GitHub.
+
 6.4.0 (2026-04-23)
 ------------------
 
@@ -1303,3 +1323,4 @@ For a complete list of commits, check out the `2.7.0`_ release on GitHub.
 .. _6.3.0: https://github.com/canonical/craft-application/releases/tag/6.3.0
 .. _6.3.1: https://github.com/canonical/craft-application/releases/tag/6.3.1
 .. _6.4.0: https://github.com/canonical/craft-application/releases/tag/6.4.0
+.. _7.0.0: https://github.com/canonical/craft-application/releases/tag/7.0.0

--- a/docs/reference/commands/index.rst
+++ b/docs/reference/commands/index.rst
@@ -39,8 +39,6 @@ Craft Application's commands.
 
     .. autoattribute:: AppCommand.always_load_project
 
-    .. automethod:: AppCommand.run_managed
-
     .. automethod:: AppCommand.provider_name
 
     **Execution**

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -20,21 +20,14 @@ from unittest import mock
 
 import pytest
 from craft_application.commands import base
-from craft_cli import EmitterMode, emit
-from typing_extensions import override
 
 
 @pytest.fixture
 def fake_command(app_metadata, fake_services):
     class FakeCommand(base.AppCommand):
-        _run_managed = True
         name = "fake"
         help_msg = "Help!"
         overview = "It's an overview."
-
-        @override
-        def run_managed(self, parsed_args: argparse.Namespace) -> bool:
-            return self._run_managed
 
     return FakeCommand(
         {
@@ -42,26 +35,6 @@ def fake_command(app_metadata, fake_services):
             "services": fake_services,
         }
     )
-
-
-def test_get_managed_cmd_unmanaged(fake_command):
-    fake_command._run_managed = False
-
-    with pytest.raises(RuntimeError):
-        fake_command.get_managed_cmd(argparse.Namespace())
-
-
-@pytest.mark.parametrize("verbosity", list(EmitterMode))
-def test_get_managed_cmd(fake_command, verbosity, app_metadata):
-    emit.set_mode(verbosity)
-
-    actual = fake_command.get_managed_cmd(argparse.Namespace())
-
-    assert actual == [
-        app_metadata.name,
-        f"--verbosity={verbosity.name.lower()}",
-        "fake",
-    ]
 
 
 def test_without_config(emitter):

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -95,17 +95,13 @@ NON_CLEAN_COMMANDS = (*MANAGED_LIFECYCLE_COMMANDS, PackCommand)
 # fmt: on
 
 
-def get_fake_command_class(parent_cls, managed):
+def get_fake_command_class(parent_cls):
     """Create a fully described fake command based on a partial class."""
 
     class FakeCommand(parent_cls):
-        _run_managed = managed
         name = "fake"
         help_msg = "help"
         overview = "overview"
-
-        def run_managed(self, parsed_args: argparse.Namespace) -> bool:
-            return self._run_managed
 
     return FakeCommand
 
@@ -159,7 +155,7 @@ def test_lifecycle_command_fill_parser(
     shell_dict,
     shell_args,
 ):
-    cls = get_fake_command_class(LifecycleCommand, managed=True)
+    cls = get_fake_command_class(LifecycleCommand)
     parser = argparse.ArgumentParser("parts_command")
     command = cls({"app": app_metadata, "services": fake_services})
     expected = {
@@ -202,7 +198,7 @@ def test_use_provider(
     build_env: str,
     expected: bool,
 ):
-    cls = get_fake_command_class(LifecycleCommand, managed=False)
+    cls = get_fake_command_class(LifecycleCommand)
     command = cls({"app": app_metadata, "services": fake_services})
 
     parsed_args = argparse.Namespace(destructive_mode=destructive)
@@ -219,7 +215,7 @@ def test_run_sets_platform_arg(
     fake_platform: str,
 ):
     build_planner = fake_services.get("build_plan")
-    cls = get_fake_command_class(LifecycleCommand, managed=False)
+    cls = get_fake_command_class(LifecycleCommand)
     command = cls({"app": app_metadata, "services": fake_services})
 
     mocker.patch.object(command, "_use_provider", return_value=False)
@@ -240,7 +236,7 @@ def test_run_sets_platform_from_env(
     fake_platform: str,
 ):
     build_planner = fake_services.get("build_plan")
-    cls = get_fake_command_class(LifecycleCommand, managed=False)
+    cls = get_fake_command_class(LifecycleCommand)
     command = cls({"app": app_metadata, "services": fake_services})
 
     mocker.patch.object(command, "_use_provider", return_value=False)
@@ -264,7 +260,7 @@ def test_run_sets_build_for_arg(
     arch: str,
 ):
     build_planner = fake_services.get("build_plan")
-    cls = get_fake_command_class(LifecycleCommand, managed=False)
+    cls = get_fake_command_class(LifecycleCommand)
     command = cls({"app": app_metadata, "services": fake_services})
 
     mocker.patch.object(command, "_use_provider", return_value=False)
@@ -288,7 +284,7 @@ def test_run_sets_build_for_from_env(
     arch: str,
 ):
     build_planner = fake_services.get("build_plan")
-    cls = get_fake_command_class(LifecycleCommand, managed=False)
+    cls = get_fake_command_class(LifecycleCommand)
     command = cls({"app": app_metadata, "services": fake_services})
 
     mocker.patch.object(command, "_use_provider", return_value=False)
@@ -317,7 +313,7 @@ def test_run_manager_for_build_plan(
     )
     mock_run_managed = mocker.patch.object(fake_services.get("provider"), "run_managed")
     mocker.patch.object(fake_services.get("build_plan"), "plan", return_value=[build])
-    cls = get_fake_command_class(LifecycleCommand, managed=False)
+    cls = get_fake_command_class(LifecycleCommand)
 
     command = cls({"app": app_metadata, "services": fake_services})
     command._run_manager_for_build_plan(fetch)
@@ -348,7 +344,7 @@ def test_step_command_fill_parser(
     shell_args,
     shell_dict,
 ):
-    cls = get_fake_command_class(LifecyclePartsCommand, managed=True)
+    cls = get_fake_command_class(LifecyclePartsCommand)
     parser = argparse.ArgumentParser("step_command")
     expected = {
         "parts": parts_args,
@@ -375,7 +371,7 @@ def test_step_command_fill_parser(
 @pytest.mark.parametrize("parts", PARTS_LISTS)
 @pytest.mark.usefixtures("managed_mode")
 def test_step_command_run_explicit_step(app_metadata, mock_services, parts, step_name):
-    cls = get_fake_command_class(LifecyclePartsCommand, managed=True)
+    cls = get_fake_command_class(LifecyclePartsCommand)
     mock_services.get("project").configure(platform=None, build_for=None)
 
     parsed_args = argparse.Namespace(destructive_mode=False, parts=parts)
@@ -1237,7 +1233,7 @@ def test_check_pro_features(
     pro_services: set[str],
 ) -> None:
     """Ensure that lifecycle commands will validate the pro context, even if it is not requested"""
-    command = get_fake_command_class(_BaseLifecycleCommand, managed=False)(
+    command = get_fake_command_class(_BaseLifecycleCommand)(
         {"app": app_metadata, "services": mock_services}
     )
     mocker.patch("craft_application.util.is_managed_mode", return_value=is_managed_mode)

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -21,7 +21,6 @@ import importlib.metadata
 import logging
 import pathlib
 import re
-import subprocess
 import sys
 from textwrap import dedent
 from unittest import mock
@@ -53,7 +52,6 @@ from craft_application.util import (
 )
 from craft_cli import CraftError, emit
 from craft_parts.plugins.plugins import PluginType
-from craft_providers import lxd
 
 from tests.conftest import FakeApplication
 
@@ -280,56 +278,6 @@ def test_log_path(monkeypatch, app, provider_managed, expected):
     assert actual == expected
 
 
-@pytest.mark.usefixtures("platform_independent_project")
-def test_run_managed_success(mocker, app, fake_host_architecture):
-    mock_provider = mock.MagicMock(spec_set=services.ProviderService)
-    app.services._services["provider"] = mock_provider
-    mock_pause = mocker.spy(craft_cli.emit, "pause")
-
-    app.run_managed("platform-independent", None)
-
-    mock_provider.instance.assert_called_once_with(
-        craft_platforms.BuildInfo(
-            platform="platform-independent",
-            build_on=fake_host_architecture,
-            build_for="all",
-            build_base=mock.ANY,
-        ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
-    )
-    mock_pause.assert_called_once_with()
-
-
-def test_run_managed_failure(app, fake_project):
-    mock_provider = mock.MagicMock(spec_set=services.ProviderService)
-    instance = mock_provider.instance.return_value.__enter__.return_value
-    instance.execute_run.side_effect = subprocess.CalledProcessError(1, [])
-    app.services._services["provider"] = mock_provider
-    app.project = fake_project
-
-    with pytest.raises(craft_providers.ProviderError) as exc_info:
-        app.run_managed(None, get_host_architecture())
-
-    assert exc_info.value.brief == "Failed to execute testcraft in instance."
-
-
-@pytest.mark.parametrize("app_metadata", [{"enable_pro_support": True}], indirect=True)
-def test_run_managed_configure_pro(mocker, app, fake_project):
-    """Ensure that configure_instance_with_pro is called during run_managed."""
-    mock_provider = mocker.MagicMock(spec_set=services.ProviderService)
-    app.services.provider = mock_provider
-    mock_instance = mocker.MagicMock(spec=lxd.LXDInstance)
-    mock_provider.instance.return_value.__enter__.return_value = mock_instance
-    app.project = fake_project
-    app._pro_services = ProServices(["esm-apps"])
-
-    app.run_managed(None, get_host_architecture())
-
-    mock_provider.configure_instance_with_pro.assert_called_once_with(mock_instance)
-
-
 @pytest.mark.parametrize(
     "pro_services", [None, ProServices(), ProServices(["esm-apps"])]
 )
@@ -347,84 +295,6 @@ def test_configure_services_pro_services(
     calls = {call.args[0]: call.kwargs for call in mock_update.call_args_list}
     assert calls["lifecycle"]["use_host_sources"] is bool(pro_services)
     assert calls["provider"]["pro_services"] is pro_services
-
-
-def test_run_managed_multiple(app, fake_host_architecture):
-    mock_provider = mock.MagicMock(spec_set=services.ProviderService)
-    app.services._services["provider"] = mock_provider
-
-    app.run_managed(None, None)
-
-    mock_provider.instance.assert_called_with(
-        craft_platforms.BuildInfo(
-            platform=mock.ANY,
-            build_on=fake_host_architecture,
-            build_for=mock.ANY,
-            build_base=mock.ANY,
-        ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
-    )
-
-    assert len(mock_provider.instance.mock_calls) > 1
-
-
-@pytest.mark.parametrize("build_for", craft_platforms.DebianArchitecture)
-def test_run_managed_specified_arch(app, fake_host_architecture, build_for):
-    mock_provider = mock.MagicMock(spec_set=services.ProviderService)
-    app.services._services["provider"] = mock_provider
-
-    try:
-        app.run_managed(None, build_for)
-    except errors.EmptyBuildPlanError:
-        pytest.skip(
-            reason=f"build-for {build_for} has no build-on {fake_host_architecture}"
-        )
-
-    mock_provider.instance.assert_called_with(
-        craft_platforms.BuildInfo(
-            platform=mock.ANY,
-            build_on=fake_host_architecture,
-            build_for=build_for,
-            build_base=mock.ANY,
-        ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
-    )
-
-
-def test_run_managed_specified_platform(app, fake_platform, fake_host_architecture):
-    mock_provider = mock.MagicMock(spec_set=services.ProviderService)
-    app.services._services["provider"] = mock_provider
-
-    try:
-        app.run_managed(fake_platform, None)
-    except errors.EmptyBuildPlanError:
-        pytest.skip(
-            reason=f"Platform {fake_platform} has no builds on {fake_host_architecture}"
-        )
-
-    mock_provider.instance.assert_called_once_with(
-        craft_platforms.BuildInfo(
-            platform=fake_platform,
-            build_on=fake_host_architecture,
-            build_for=mock.ANY,
-            build_base=mock.ANY,
-        ),
-        work_dir=mock.ANY,
-        clean_existing=False,
-        use_base_instance=True,
-    )
-
-
-def test_run_managed_empty_plan(mocker, app):
-    build_plan_service = app.services.get("build_plan")
-    mocker.patch.object(build_plan_service, "plan", return_value=[])
-
-    with pytest.raises(errors.EmptyBuildPlanError):
-        app.run_managed(None, None)
 
 
 @pytest.mark.parametrize(
@@ -714,7 +584,7 @@ def test_run_success_unmanaged(
     with check:
         emitter.assert_debug("Preparing application...")
     with check:
-        emitter.assert_debug("Running testcraft pass on host")
+        emitter.assert_debug("Running 'testcraft pass'.")
 
 
 @pytest.mark.parametrize("return_code", [None, 0, 1])
@@ -732,7 +602,9 @@ def test_run_success_managed_inside_managed(
     mocker.patch.object(
         mock_dispatcher, "parsed_args", return_value={"platform": "foo"}
     )
-    app.run_managed = mock.Mock()
+    mock_provider_run_managed = mocker.patch.object(
+        app.services.get("provider"), "run_managed"
+    )
     mock_dispatcher.run.return_value = return_code
     mock_dispatcher.pre_parse_args.return_value = {}
     monkeypatch.setattr(sys, "argv", ["testcraft", "pull"])
@@ -740,7 +612,7 @@ def test_run_success_managed_inside_managed(
 
     check.equal(app.run(), return_code or 0)
     with check:
-        app.run_managed.assert_not_called()
+        mock_provider_run_managed.assert_not_called()
     with check:
         mock_dispatcher.run.assert_called_once_with()
 


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

This PR is a breaking change that completes the migration of where managed instances are dispatched.

Now, launching a managed instance can only be done through the `ProviderService`.  The `LifecycleCommand`s have been doing this for a while, so the removed code in this PR was unused by Craft Application itself.

Unless your app had a custom, non-lifecycle command that runs a managed instance, you should be unaffected by this change.

Fixes #1062
(CRAFT-5150)