### PR TITLE
fix: don't package projects with no parts

### DIFF
--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -532,6 +532,7 @@ class PackCommand(LifecycleCommand):
         if not self._project.parts:
             emit.debug("No parts to pack, skipping.")
             emit.progress("No packages created.", permanent=True)
+            self._services.package.write_artifacts_state({})
             if shell_after:
                 _launch_shell()
             return

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -485,10 +485,7 @@ class PackCommand(LifecycleCommand):
             return
 
         # Legacy packaging for applications not implementing ST160
-        if not self._project.parts:
-            emit.debug("No parts to pack, skipping.")
-            packages: list[pathlib.Path] = []
-        else:
+        if self._project.parts:
             emit.progress("Packing...")
             try:
                 packages = self._services.package.pack(
@@ -499,6 +496,9 @@ class PackCommand(LifecycleCommand):
                     emit.progress(str(err), permanent=True)
                     _launch_shell()
                 raise
+        else:
+            emit.debug("No parts to pack, skipping.")
+            packages: list[pathlib.Path] = []
 
         packages = self._relativize_paths(packages, root=pathlib.Path())
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -485,16 +485,20 @@ class PackCommand(LifecycleCommand):
             return
 
         # Legacy packaging for applications not implementing ST160
-        emit.progress("Packing...")
-        try:
-            packages = self._services.package.pack(
-                self.services.get("lifecycle").prime_dir, parsed_args.output
-            )
-        except Exception as err:
-            if debug:
-                emit.progress(str(err), permanent=True)
-                _launch_shell()
-            raise
+        if not self._project.parts:
+            emit.debug("No parts to pack, skipping.")
+            packages: list[pathlib.Path] = []
+        else:
+            emit.progress("Packing...")
+            try:
+                packages = self._services.package.pack(
+                    self.services.get("lifecycle").prime_dir, parsed_args.output
+                )
+            except Exception as err:
+                if debug:
+                    emit.progress(str(err), permanent=True)
+                    _launch_shell()
+                raise
 
         packages = self._relativize_paths(packages, root=pathlib.Path())
 
@@ -525,6 +529,13 @@ class PackCommand(LifecycleCommand):
         debug: bool,
     ) -> None:
         """Run the artifact-aware packing flow."""
+        if not self._project.parts:
+            emit.debug("No parts to pack, skipping.")
+            emit.progress("No packages created.", permanent=True)
+            if shell_after:
+                _launch_shell()
+            return
+
         emit.progress("Packing...")
         package_service = self._services.package
 

--- a/craft_application/services/package.py
+++ b/craft_application/services/package.py
@@ -282,6 +282,9 @@ class PackageService(base.AppService):
 
     def needs_packing(self, partition: str | None = None) -> bool:
         """Determine whether the given artifact/partition requires packing."""
+        if not self._project.parts:
+            emit.debug("No parts to pack, skipping.")
+            return False
         lifecycle = self._services.get("lifecycle")
         if (
             self._app.always_repack

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -626,6 +626,56 @@ def test_pack_fetch_manifest(
     assert mock_services.fetch.create_project_manifest.called == expect_create_called
 
 
+def test_pack_run_no_parts_legacy(
+    mocker, emitter, mock_services, app_metadata, tmp_path, fake_project
+):
+    """Legacy non-ST160 apps should skip packing when the project has no parts."""
+    mock_services.package.pack.return_value = [pathlib.Path("package.zip")]
+    project_service = mock_services.get("project")
+    project_service.configure(platform=None, build_for=None)
+    fake_project.parts = {}
+    mocker.patch.object(project_service, "get", return_value=fake_project)
+    command = PackCommand(
+        {
+            "app": app_metadata,
+            "services": mock_services,
+        }
+    )
+    mocker.patch.object(command._services.lifecycle.project_info, "work_dir", tmp_path)
+
+    parsed_args = argparse.Namespace(
+        destructive_mode=True, parts=None, output=tmp_path, fetch_service_policy=None
+    )
+    command.run(parsed_args)
+
+    mock_services.package.pack.assert_not_called()
+    emitter.assert_debug("No parts to pack, skipping.")
+    emitter.assert_progress("No packages created.", permanent=True)
+
+
+def test_pack_run_st160_no_parts(mocker, emitter, mock_services, app_metadata, tmp_path):
+    """ST160 apps should also skip packing when the project has no parts."""
+    mock_services.get("project").configure(platform=None, build_for=None)
+    mock_services.package.supports_conditional_repack = True
+    parsed_args = argparse.Namespace(
+        destructive_mode=True, output=tmp_path, fetch_service_policy=None
+    )
+    command = PackCommand(
+        {
+            "app": app_metadata,
+            "services": mock_services,
+        }
+    )
+    mocker.patch.object(command._services.lifecycle.project_info, "work_dir", tmp_path)
+    command._project.parts = {}
+
+    command.run(parsed_args)
+
+    mock_services.package.pack_artifacts.assert_not_called()
+    emitter.assert_debug("No parts to pack, skipping.")
+    emitter.assert_progress("No packages created.", permanent=True)
+
+
 def test_pack_run_st160(mocker, emitter, mock_services, app_metadata, tmp_path):
     mock_services.get("project").configure(platform=None, build_for=None)
     mock_services.package.supports_conditional_repack = True

--- a/tests/unit/commands/test_lifecycle.py
+++ b/tests/unit/commands/test_lifecycle.py
@@ -653,7 +653,9 @@ def test_pack_run_no_parts_legacy(
     emitter.assert_progress("No packages created.", permanent=True)
 
 
-def test_pack_run_st160_no_parts(mocker, emitter, mock_services, app_metadata, tmp_path):
+def test_pack_run_st160_no_parts(
+    mocker, emitter, mock_services, app_metadata, tmp_path
+):
     """ST160 apps should also skip packing when the project has no parts."""
     mock_services.get("project").configure(platform=None, build_for=None)
     mock_services.package.supports_conditional_repack = True

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -211,6 +211,22 @@ def test_needs_packing_false_when_artifact_exists(
     assert service.needs_packing(None) is False
 
 
+def test_needs_packing_false_when_no_parts(
+    app_metadata, fake_project, fake_services, tmp_path, emitter
+):
+    """When the project has no parts, no artifact should require packing."""
+    artifact_path = tmp_path / "artifact"
+    artifact_path.touch()
+    service = MultiArtifactPackageService(
+        app_metadata, fake_services, artifacts={None: artifact_path}
+    )
+    fake_project.parts = {}
+    service._services.get("project").set(fake_project)
+
+    assert service.needs_packing(None) is False
+    emitter.assert_debug("No parts to pack, skipping.")
+
+
 @pytest.mark.parametrize(
     ("project_updated", "expected"),
     [(True, True), (False, False)],

--- a/tests/unit/services/test_package.py
+++ b/tests/unit/services/test_package.py
@@ -217,11 +217,11 @@ def test_needs_packing_false_when_no_parts(
     """When the project has no parts, no artifact should require packing."""
     artifact_path = tmp_path / "artifact"
     artifact_path.touch()
+    fake_services.get("project").set(fake_project)
     service = MultiArtifactPackageService(
         app_metadata, fake_services, artifacts={None: artifact_path}
     )
     fake_project.parts = {}
-    service._services.get("project").set(fake_project)
 
     assert service.needs_packing(None) is False
     emitter.assert_debug("No parts to pack, skipping.")


### PR DESCRIPTION
Skip package creation When a project has no parts defined.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
CRAFT-4693