### PR TITLE
test: fix doc version tests

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -30,6 +30,7 @@ LaTeX
 latexmk
 Launchpadlib
 Makefile
+monorepo
 Multipass
 MyST
 namespaced

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -89,7 +89,7 @@ Commands can be classified as follows:
 
 For more information about a command, run 'testcraft help <command>'.
 For a summary of all commands, run 'testcraft help --all'.
-For more information about testcraft, check out: www.testcraft.example/docs/3.14159
+For more information about testcraft, check out: www.testcraft.example/docs/3
 
 """
 INVALID_COMMAND = """\
@@ -308,7 +308,7 @@ def test_get_command_help(monkeypatch, emitter, capsys, app, cmd, help_param):
     assert f"testcraft {cmd} [options]" in stderr
     assert stderr.endswith(
         "For more information, check out: "
-        f"www.testcraft.example/docs/3.14159/reference/commands/{cmd}\n\n"
+        f"www.testcraft.example/docs/3/reference/commands/{cmd}\n\n"
     )
 
 

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1103,7 +1103,7 @@ def test_emitter_docs_url(monkeypatch, mocker, app):
 
     assert app.app.docs_url == "www.testcraft.example/docs/{version}"
     assert app.app.version == "3.14159"
-    expected_url = "www.testcraft.example/docs/3.14159"
+    expected_url = "www.testcraft.example/docs/3"
 
     spied_init = mocker.spy(emit, "init")
 
@@ -1159,7 +1159,7 @@ def test_doc_url_in_general_help(help_args, monkeypatch, capsys, app):
     with pytest.raises(SystemExit):
         app.run()
 
-    expected = "For more information about testcraft, check out: www.testcraft.example/docs/3.14159\n\n"
+    expected = "For more information about testcraft, check out: www.testcraft.example/docs/3\n\n"
     _, err = capsys.readouterr()
     assert err.endswith(expected)
 
@@ -1173,6 +1173,6 @@ def test_doc_url_in_command_help(monkeypatch, capsys, app):
     with pytest.raises(SystemExit):
         app.run()
 
-    expected = "For more information, check out: www.testcraft.example/docs/3.14159/reference/commands/app-config\n\n"
+    expected = "For more information, check out: www.testcraft.example/docs/3/reference/commands/app-config\n\n"
     _, err = capsys.readouterr()
     assert err.endswith(expected)


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Fixes a test failure accidentally added by https://github.com/canonical/craft-application/pull/1140.