### PR TITLE
feat: support testing of multi-artifact projects

### DIFF
--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -17,9 +17,14 @@
 
 import pathlib
 import re
+from typing import TYPE_CHECKING
 
 import pydantic
 from typing_extensions import Any, Self
+
+if TYPE_CHECKING:
+    from .state import PackedArtifact
+
 
 from craft_application.models import CraftBaseModel
 

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Models representing spread projects."""
 
-import pathlib
 import re
 from typing import TYPE_CHECKING
 

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -229,8 +229,7 @@ class SpreadYaml(SpreadBaseModel):
         simple: CraftSpreadYaml,
         *,
         craft_backend: SpreadBackend,
-        artifact: pathlib.Path,
-        resources: dict[str, pathlib.Path],
+        artifacts: list["PackedArtifact"],
     ) -> Self:
         """Create the spread configuration from the simplified version."""
         environment = {
@@ -239,12 +238,17 @@ class SpreadYaml(SpreadBaseModel):
             "LANG": "C.UTF-8",
             "LANGUAGE": "en",
             "PROJECT_PATH": "/root/proj",
-            "CRAFT_ARTIFACT": f"$PROJECT_PATH/{artifact}",
         }
 
-        for name, path in resources.items():
-            var_name = cls._translate_resource_name(name)
-            environment[f"CRAFT_RESOURCE_{var_name}"] = f"$PROJECT_PATH/{path}"
+        for artifact in artifacts:
+            if artifact.name is None:
+                environment["CRAFT_ARTIFACT"] = f"$PROJECT_PATH/{artifact.path}"
+                continue
+
+            var_name = cls._translate_resource_name(artifact.name)
+            environment[f"CRAFT_ARTIFACT_{var_name}"] = (
+                f"$PROJECT_PATH/{artifact.path}"
+            )
 
         return cls(
             project="craft-test",

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -250,9 +250,7 @@ class SpreadYaml(SpreadBaseModel):
                 continue
 
             var_name = cls._translate_resource_name(artifact.name)
-            environment[f"CRAFT_ARTIFACT_{var_name}"] = (
-                f"$PROJECT_PATH/{artifact.path}"
-            )
+            environment[f"CRAFT_ARTIFACT_{var_name}"] = f"$PROJECT_PATH/{artifact.path}"
 
         return cls(
             project="craft-test",

--- a/craft_application/services/testing.py
+++ b/craft_application/services/testing.py
@@ -106,7 +106,7 @@ class TestingService(base.AppService):
 
         craft_backend = self._get_backend()
 
-        if not pack_state.artifact:
+        if not pack_state.artifacts:
             raise CraftError(
                 f"No {self._app.artifact_type} files to test.",
                 resolution=f"Ensure that {self._app.artifact_type} files are generated before running the test.",
@@ -115,8 +115,7 @@ class TestingService(base.AppService):
         spread_yaml = models.SpreadYaml.from_craft(
             simple,
             craft_backend=craft_backend,
-            artifact=pack_state.artifact,
-            resources=pack_state.resources or {},
+            artifacts=pack_state.artifacts,
         )
 
         emit.trace(f"Writing processed spread file to {dest}")

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,15 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+Unreleased
+----------
+
+Services
+========
+
+- The testing service now handles multiple artifacts by defining variables
+  ``CRAFT_ARTIFACT_<name>`` in the Spread test environment.
+
 7.2.0 (2028-08-11)
 ------------------
 

--- a/tests/unit/models/test_spread.py
+++ b/tests/unit/models/test_spread.py
@@ -122,9 +122,7 @@ def test_spread_yaml_from_craft_spread():
         craft_backend=backend,
         artifacts=[
             models.PackedArtifact(name=None, path=pathlib.Path("artifact")),
-            models.PackedArtifact(
-                name="my-resource", path=pathlib.Path("resource")
-            ),
+            models.PackedArtifact(name="my-resource", path=pathlib.Path("resource")),
         ],
     )
 

--- a/tests/unit/models/test_spread.py
+++ b/tests/unit/models/test_spread.py
@@ -20,6 +20,7 @@ import pathlib
 
 import pytest
 from craft_application import util
+from craft_application import models
 from craft_application.models import spread as model
 
 
@@ -120,8 +121,12 @@ def test_spread_yaml_from_craft_spread():
     spread = model.SpreadYaml.from_craft(
         craft_spread,
         craft_backend=backend,
-        artifact=pathlib.Path("artifact"),
-        resources={"my-resource": pathlib.Path("resource")},
+        artifacts=[
+            models.PackedArtifact(name=None, path=pathlib.Path("artifact")),
+            models.PackedArtifact(
+                name="my-resource", path=pathlib.Path("resource")
+            ),
+        ],
     )
 
     assert (
@@ -135,7 +140,7 @@ def test_spread_yaml_from_craft_spread():
                 "LANGUAGE": "en",
                 "PROJECT_PATH": "/root/proj",
                 "CRAFT_ARTIFACT": "$PROJECT_PATH/artifact",
-                "CRAFT_RESOURCE_MY_RESOURCE": "$PROJECT_PATH/resource",
+                "CRAFT_ARTIFACT_MY_RESOURCE": "$PROJECT_PATH/resource",
             },
             backends={
                 "craft": model.SpreadBackend(
@@ -197,3 +202,20 @@ def test_spread_yaml_from_craft_spread():
 def test_translate_resource_name(name, var):
     var_name = model.SpreadYaml._translate_resource_name(name)
     assert var_name == var
+
+
+def test_spread_yaml_from_craft_named_artifacts_only():
+    backend = model.SpreadBackend(type="type")
+    data = util.safe_yaml_load(io.StringIO(_CRAFT_SPREAD))
+    craft_spread = model.CraftSpreadYaml.unmarshal(data)
+
+    spread = model.SpreadYaml.from_craft(
+        craft_spread,
+        craft_backend=backend,
+        artifacts=[
+            models.PackedArtifact(name="my-resource", path=pathlib.Path("resource")),
+        ],
+    )
+
+    assert spread.environment["CRAFT_ARTIFACT_MY_RESOURCE"] == "$PROJECT_PATH/resource"
+    assert "CRAFT_ARTIFACT" not in spread.environment

--- a/tests/unit/models/test_spread.py
+++ b/tests/unit/models/test_spread.py
@@ -19,8 +19,7 @@ import io
 import pathlib
 
 import pytest
-from craft_application import util
-from craft_application import models
+from craft_application import models, util
 from craft_application.models import spread as model
 
 

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -231,7 +231,11 @@ def test_process_spread_yaml_accepts_named_artifacts_only(
     state = models.PackState(
         artifacts=[models.PackedArtifact(name="tools", path=pathlib.Path("tools.tar"))]
     )
-    mocker.patch.object(testing_service, "_get_backend", return_value=mock.Mock())
+    mocker.patch.object(
+        testing_service,
+        "_get_backend",
+        return_value=models.SpreadBackend(type="adhoc"),
+    )
 
     dest = tmp_path / "processed-spread.yaml"
     monkeypatch.chdir(tmp_path)
@@ -260,7 +264,11 @@ def test_process_spread_yaml_requires_any_artifact(
             """)
     )
     state = models.PackState(artifacts=[])
