### PR TITLE
feat(remotebuild): add build-path to snap recipes

### DIFF
--- a/craft_application/launchpad/models/recipe.py
+++ b/craft_application/launchpad/models/recipe.py
@@ -171,6 +171,7 @@ class SnapRecipe(_StoreRecipe):
         owner: str,
         *,
         architectures: Collection[str] | None = None,
+        build_path: str | None = None,
         description: str | None = None,
         project: str | models.Project | None = None,
         information_type: models.InformationType | None = None,
@@ -194,6 +195,10 @@ class SnapRecipe(_StoreRecipe):
         :param owner: The username of the person or team who owns the recipe
         :param architectures: A collection of architecture names to build the recipe.
             If None, detects the architectures from `snapcraft.yaml`
+        :param build_path: (Optional) The sub-directory containing the project file.
+            The entire repo is uploaded, but Launchpad will set the cwd to the build
+            path before building the snap. Files and directories outside of the build
+            path won't be accesible.
         :param description: (Optional) A description of the recipe.
         :param project: (Optional) The project or name of the project to which to
             attach this recipe. Defines the information type of the repository if
@@ -220,6 +225,8 @@ class SnapRecipe(_StoreRecipe):
         kwargs: dict[str, Any] = {}
         if architectures:
             kwargs["processors"] = [util.get_processor(arch) for arch in architectures]
+        if build_path:
+            kwargs["build_path"] = build_path
         if description:
             kwargs["description"] = description
 

--- a/craft_application/launchpad/models/recipe.py
+++ b/craft_application/launchpad/models/recipe.py
@@ -198,7 +198,7 @@ class SnapRecipe(_StoreRecipe):
         :param build_path: (Optional) The sub-directory containing the project file.
             The entire repo is uploaded, but Launchpad will set the cwd to the build
             path before building the snap. Files and directories outside of the build
-            path won't be accesible.
+            path won't be accessible.
         :param description: (Optional) A description of the recipe.
         :param project: (Optional) The project or name of the project to which to
             attach this recipe. Defines the information type of the repository if

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -115,11 +115,21 @@ class RemoteBuildService(base.AppService):
         self._deadline = time.monotonic_ns() + (seconds_in_future * 10**9)
 
     def start_builds(
-        self, project_dir: pathlib.Path, architectures: Collection[str] | None = None
+        self,
+        project_dir: pathlib.Path,
+        architectures: Collection[str] | None = None,
+        build_path: str | None = None,
     ) -> Collection[launchpad.models.Build]:
         """Start one or more builds for the project.
 
         This method requires a project to be loaded.
+
+        :param project_dir: The directory containing the project to build.
+        :param architectures: (Optional) A collection of architectures to build for.
+        :param build_path: (Optional) The sub-directory containing the project file.
+            The entire repo is uploaded, but Launchpad will set the cwd to the build
+            path before building the artifact. Files and directories outside of the
+            build path won't be accesible.
         """
         if self._builds:
             raise ValueError("Cannot start builds if already running builds")
@@ -132,7 +142,10 @@ class RemoteBuildService(base.AppService):
         self._lp_project = self._ensure_project()
         _, self._repository = self._ensure_repository(project_dir)
         self._recipe = self._ensure_recipe(
-            self._name, self._repository, architectures=architectures
+            self._name,
+            self._repository,
+            architectures=architectures,
+            build_path=build_path,
         )
         self._check_timeout()
         self._builds = list(self._new_builds(self._recipe))

--- a/craft_application/services/remotebuild.py
+++ b/craft_application/services/remotebuild.py
@@ -129,7 +129,7 @@ class RemoteBuildService(base.AppService):
         :param build_path: (Optional) The sub-directory containing the project file.
             The entire repo is uploaded, but Launchpad will set the cwd to the build
             path before building the artifact. Files and directories outside of the
