### PR TITLE
docs: declare slug in config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ html_theme_options = {
   'source_edit_link': "https://github.com/canonical/craft-application",
 }
 
-# Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
+# The version slug passed to the sphinx-notfound-page extenssion
 slug = "craft-application"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ html_theme_options = {
   'source_edit_link': "https://github.com/canonical/craft-application",
 }
 
-# The version slug passed to the sphinx-notfound-page extension
+# The project slug passed to the sphinx-notfound-page extension
 slug = "craft-application"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ html_theme_options = {
   'source_edit_link': "https://github.com/canonical/craft-application",
 }
 
-# The version slug passed to the sphinx-notfound-page extenssion
+# The version slug passed to the sphinx-notfound-page extension
 slug = "craft-application"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ html_theme_options = {
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
-# slug = ''
+slug = "craft-application"
 
 
 #########################


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Canonical Sphinx uses this to configure the sphinx-notfound-page extension.

Live 404 page: https://documentation.ubuntu.com/craft-application/oops

PR build 404 page: https://canonical-ubuntu-documentation-library--1158.com.readthedocs.build/craft-application/1158/oops