### PR TITLE
style(prettier): Ignore agent Markdown instructions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 tests/**/*.yaml
 docs/.sphinx
 .github/skills
+.github/instructions


### PR DESCRIPTION
Currently whenever we update instructions from copilot-collections, we get prettier complaints. We don't need to care about the format for those here, so we just ignore them instead.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
