### PR TITLE
fix(lint): ignore PLR0917 in tests alongside PLR0913

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,6 +403,7 @@ classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
     "S103",    # Allow `os.chmod` setting a permissive mask `0o555` on file or directory
     "S108",    # Allow Probable insecure usage of temporary file or directory
     "PLR0913", # Allow many arguments for test functions (useful if we need many fixtures)
+    "PLR0917", # Allow many positional arguments for test functions (same reason as PLR0913)
     "PLR2004", # Allow magic values in tests
     "SLF",     # Allow accessing private members from tests.
     "FBT001",  # Boolean-typed parametrized tests can be useful


### PR DESCRIPTION
## Summary

\`make lint-ruff\` was failing with 9 \`PLR0917\` (too many positional arguments) errors across several test files that use many fixtures and \`@pytest.mark.parametrize\` decorators.

This extends the existing test per-file-ignore for \`PLR0913\` to also cover \`PLR0917\`, for the same reasoning: test functions often need many positional arguments for fixtures/parametrization.

## Testing

\`make lint-ruff\` now passes cleanly.