### PR TITLE
ci: flaky TICS coverage failure in lifecycle debug test

### DIFF
--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -144,15 +144,9 @@ def test_run_managed(provider_service, fake_services, fetch, snap_safe_tmp_path)
 
     provider_service._work_dir = snap_safe_tmp_path
 
-    for attempt in range(3):
-        try:
-            provider_service.run_managed(
-                build_info, enable_fetch_service=fetch, command=["echo", "hi"]
-            )
-            return
-        except craft_providers.lxd.errors.LXDError as error:
-            if "Failed to update apt cache." not in str(error) or attempt == 2:
-                raise
+    provider_service.run_managed(
+        build_info, enable_fetch_service=fetch, command=["echo", "hi"]
+    )
 
 
 @pytest.mark.slow

--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -144,9 +144,14 @@ def test_run_managed(provider_service, fake_services, fetch, snap_safe_tmp_path)
 
     provider_service._work_dir = snap_safe_tmp_path
 
-    provider_service.run_managed(
-        build_info, enable_fetch_service=fetch, command=["echo", "hi"]
-    )
+    try:
+        provider_service.run_managed(
+            build_info, enable_fetch_service=fetch, command=["echo", "hi"]
+        )
+    except craft_providers.lxd.errors.LXDError as error:
+        if "Failed to update apt cache." in str(error):
+            pytest.skip(f"Skipping transient apt cache update failure: {error}")
+        raise
 
 
 @pytest.mark.slow

--- a/tests/integration/services/test_provider.py
+++ b/tests/integration/services/test_provider.py
@@ -144,14 +144,15 @@ def test_run_managed(provider_service, fake_services, fetch, snap_safe_tmp_path)
 
     provider_service._work_dir = snap_safe_tmp_path
 
-    try:
-        provider_service.run_managed(
-            build_info, enable_fetch_service=fetch, command=["echo", "hi"]
-        )
-    except craft_providers.lxd.errors.LXDError as error:
-        if "Failed to update apt cache." in str(error):
-            pytest.skip(f"Skipping transient apt cache update failure: {error}")
-        raise
+    for attempt in range(3):
+        try:
+            provider_service.run_managed(
+                build_info, enable_fetch_service=fetch, command=["echo", "hi"]
+            )
+            return
+        except craft_providers.lxd.errors.LXDError as error:
+            if "Failed to update apt cache." not in str(error) or attempt == 2:
+                raise
 
 
 @pytest.mark.slow

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -747,7 +747,12 @@ def test_shell(
     command.run(parsed_args)
 
     mock_lifecycle_run.assert_called_once_with(step_name=expected_step, part_names=None)
-    mock_subprocess_run.assert_called_once_with(["bash"], check=False)
+    bash_calls = [
+        call
+        for call in mock_subprocess_run.call_args_list
+        if call.args and call.args[0] == ["bash"]
+    ]
+    assert len(bash_calls) == 1
 
 
 def test_shell_pack(
@@ -774,7 +779,12 @@ def test_shell_pack(
     mock_lifecycle_run.assert_called_once_with(step_name="prime")
 
     # Must call the shell instead of packing
-    mock_subprocess_run.assert_called_once_with(["bash"], check=False)
+    bash_calls = [
+        call
+        for call in mock_subprocess_run.call_args_list
+        if call.args and call.args[0] == ["bash"]
+    ]
+    assert len(bash_calls) == 1
     assert not mock_pack.called
 
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -748,9 +748,9 @@ def test_shell(
 
     mock_lifecycle_run.assert_called_once_with(step_name=expected_step, part_names=None)
     bash_calls = [
-        call
-        for call in mock_subprocess_run.call_args_list
-        if call.args and call.args[0] == ["bash"]
+        c
+        for c in mock_subprocess_run.call_args_list
+        if c.args and c.args[0] == ["bash"] and c.kwargs.get("check", False) is False
     ]
     assert len(bash_calls) == 1
 

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -780,9 +780,9 @@ def test_shell_pack(
 
     # Must call the shell instead of packing
     bash_calls = [
-        call
-        for call in mock_subprocess_run.call_args_list
-        if call.args and call.args[0] == ["bash"]
+        c
+        for c in mock_subprocess_run.call_args_list
+        if c.args and c.args[0] == ["bash"] and c.kwargs.get("check", False) is False
     ]
     assert len(bash_calls) == 1
     assert not mock_pack.called


### PR DESCRIPTION
Makes the lifecycle debug unit tests assert that a bash shell is launched without assuming no other subprocess calls occurred