### PR TITLE
chore!: remove deprecated APIs

### DIFF
--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -374,38 +374,6 @@ class Application:
             pro_services=self._pro_services,
         )
 
-    def get_project(
-        self,
-        *,
-        platform: str | None = None,
-        build_for: str | None = None,
-    ) -> models.Project:
-        """Get the project model.
-
-        This only resolves and renders the project the first time it gets run.
-        After that, it merely uses a cached project model.
-
-        :param platform: the platform name listed in the build plan.
-        :param build_for: the architecture to build this project for.
-        :returns: A transformed, loaded project model.
-        """
-        warnings.warn(
-            DeprecationWarning(
-                "Do not get the project directly from the Application. "
-                "Get it from the project service."
-            ),
-            stacklevel=2,
-        )
-        project_service = self.services.get("project")
-        if not project_service.is_configured:
-            project_service.configure(platform=platform, build_for=build_for)
-        return project_service.get()
-
-    @cached_property
-    def project(self) -> models.Project:
-        """Get this application's Project metadata."""
-        return self.get_project()
-
     def is_managed(self) -> bool:
         """Shortcut to tell whether we're running in managed mode."""
         return self.services.get_class("provider").is_managed()

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     import argparse
     from collections.abc import Iterable, Sequence
 
-    from craft_parts.infos import ProjectInfo
     from craft_parts.plugins.plugins import PluginType
 
     from craft_application.services import service_factory
@@ -574,24 +573,6 @@ class Application:
             error.logpath_report = False
 
         craft_cli.emit.error(error)
-
-    def _set_global_environment(self, info: ProjectInfo) -> None:
-        """Populate the ProjectInfo's global environment.
-
-        DEPRECATED: This method is deprecated and is not called by default.
-        Use ``ProjectService.update_project_environment`` instead.
-        """
-        warnings.warn(
-            "Application._set_global_environment is deprecated and not called by "
-            "default. Use ProjectService.update_project_environment instead.",
-            category=DeprecationWarning,
-            stacklevel=1,
-        )
-        info.global_environment.update(
-            {
-                "CRAFT_PROJECT_VERSION": info.get_project_var("version", raw_read=True),
-            }
-        )
 
     def _setup_logging(self) -> None:
         """Initialize the logging system."""

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -575,24 +575,6 @@ class Application:
 
         craft_cli.emit.error(error)
 
-    def _get_project_vars(self, yaml_data: dict[str, Any]) -> dict[str, str]:
-        """Return a dict with project variables to be expanded.
-
-        DEPRECATED: This method is deprecated and is not called by default.
-        Use ``ProjectService.project_vars`` instead.
-        """
-        warnings.warn(
-            "'Application._get_project_vars' is deprecated. "
-            "Use 'ProjectService.project_vars' instead.",
-            category=DeprecationWarning,
-            stacklevel=1,
-        )
-
-        pvars: dict[str, str] = {}
-        for var in self.app.project_variables:
-            pvars[var] = str(yaml_data.get(var, ""))
-        return pvars
-
     def _set_global_environment(self, info: ProjectInfo) -> None:
         """Populate the ProjectInfo's global environment.
 

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -23,7 +23,6 @@ import pathlib
 import signal
 import sys
 import traceback
-import warnings
 from dataclasses import dataclass, field
 from functools import cached_property
 from importlib import metadata

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -457,27 +457,14 @@ class Application:
         """
         return {}
 
-    def register_plugins(self, plugins: dict[str, PluginType]) -> None:
-        """Register plugins for this application."""
-        if not plugins:
-            return
-
-        warnings.warn(
-            "Registering plugins through the Application is deprecated. Override "
-            "the Lifecycle service's get_plugin_group instead.",
-            DeprecationWarning,
-            stacklevel=0,
-        )
-        from craft_parts.plugins import register  # noqa: PLC0415
-
-        craft_cli.emit.trace("Registering plugins...")
-        craft_cli.emit.trace(f"Plugins: {', '.join(plugins.keys())}")
-        register(plugins)
-
     def _register_default_plugins(self) -> None:
         """Register per application plugins when initializing."""
