### PR TITLE
ci: separate flaky tests into their own run

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -26,8 +26,8 @@ jobs:
   test-flaky:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
-      fast-test-python-versions: '["3.10", "3.12"]'
+      fast-test-platforms: "[]"
+      fast-test-python-versions: "[]"
       slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
       slow-test-python-versions: '["3.10", "3.12"]'
       lowest-python-platform: ubuntu-22.04

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -22,3 +22,15 @@ jobs:
       lowest-python-platform: ubuntu-22.04
       lowest-python-version: "3.10"
       use-lxd: true
+      pytest-markers: "not flaky"
+  test-flaky:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
+      fast-test-python-versions: '["3.10", "3.12"]'
+      slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
+      slow-test-python-versions: '["3.10", "3.12"]'
+      lowest-python-platform: ubuntu-22.04
+      lowest-python-version: "3.10"
+      use-lxd: true
+      pytest-markers: "flaky"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ xfail_strict = true
 markers = [
     "enable_features: Tests that require specific features",
     "slow: Tests that take a long time",
-    "flaky: tests that are known to be flaky and may need reruns (e.g. network-dependent)",
+    "flaky: Tests that are known to be flaky and may need reruns (e.g. network-dependent)",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,7 @@ xfail_strict = true
 markers = [
     "enable_features: Tests that require specific features",
     "slow: Tests that take a long time",
+    "flaky: tests that are known to be flaky and may need reruns (e.g. network-dependent)",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/git/test_git.py
+++ b/tests/integration/git/test_git.py
@@ -27,6 +27,7 @@ def git_repo(empty_repository: pathlib.Path) -> GitRepo:
     return GitRepo(empty_repository)
 
 
+@pytest.mark.flaky(reruns=3, reason="Git fetching from Launchpad can be flaky")
 @pytest.mark.slow
 def test_fetching_hello_repository(
     empty_repository: pathlib.Path,

--- a/tests/integration/launchpad/test_anonymous_access.py
+++ b/tests/integration/launchpad/test_anonymous_access.py
@@ -15,6 +15,7 @@ def _ignore_staging() -> bool:
 _IGNORE_STAGING = _ignore_staging()
 
 
+@pytest.mark.flaky(reruns=3, reason="Launchpad staging is often unreachable")
 @pytest.mark.parametrize(
     "root",
     [
@@ -54,6 +55,7 @@ def test_anonymous_login(tmp_path, root):
 #         assert recipe.owner_name == "lengau"
 
 
+@pytest.mark.flaky(reruns=3, reason="Launchpad can be flaky")
 @pytest.mark.parametrize(
     ("name", "path"),
     [
@@ -69,6 +71,7 @@ def test_get_real_repository_by_path(anonymous_lp, name, path):
     assert repo.name == name
 
 
+@pytest.mark.flaky(reruns=3, reason="Launchpad can be flaky")
 @pytest.mark.parametrize(
     ("name", "owner", "project"),
     [

--- a/tests/integration/launchpad/test_anonymous_access.py
+++ b/tests/integration/launchpad/test_anonymous_access.py
@@ -8,7 +8,12 @@ from craft_application import launchpad
 def _ignore_staging() -> bool:
     """Check if we should ignore staging."""
     # If the base API page is up, run the tests as normal.
-    api_result = requests.get("https://api.staging.launchpad.net/devel/", timeout=4.0)
+    try:
+        api_result = requests.get(
+            "https://api.staging.launchpad.net/devel/", timeout=4.0
+        )
+    except requests.RequestException:
+        return True
     return api_result.status_code >= 500
 
 

--- a/tests/integration/services/test_fetch.py
+++ b/tests/integration/services/test_fetch.py
@@ -281,6 +281,10 @@ def lxd_instance(snap_safe_tmp_path, provider_service):
     craft_platforms.DebianArchitecture.from_host() != "amd64",
     reason="https://github.com/canonical/craft-application/issues/1032",
 )
+@pytest.mark.flaky(
+    reruns=3,
+    reason="Fetch service integration tests involve network and LXD, which can be flaky",
+)
 @pytest.mark.slow
 def test_build_instance_integration_managed_fetch_service(
     app_service,
@@ -312,6 +316,10 @@ def test_build_instance_integration_managed_fetch_service(
     _check_log(capsys)
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    reason="Fetch service integration tests involve network and LXD, which can be flaky",
+)
 @pytest.mark.slow
 def test_build_instance_integration_external_fetch_service(
     app_service,

--- a/tests/integration/services/test_lifecycle.py
+++ b/tests/integration/services/test_lifecycle.py
@@ -142,6 +142,10 @@ def test_lifecycle_messages_no_duplicates(
     assert expected_output in stderr
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    reason="Overlay integration involves keyservers and repositories, which can be flaky",
+)
 @pytest.mark.slow
 @pytest.mark.usefixtures("enable_overlay")
 def test_package_repositories_in_overlay(

--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -97,6 +97,7 @@ def test_provider_lifecycle(
     ],
 )
 @pytest.mark.parametrize("provider_name", [pytest.param("lxd", marks=pytest.mark.lxd)])
+@pytest.mark.flaky(reruns=3, reason="LXD/network integration can be flaky")
 @pytest.mark.slow
 def test_proxy_variables_forwarded(
     monkeypatch, snap_safe_tmp_path, provider_service, base, proxy_vars, provider_name
@@ -130,6 +131,7 @@ def test_proxy_variables_forwarded(
         assert instance_env.get(var) == content
 
 
+@pytest.mark.flaky(reruns=3, reason="LXD/network integration can be flaky")
 @pytest.mark.slow
 @pytest.mark.parametrize("fetch", [False, True])
 def test_run_managed(provider_service, fake_services, fetch, snap_safe_tmp_path):
@@ -194,6 +196,7 @@ def test_get_incompatible_instance_error(
             pass
 
 
+@pytest.mark.flaky(reruns=3, reason="LXD integration can be flaky")
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "build_on",

--- a/tests/integration/services/test_remotebuild.py
+++ b/tests/integration/services/test_remotebuild.py
@@ -24,6 +24,7 @@ def public_project_name(request):
     return request.param
 
 
+@pytest.mark.flaky(reruns=3, reason="Launchpad can be flaky")
 @pytest.mark.slow
 def test_use_public_project(anonymous_remote_build_service, public_project_name):
     """Test that we can get a real (public) project using an anonymous client."""
@@ -32,6 +33,7 @@ def test_use_public_project(anonymous_remote_build_service, public_project_name)
     assert anonymous_remote_build_service._lp_project.name == public_project_name
 
 
+@pytest.mark.flaky(reruns=3, reason="Launchpad can be flaky")
 @pytest.mark.slow
 def test_error_with_nonexistent_project(anonymous_remote_build_service):
     """Test failing gracefully with a nonexistent project."""
@@ -43,6 +45,7 @@ def test_error_with_nonexistent_project(anonymous_remote_build_service):
         anonymous_remote_build_service.set_project(name)
 
 
+@pytest.mark.flaky(reruns=3, reason="Launchpad can be flaky")
 @pytest.mark.slow
 def test_project_is_public(anonymous_remote_build_service, public_project_name):
     """Test that the given project is public."""

--- a/tests/integration/services/test_request.py
+++ b/tests/integration/services/test_request.py
@@ -37,6 +37,7 @@ import pytest_check
         )
     ],
 )
+@pytest.mark.flaky(reruns=3, reason="External downloads can be flaky")
 @pytest.mark.slow
 def test_get_real_file(tmp_path, emitter, request_service, url, checksum, size):
     result = request_service.download_with_progress(url, tmp_path)
@@ -65,6 +66,7 @@ def test_get_real_file(tmp_path, emitter, request_service, url, checksum, size):
         },
     ],
 )
+@pytest.mark.flaky(reruns=3, reason="External downloads can be flaky")
 @pytest.mark.slow
 def test_get_real_files(tmp_path, request_service, files):
     result = request_service.download_files_with_progress(


### PR DESCRIPTION
This should make it quicker and easier to re-run flaky tests once the network issue breaking them is resolved.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