-    mocker.patch.object(testing_service, "_get_backend", return_value=mock.Mock())
+    mocker.patch.object(
+        testing_service,
+        "_get_backend",
+        return_value=models.SpreadBackend(type="adhoc"),
+    )
 
     dest = tmp_path / "processed-spread.yaml"
     monkeypatch.chdir(tmp_path)

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -208,6 +208,43 @@ def test_process_without_spread_file(new_dir, testing_service):
         testing_service.process_spread_yaml(new_dir / "wherever", state)
 
 
+def test_process_spread_yaml_accepts_named_artifacts_only(
+    testing_service: TestingService,
+    tmp_path: pathlib.Path,
+    mocker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    spread_file = tmp_path / "spread.yaml"
+    spread_file.write_text("project: test-project\n")
+    state = models.PackState(
+        artifacts=[models.PackedArtifact(name="tools", path=pathlib.Path("tools.tar"))]
+    )
+    mocker.patch.object(testing_service, "_get_backend", return_value=mock.Mock())
+
+    dest = tmp_path / "processed-spread.yaml"
+    monkeypatch.chdir(tmp_path)
+    testing_service.process_spread_yaml(dest, state)
+
+    assert "CRAFT_ARTIFACT_TOOLS: $PROJECT_PATH/tools.tar" in dest.read_text()
+
+
+def test_process_spread_yaml_requires_any_artifact(
+    testing_service: TestingService,
+    tmp_path: pathlib.Path,
+    mocker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    spread_file = tmp_path / "spread.yaml"
+    spread_file.write_text("project: test-project\n")
+    state = models.PackState(artifacts=[])
+    mocker.patch.object(testing_service, "_get_backend", return_value=mock.Mock())
+
+    dest = tmp_path / "processed-spread.yaml"
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(CraftError, match="No .* files to test"):
+        testing_service.process_spread_yaml(dest, state)
+
+
 @pytest.mark.parametrize(
     ("env_var", "value", "testspec"),
     [("", "", "craft"), ("CI", "1", "craft:id-1.0")],

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -18,6 +18,7 @@
 import pathlib
 import stat
 from collections.abc import Iterable
+from textwrap import dedent
 from typing import Any
 from unittest import mock
 
@@ -215,7 +216,16 @@ def test_process_spread_yaml_accepts_named_artifacts_only(
     monkeypatch: pytest.MonkeyPatch,
 ):
     spread_file = tmp_path / "spread.yaml"
-    spread_file.write_text("project: test-project\n")
+    spread_file.write_text(dedent("""
+            project: test-project
+            backends:
+              craft:
+                systems:
+                  - ubuntu-24.04:
+            suites:
+              spread/general/:
+                summary: General tests
+            """))
     state = models.PackState(
         artifacts=[models.PackedArtifact(name="tools", path=pathlib.Path("tools.tar"))]
     )
@@ -235,7 +245,16 @@ def test_process_spread_yaml_requires_any_artifact(
     monkeypatch: pytest.MonkeyPatch,
 ):
     spread_file = tmp_path / "spread.yaml"
-    spread_file.write_text("project: test-project\n")
+    spread_file.write_text(dedent("""
+            project: test-project
+            backends:
+              craft:
+                systems:
+                  - ubuntu-24.04:
+            suites:
+              spread/general/:
+                summary: General tests
+            """))
     state = models.PackState(artifacts=[])
     mocker.patch.object(testing_service, "_get_backend", return_value=mock.Mock())
 

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -216,7 +216,8 @@ def test_process_spread_yaml_accepts_named_artifacts_only(
     monkeypatch: pytest.MonkeyPatch,
 ):
     spread_file = tmp_path / "spread.yaml"
-    spread_file.write_text(dedent("""
+    spread_file.write_text(
+        dedent("""
             project: test-project
             backends:
               craft:
@@ -225,7 +226,8 @@ def test_process_spread_yaml_accepts_named_artifacts_only(
             suites:
               spread/general/:
                 summary: General tests
-            """))
+            """)
+    )
     state = models.PackState(
         artifacts=[models.PackedArtifact(name="tools", path=pathlib.Path("tools.tar"))]
     )
@@ -245,7 +247,8 @@ def test_process_spread_yaml_requires_any_artifact(
     monkeypatch: pytest.MonkeyPatch,
 ):
     spread_file = tmp_path / "spread.yaml"
-    spread_file.write_text(dedent("""
+    spread_file.write_text(
+        dedent("""
             project: test-project
             backends:
               craft:
@@ -254,7 +257,8 @@ def test_process_spread_yaml_requires_any_artifact(
             suites:
               spread/general/:
                 summary: General tests
-            """))
+            """)
+    )
     state = models.PackState(artifacts=[])
     mocker.patch.object(testing_service, "_get_backend", return_value=mock.Mock())
 


### PR DESCRIPTION
Define` CRAFT_ARTIFACT_<name>` in the spread environment for each artifact
generated by the project. This allows testing in tools that can generate multiple
artifacts, such as Debcraft.

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
CRAFT-5257