-        with warnings.catch_warnings():
-            self.register_plugins(self._get_app_plugins())
+        if plugins := self._get_app_plugins():
+            from craft_parts.plugins import register  # noqa: PLC0415
+
+            craft_cli.emit.trace("Registering plugins...")
+            craft_cli.emit.trace(f"Plugins: {', '.join(plugins.keys())}")
+            register(plugins)
 
     def _pre_run(self, dispatcher: craft_cli.Dispatcher) -> None:
         """Do any final setup before running the command.

--- a/craft_application/commands/base.py
+++ b/craft_application/commands/base.py
@@ -18,10 +18,9 @@
 from __future__ import annotations
 
 import abc
-import warnings
 from typing import TYPE_CHECKING, Any, Protocol, final
 
-from craft_cli import BaseCommand, emit
+from craft_cli import BaseCommand
 from typing_extensions import Self
 
 from craft_application import application, util
@@ -62,16 +61,7 @@ class AppCommand(BaseCommand):
     :deprecated: override :meth:`needs_project` instead.
     """
 
-    def __init__(self, config: dict[str, Any] | None) -> None:
-        if config is None:
-            warnings.warn(
-                "Creating an AppCommand without a config dict is pending deprecation.",
-                PendingDeprecationWarning,
-                stacklevel=3,
-            )
-            emit.trace("Not completing command configuration")
-            return
-
+    def __init__(self, config: dict[str, Any]) -> None:
         super().__init__(config)
 
         self._app: application.AppMetadata = config["app"]

--- a/craft_application/services/project.py
+++ b/craft_application/services/project.py
@@ -19,7 +19,6 @@ import copy
 import datetime
 import os
 import pathlib
-import warnings
 from typing import TYPE_CHECKING, Any, Literal, cast, final
 
 import craft_parts
@@ -326,24 +325,6 @@ class ProjectService(base.AppService):
                 logpath_report=False,
                 retcode=os.EX_DATAERR,
             )
-
-    @final
-    def _get_project_vars(
-        self,
-        yaml_data: dict[str, Any],  # noqa: ARG002 (unused-method-argument)
-    ) -> dict[str, Any]:
-        """Return a dict with project variables to be expanded.
-
-        DEPRECATED: This method is deprecated and is not called by default.
-        Use ``ProjectService.project_vars`` instead.
-        """
-        warnings.warn(
-            "'ProjectService._get_project_vars' is deprecated. "
-            "Use 'project_vars' property instead.",
-            category=DeprecationWarning,
-            stacklevel=1,
-        )
-        return self._project_vars.marshal("value") if self._project_vars else {}
 
     @final
     @property

--- a/craft_application/services/service_factory.py
+++ b/craft_application/services/service_factory.py
@@ -91,28 +91,10 @@ class ServiceFactory:
         testing: services.TestingService
         linter: services.LinterService
 
-    def __init__(
-        self,
-        app: AppMetadata,
-        **kwargs: type[services.AppService] | None,
-    ) -> None:
+    def __init__(self, app: AppMetadata) -> None:
         self.app = app
         self._service_kwargs: dict[str, dict[str, Any]] = {}
         self._services: dict[str, services.AppService] = {}
