### PR TITLE
docs: update craft providers intersphinx link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,7 +245,7 @@ intersphinx_mapping = {
         None,
     ),
     "craft-providers": (
-        "https://documentation.ubuntu.com/craft-providers/en/latest", None
+        "https://documentation.ubuntu.com/craft-providers/latest", None
     ),
     "starflow": (
         "https://documentation.ubuntu.com/starflow/latest", None


### PR DESCRIPTION
I removed the language slug recently.

---

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