-            build path won't be accesible.
+            build path won't be accessible.
         """
         if self._builds:
             raise ValueError("Cannot start builds if already running builds")

--- a/tests/unit/launchpad/test_launchpad.py
+++ b/tests/unit/launchpad/test_launchpad.py
@@ -276,6 +276,48 @@ def test_recipe_new_info_type_in_project(
     )
 
 
+@pytest.mark.parametrize(
+    ("recipe", "recipe_name"),
+    [
+        (models.SnapRecipe, "snaps"),
+        (models.CharmRecipe, "charm_recipes"),
+        (models.RockRecipe, "rock_recipes"),
+    ],
+)
+@pytest.mark.parametrize("build_path", [None, "", "subdir"])
+def test_recipe_new_build_path(recipe, recipe_name, build_path):
+    """Pass build_path to the Launchpad API only when it's set."""
+    mock_launchpad = mock.Mock(spec=launchpad.Launchpad)
+    mock_launchpad.lp = mock.Mock(spec=launchpadlib.launchpad.Launchpad)
+    mock_recipe = mock.Mock()
+
+    mock_entry = mock.Mock(spec=Entry)
+    mock_entry.resource_type_link = "http://blah/#snap"
+    mock_entry.name = "test-recipe"
+
+    mock_recipe.new = mock.Mock(return_value=mock_entry)
+    setattr(mock_launchpad.lp, f"{recipe_name}", mock_recipe)
+
+    kwargs = {}
+    if recipe is not models.SnapRecipe:
+        kwargs["project"] = "test-project"
+
+    actual_recipe = recipe.new(
+        mock_launchpad,
+        "my_recipe",
+        "test_user",
+        git_ref="my_ref",
+        build_path=build_path,
+        **kwargs,
+    )
+
+    assert isinstance(actual_recipe, recipe)
+    if build_path:
+        assert mock_recipe.new.mock_calls[0].kwargs["build_path"] == build_path
+    else:
+        assert "build_path" not in mock_recipe.new.mock_calls[0].kwargs
+
+
 def test_recipe_snap_new_retry(emitter, mocker):
     """Test that a SnapRecipe is retried when it fails to create."""
     mocker.patch("time.sleep")

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -336,6 +336,27 @@ def test_create_new_recipe_archs(
     )
 
 
+def test_create_new_recipe_build_path(remote_build_service, mock_lp_project):
+    """Test that _new_recipe forwards build_path to the recipe."""
+    remote_build_service._lp_project = mock_lp_project
+    remote_build_service.RecipeClass = mock.Mock()
+    repo = mock.Mock(
+        git_https_url="https://localhost/~me/some-project/+git/my-repo",
+        private=False,
+    )
+
+    remote_build_service._new_recipe("test-recipe", repo, build_path="subdir")
+
+    remote_build_service.RecipeClass.new.assert_called_once_with(
+        remote_build_service.lp,
+        "test-recipe",
+        "craft_test_user",
+        git_ref="/~me/some-project/+git/my-repo/+ref/main",
+        project=mock_lp_project,
+        build_path="subdir",
+    )
+
+
 def test_not_setup(remote_build_service):
     with pytest.raises(RuntimeError):
         all(remote_build_service.monitor_builds())
@@ -467,14 +488,16 @@ def test_fetch_artifacts_url_decode(tmp_path, remote_build_service, mocker):
 
 
 @pytest.mark.parametrize("architectures", [["amd64"], None])
+@pytest.mark.parametrize("build_path", [None, "subdir"])
 @pytest.mark.usefixtures("mock_push_url")
 def test_new_build(
     tmp_path,
     remote_build_service,
     architectures,
+    build_path,
 ):
     git.GitRepo(tmp_path)
-    remote_build_service.start_builds(tmp_path, architectures)
+    remote_build_service.start_builds(tmp_path, architectures, build_path)
     remote_build_service.monitor_builds()
     remote_build_service.fetch_logs(tmp_path)
     remote_build_service.fetch_artifacts(tmp_path)

--- a/tests/unit/services/test_remotebuild.py
+++ b/tests/unit/services/test_remotebuild.py
@@ -497,7 +497,7 @@ def test_new_build(
     build_path,
 ):
     git.GitRepo(tmp_path)
-    remote_build_service.start_builds(tmp_path, architectures, build_path)
+    remote_build_service.start_builds(tmp_path, architectures, build_path=build_path)
     remote_build_service.monitor_builds()
     remote_build_service.fetch_logs(tmp_path)
     remote_build_service.fetch_artifacts(tmp_path)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [x] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Adds the [build-path](https://api.launchpad.net/devel.html#snaps-new) field to snap recipes and to the `RemoteBuildService`.

I tested this in a prototype branch in Snapcraft and it worked as-expected.

Fixes #1106
Unblocks https://github.com/canonical/snapcraft/issues/6287
(CRAFT-5244)