-
-        for cls_name, value in kwargs.items():
-            if cls_name.endswith("Class"):
-                if value is not None:
-                    identifier = _CAMEL_TO_PYTHON_CASE_REGEX.sub(
-                        "_", cls_name[:-5]
-                    ).lower()
-                    warnings.warn(
-                        f'Registering services on service factory instantiation is deprecated. Use ServiceFactory.register("{identifier}", {value.__name__}) instead.',
-                        category=DeprecationWarning,
-                        stacklevel=3,
-                    )
-                    self.register(identifier, value)
-                setattr(self, cls_name, self.get_class(cls_name))
 
         if "package" not in self._service_classes:
             raise TypeError(

--- a/craft_application/services/service_factory.py
+++ b/craft_application/services/service_factory.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import importlib
 import re
-import warnings
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -141,23 +140,6 @@ class ServiceFactory:
             cls.register(
                 name, class_name, module=f"craft_application.services.{module_name}"
             )
-
-    def set_kwargs(
-        self,
-        service: str,
-        **kwargs: Any,
-    ) -> None:
-        """Set up the keyword arguments to pass to a particular service class.
-
-        DEPRECATED: use update_kwargs instead
-        """
-        warnings.warn(
-            DeprecationWarning(
-                "ServiceFactory.set_kwargs is deprecated. Use update_kwargs instead."
-            ),
-            stacklevel=2,
-        )
-        self._service_kwargs[service] = kwargs
 
     def update_kwargs(
         self,
@@ -318,7 +300,7 @@ class ServiceFactory:
         treating them as attributes of our factory in a dynamic manner.
         For a service (e.g. ``package``, the PackageService instance) that has not
         been instantiated, this method finds the corresponding class, instantiates
-        it with defaults and any values set using ``set_kwargs``, and stores the
+        it with defaults and any values set using ``update_kwargs``, and stores the
         instantiated service as an instance attribute, allowing the same service
         instance to be reused for the entire run of the application.
         """

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -28,6 +28,8 @@ Application
   with ``services.get("project").get()``.
 - ``Application.register_plugins()`` is removed. Register plugins by overriding
   ``LifecycleService.get_plugin_group()`` instead.
+- ``Application._get_project_vars()`` is removed. Use ``ProjectService.project_vars``
+  instead.
 
 Commands
 ========

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -40,6 +40,7 @@ Commands
   ``Application.run_managed()`` are removed. Commands that need to run in a
   managed instance should call :py:meth:`ProviderService.run_managed
   <craft_application.services.ProviderService.run_managed>`.
+- ``AppCommand(config=None)`` is removed. A config dict is now required.
 
 For a complete list of commits, check out the `7.0.0`_ release on GitHub.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -24,6 +24,8 @@ Application
 
 - ``Application._enable_fetch_service`` and ``Application._fetch_service_policy``
    are removed.
+- ``Application.get_project()`` is removed. Get the project from the project service
+  with ``services.get("project").get()``.
 
 Commands
 ========

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -30,6 +30,8 @@ Application
   ``LifecycleService.get_plugin_group()`` instead.
 - ``Application._get_project_vars()`` is removed. Use ``ProjectService.project_vars``
   instead.
+- ``Application._set_global_environment()`` is removed. Use
+  ``ProjectService.update_project_environment()`` instead.
 
 Commands
 ========

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -26,6 +26,8 @@ Application
    are removed.
 - ``Application.get_project()`` is removed. Get the project from the project service
   with ``services.get("project").get()``.
+- ``Application.register_plugins()`` is removed. Register plugins by overriding
+  ``LifecycleService.get_plugin_group()`` instead.
 
 Commands
 ========

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -47,6 +47,8 @@ Services
 
 - ``ProjectService._get_project_vars()`` is removed. Use the
   ``ProjectService.project_vars`` property instead.
+- Registering services on ``ServiceFactory`` instantiation is removed. Use
+  ``ServiceFactory.register()`` instead.
 
 For a complete list of commits, check out the `7.0.0`_ release on GitHub.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -49,6 +49,8 @@ Services
   ``ProjectService.project_vars`` property instead.
 - Registering services on ``ServiceFactory`` instantiation is removed. Use
   ``ServiceFactory.register()`` instead.
+- ``ServiceFactory.set_kwargs()`` is removed. Use ``ServiceFactory.update_kwargs()``
+  instead.
 
 For a complete list of commits, check out the `7.0.0`_ release on GitHub.
 

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -42,6 +42,12 @@ Commands
   <craft_application.services.ProviderService.run_managed>`.
 - ``AppCommand(config=None)`` is removed. A config dict is now required.
 
+Services
+========
+
+- ``ProjectService._get_project_vars()`` is removed. Use the
+  ``ProjectService.project_vars`` property instead.
+
 For a complete list of commits, check out the `7.0.0`_ release on GitHub.
 
 6.4.0 (2026-04-23)

--- a/tests/integration/services/test_service_factory.py
+++ b/tests/integration/services/test_service_factory.py
@@ -19,34 +19,6 @@ import pytest
 from craft_application import services
 
 
-def test_gets_dataclass_services(
-    check,
-    app_metadata,
-    fake_project,
-    project_path,
-    fake_package_service_class,
-    fake_lifecycle_service_class,
-    fake_project_service_class,
-    fake_provider_service_class,
-):
-    with pytest.warns(DeprecationWarning, match="Use ServiceFactory.register"):
-        factory = services.ServiceFactory(
-            app_metadata,
-            project=fake_project,
-            PackageClass=fake_package_service_class,
-            LifecycleClass=fake_lifecycle_service_class,
-            ProjectClass=fake_project_service_class,
-            ProviderClass=fake_provider_service_class,
-        )
-    factory.update_kwargs("project", project_dir=project_path)
-    factory.get("project").configure(platform=None, build_for=None)
-    factory.get("project").set(fake_project)  # type: ignore[reportAttributeAccessIssue]
-
-    check.is_instance(factory.package, services.PackageService)
-    check.is_instance(factory.lifecycle, services.LifecycleService)
-    check.is_instance(factory.provider, services.ProviderService)
-
-
 def test_gets_registered_services(
     check,
     app_metadata,
@@ -74,9 +46,9 @@ def test_gets_registered_services(
     check.is_instance(factory.get("provider"), services.ProviderService)
 
 
-def test_real_service_error(app_metadata, fake_project):
+def test_real_service_error(app_metadata):
     services.ServiceFactory.register("package", services.PackageService)
-    factory = services.ServiceFactory(app_metadata, project=fake_project)
+    factory = services.ServiceFactory(app_metadata)
 
     with pytest.raises(
         TypeError,

--- a/tests/unit/commands/test_base.py
+++ b/tests/unit/commands/test_base.py
@@ -37,19 +37,6 @@ def fake_command(app_metadata, fake_services):
     )
 
 
-def test_without_config(emitter):
-    """Test that a command can be initialised without a config.
-    This is pending deprecation but still supported.
-    """
-
-    with pytest.deprecated_call():
-        command = base.AppCommand(None)
-
-    emitter.assert_trace("Not completing command configuration")
-    assert not hasattr(command, "_app")
-    assert not hasattr(command, "_services")
-
-
 @pytest.mark.parametrize("always_load_project", [True, False])
 def test_needs_project(fake_command, always_load_project):
     """`needs_project()` defaults to `always_load_project`."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -79,7 +79,7 @@ def mock_services(monkeypatch, app_metadata, fake_project, project_path):
     monkeypatch.setattr(
         service_factory, "issubclass", forgiving_is_subclass, raising=False
     )
-    factory = services.ServiceFactory(app_metadata, project=fake_project)
+    factory = services.ServiceFactory(app_metadata)
     factory.update_kwargs("project", project_dir=project_path)
     return factory
 

--- a/tests/unit/services/test_project.py
+++ b/tests/unit/services/test_project.py
@@ -309,32 +309,6 @@ def test_get_platforms_bad_value(
 @pytest.mark.parametrize(
     ("data", "expected"),
     [
-        pytest.param({}, {"version": None}, id="empty"),
-        pytest.param(
-            {"version": "3.14", "unrelated": "pi"},
-            {"version": "3.14"},
-            id="version-set",
-        ),
-    ],
-)
-def test_get_project_vars(real_project_service: ProjectService, data, expected):
-    real_project_service._project_vars = real_project_service._create_project_vars(data)
-    expected_warning = re.escape(
-        "'ProjectService._get_project_vars' is deprecated. "
-        "Use 'project_vars' property instead."
-    )
-    with pytest.warns(DeprecationWarning, match=expected_warning):
-        project_vars = real_project_service._get_project_vars(data)
-
-    assert project_vars == expected | {
-        "summary": None,
-        "description": None,
-    }
-
-
-@pytest.mark.parametrize(
-    ("data", "expected"),
-    [
         pytest.param(
             {},
             ProjectVarInfo.unmarshal({"version": {}, "summary": {}, "description": {}}),

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -96,35 +96,6 @@ def test_register_service_by_reference_with_module():
 
 
 @pytest.mark.parametrize(
-    "kwargs",
-    [
-        {},
-        {"arg_1": None, "arg_b": "something"},
-    ],
-)
-def test_set_kwargs(
-    app_metadata, fake_project, check, fake_package_service_class, kwargs
-):
-    class MockPackageService(fake_package_service_class):
-        mock_class = mock.Mock(return_value=mock.Mock(spec_set=services.PackageService))
-
-        def __new__(cls, *args, **kwargs):
-            return cls.mock_class(*args, **kwargs)
-
-    services.ServiceFactory.register("package", MockPackageService)
-    factory = services.ServiceFactory(app_metadata, project=fake_project)
-
-    with pytest.warns(DeprecationWarning, match="set_kwargs is deprecated"):
-        factory.set_kwargs("package", **kwargs)
-
-    check.equal(factory.package, MockPackageService.mock_class.return_value)
-    with check:
-        MockPackageService.mock_class.assert_called_once_with(
-            app=app_metadata, services=factory, **kwargs
-        )
-
-
-@pytest.mark.parametrize(
     ("first_kwargs", "second_kwargs", "expected"),
     [
         ({}, {}, {}),

--- a/tests/unit/services/test_service_factory.py
+++ b/tests/unit/services/test_service_factory.py
@@ -26,10 +26,6 @@ from craft_cli import emit
 if TYPE_CHECKING:
     import pathlib
 
-pytestmark = [
-    pytest.mark.filterwarnings("ignore:Registering services on service factory")
-]
-
 
 class FakeService(services.AppService):
     """A fake service for testing."""
@@ -39,7 +35,6 @@ class FakeService(services.AppService):
 def factory(
     tmp_path,
     app_metadata,
-    fake_project,
     fake_project_file,
     fake_package_service_class,
     fake_lifecycle_service_class,
@@ -100,22 +95,6 @@ def test_register_service_by_reference_with_module():
         services.ServiceFactory.register("testy", FakeService, module="__main__")
 
 
-def test_register_services_in_init(
-    app_metadata,
-    fake_package_service_class,
-    fake_lifecycle_service_class,
-    fake_provider_service_class,
-):
-    factory = services.ServiceFactory(
-        app_metadata,
-        PackageClass=fake_package_service_class,
-        ProviderClass=fake_provider_service_class,
-    )
-
-    pytest_check.is_instance(factory.package, fake_package_service_class)
-    pytest_check.is_instance(factory.provider, fake_provider_service_class)
-
-
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -163,7 +142,6 @@ def test_set_kwargs(
 )
 def test_update_kwargs(
     app_metadata,
-    fake_project,
     fake_package_service_class,
     first_kwargs,
     second_kwargs,
@@ -177,7 +155,7 @@ def test_update_kwargs(
             return cls.mock_class(*args, **kwargs)
 
     services.ServiceFactory.register("package", MockPackageService)
-    factory = services.ServiceFactory(app_metadata, project=fake_project)
+    factory = services.ServiceFactory(app_metadata)
 
     factory.update_kwargs("package", **first_kwargs)
     factory.update_kwargs("package", **second_kwargs)
@@ -272,29 +250,27 @@ def test_getattr_not_a_class(factory):
         _ = factory.invalid_name
 
 
-def test_getattr_not_a_service_class(app_metadata, fake_project):
+def test_getattr_not_a_service_class(app_metadata):
     class InvalidClass:
         pass
 
-    factory = services.ServiceFactory(
-        app_metadata,
-        project=fake_project,
-        # This incorrect type is intentional
-        PackageClass=InvalidClass,  # pyright: ignore[reportArgumentType]
+    services.ServiceFactory.register(
+        "package",
+        InvalidClass,  # pyright: ignore[reportArgumentType]
     )
+    factory = services.ServiceFactory(app_metadata)
 
     with pytest.raises(TypeError):
         _ = factory.package
 
 
-def test_service_setup(app_metadata, fake_project, fake_package_service_class, emitter):
+def test_service_setup(app_metadata, fake_package_service_class, emitter):
     class FakePackageService(fake_package_service_class):
         def setup(self) -> None:
             emit.debug("setting up package service")
 
-    factory = services.ServiceFactory(
-        app_metadata, project=fake_project, PackageClass=FakePackageService
-    )
+    services.ServiceFactory.register("package", FakePackageService)
+    factory = services.ServiceFactory(app_metadata)
     _ = factory.package
 
     assert emitter.assert_debug("setting up package service")
@@ -308,6 +284,8 @@ def test_mandatory_adoptable_field(
     fake_project_file: pathlib.Path,
 ):
     services.ServiceFactory.register("project", fake_project_service_class)
+    services.ServiceFactory.register("package", fake_package_service_class)
+    services.ServiceFactory.register("lifecycle", fake_lifecycle_service_class)
     app_metadata = AppMetadata(
         "testcraft",
         "A fake app for testing craft-application",
@@ -316,25 +294,9 @@ def test_mandatory_adoptable_field(
     fake_project.license = None
     fake_project.adopt_info = "partname"
 
-    factory = services.ServiceFactory(
-        app_metadata,
-        project=fake_project,
-        PackageClass=fake_package_service_class,
-        LifecycleClass=fake_lifecycle_service_class,
-    )
+    factory = services.ServiceFactory(app_metadata)
     factory.update_kwargs("project", project_dir=fake_project_file.parent)
     factory.get("project").configure(platform=None, build_for=None)
     factory.get("project").set(fake_project)  # type: ignore[reportAttributeAccessIssue]
 
     factory.get("lifecycle")
-
-
-@pytest.mark.parametrize(
-    ("name", "cls"),
-    [
-        ("PackageClass", services.PackageService),
-    ],
-)
-def test_services_on_instantiation_deprecated(app_metadata, name, cls):
-    with pytest.warns(DeprecationWarning, match="Use ServiceFactory.register"):
-        services.ServiceFactory(**{"app": app_metadata, name: cls})

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -115,21 +115,6 @@ def test_app_metadata_default_mandatory_adoptable_fields():
     assert app.mandatory_adoptable_fields == ["version", "summary", "description"]
 
 
-def test_app_project_vars_deprecated(app):
-    expected = re.escape(
-        "'Application._get_project_vars' is deprecated. "
-        "Use 'ProjectService.project_vars' instead."
-    )
-    with pytest.warns(DeprecationWarning, match=expected):
-        project_vars = app._get_project_vars({"version": "test-version"})
-
-    assert project_vars == {
-        "description": "",
-        "summary": "",
-        "version": "test-version",
-    }
-
-
 class FakePlugin(craft_parts.plugins.Plugin):
     def __init__(self, properties, part_info):
         pass

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -46,9 +46,7 @@ from craft_application.commands import (
     get_lifecycle_command_group,
     get_other_command_group,
 )
-from craft_application.util import (
-    ProServices,  # pyright: ignore[reportGeneralTypeIssues]
-)
+from craft_application.util import ProServices
 from craft_cli import CraftError, emit
 from craft_parts.plugins.plugins import PluginType
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -47,8 +47,7 @@ from craft_application.commands import (
     get_other_command_group,
 )
 from craft_application.util import (
-    ProServices,
-    get_host_architecture,  # pyright: ignore[reportGeneralTypeIssues]
+    ProServices,  # pyright: ignore[reportGeneralTypeIssues]
 )
 from craft_cli import CraftError, emit
 from craft_parts.plugins.plugins import PluginType
@@ -397,7 +396,6 @@ def test_gets_project(
     app.run()
 
     pytest_check.is_not_none(fake_services.project)
-    pytest_check.is_not_none(app.project)
 
 
 @pytest.mark.parametrize("app_metadata", [{"enable_pro_support": True}], indirect=True)
@@ -592,13 +590,11 @@ def test_run_success_managed_inside_managed(
     monkeypatch,
     check,
     app,
-    fake_project,
     mock_dispatcher,
     return_code,
     mocker,
     mock_pro_api_call,
 ):
-    mocker.patch.object(app, "get_project", return_value=fake_project)
     mocker.patch.object(
         mock_dispatcher, "parsed_args", return_value={"platform": "foo"}
     )
@@ -881,7 +877,7 @@ def test_work_dir_project_non_managed(monkeypatch, app_metadata, fake_services):
     app = application.Application(app_metadata, fake_services)
     assert app._work_dir == pathlib.Path.cwd()
 
-    project = app.get_project(build_for=get_host_architecture())
+    project = app.services.get("project").get()
 
     # Make sure the project is loaded correctly (from the cwd)
     assert project is not None
@@ -896,7 +892,7 @@ def test_work_dir_project_managed(monkeypatch, app_metadata, fake_services):
     app = application.Application(app_metadata, fake_services)
     assert app._work_dir == pathlib.PosixPath("/root")
 
-    project = app.get_project(build_for=get_host_architecture())
+    project = app.services.get("project").get()
 
     # Make sure the project is loaded correctly (from the cwd)
     assert project is not None
@@ -930,20 +926,6 @@ def environment_project(in_project_path):
     )
 
     return in_project_path
-
-
-@pytest.mark.usefixtures("fake_project_file")
-def test_get_project_current_dir(app):
-    # Load a project file from the current directory
-    project = app.get_project()
-
-    # Check that it caches that project.
-    assert app.get_project() is project, "Project file was not cached."
-
-
-@pytest.mark.usefixtures("fake_project_file")
-def test_get_project_all_platform(app):
-    app.get_project(platform="arm64")
 
 
 def test_get_cache_dir(tmp_path, app):


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Removes 8 deprecated APIs in craft-applications.

Apps that have already heeded the deprecation warnings should be unaffected. 

I recommend reviewing per-commit.

Fixes #1063 
(CRAFT-5151)