### PR TITLE
ci: fix empty matrix error in test-flaky job

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -26,8 +26,8 @@ jobs:
   test-flaky:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
-      fast-test-platforms: "[]"
-      fast-test-python-versions: "[]"
+      fast-test-platforms: '["ubuntu-22.04"]'
+      fast-test-python-versions: '["3.10"]'
       slow-test-platforms: '["ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"]'
       slow-test-python-versions: '["3.10", "3.12"]'
       lowest-python-platform: ubuntu-22.04


### PR DESCRIPTION
This PR fixes a CI failure where the 'fast' job in the 'test-flaky' workflow failed to start because the 'platform' matrix vector was empty. We now provide a single platform and Python version to allow the matrix to initialize.