### PR TITLE
feat(test): parse <app-name>-test.yaml, deprecate spread.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 .results.*.xml
-/.spread-*.yaml
+.spread-*.yaml
 
 # Translations
 *.mo

--- a/craft_application/application.py
+++ b/craft_application/application.py
@@ -122,6 +122,12 @@ class AppMetadata:
     enable_pro_support: bool = False
     """Whether this application supports Ubuntu Pro services."""
 
+    allow_spread_yaml: bool = True
+    """Whether the 'test' command can use the deprecated spread.yaml file.
+
+    Defaults to True for backward compatibility but new apps should set this to False.
+    """
+
     allow_git_build_root: bool = False
     """Whether to allow mounting the git working tree root as the build root.
 

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -22,16 +22,13 @@ import subprocess
 import textwrap
 from typing import Any, Literal, cast
 
-import pydantic
 from craft_cli import CommandGroup, CraftError, emit
 from craft_parts.features import Features
 from typing_extensions import override
 
 from craft_application import errors, util
 from craft_application.commands import base
-from craft_application.errors import TestFileError
 from craft_application.util import ProServices
-from craft_application.util.error_formatting import format_pydantic_errors
 from craft_application.util.logging import handle_runtime_error
 
 
@@ -652,10 +649,9 @@ class PackCommand(LifecycleCommand):
 class TestCommand(PackCommand):
     """Command to run project tests.
 
-    The test command invokes the spread command with a processed spread.yaml
-    configuration file.
+    The test command invokes spread with a processed test config file.
 
-    This command is opt-in for applications in craft-application 5 and will become
+    This command is opt-in for applications and will become
     a standard lifecycle command in a future major release.
     """
 
@@ -695,15 +691,8 @@ class TestCommand(PackCommand):
         parsed_args.output = pathlib.Path.cwd()
 
         testing_service = self._services.get("testing")
-        # Fail early if spread.yaml is invalid.
-        try:
-            testing_service.parse_spread_yaml()
-        except pydantic.ValidationError as exc:
-            raise TestFileError(
-                format_pydantic_errors(exc.errors(), file_name="spread.yaml"),
-                reportable=False,
-                retcode=os.EX_DATAERR,
-            )
+        # Fail early if the test config file is invalid.
+        testing_service.parse_spread_yaml()
 
         if util.is_managed_mode():
             # If we're in managed mode, we just need to pack.

--- a/craft_application/commands/lifecycle.py
+++ b/craft_application/commands/lifecycle.py
@@ -692,7 +692,7 @@ class TestCommand(PackCommand):
 
         testing_service = self._services.get("testing")
         # Fail early if the test config file is invalid.
-        testing_service.parse_spread_yaml()
+        testing_service.parse_test_config()
 
         if util.is_managed_mode():
             # If we're in managed mode, we just need to pack.

--- a/craft_application/errors.py
+++ b/craft_application/errors.py
@@ -49,7 +49,7 @@ class ProjectFileError(CraftError):
 
 
 class TestFileError(CraftError):
-    """Errors to do with the craft test or spread file."""
+    """Errors to do with the test config file or the deprecated spread.yaml file."""
 
 
 class ProjectGenerationError(CraftError):

--- a/craft_application/models/__init__.py
+++ b/craft_application/models/__init__.py
@@ -41,6 +41,7 @@ from craft_application.models.project import (
 )
 from craft_application.models.spread import (
     CraftSpreadYaml,
+    CraftTestYaml,
     SpreadBackend,
     SpreadYaml,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "ProjectName",
     "ProjectTitle",
     "CraftSpreadYaml",
+    "CraftTestYaml",
     "SpreadBackend",
     "SpreadYaml",
     "SummaryStr",

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -71,15 +71,14 @@ class CraftSpreadSuite(SpreadBase):
     kill_timeout: str | None = None
 
 
-class CraftSpreadYaml(SpreadBase):
-    """Simplified spread project configuration."""
+class CraftTestYaml(SpreadBase):
+    """Simplified spread project configuration for a craft test file."""
 
     model_config = pydantic.ConfigDict(
         SpreadBase.model_config,
         extra="forbid",
     )
 
-    project: str | None = None
     backends: dict[str, CraftSpreadBackend]
     suites: dict[str, CraftSpreadSuite]
     exclude: list[str] | None = None
@@ -90,6 +89,18 @@ class CraftSpreadYaml(SpreadBase):
     restore_each: str | None = None
     debug_each: str | None = None
     kill_timeout: str | None = None
+
+
+class CraftSpreadYaml(CraftTestYaml):
+    """Deprecated craft test spread.yaml.
+
+    This is different than a standard spread.yaml, which is used directly with spread.
+
+    The deprecated craft test spread.yaml is a subset of a standard spread.yaml. It
+    doesn't allow the 'path', 'environment', and 'include 'keys.
+    """
+
+    project: str | None = None
 
 
 # Processed full-form spread configuration
@@ -226,7 +237,7 @@ class SpreadYaml(SpreadBaseModel):
     @classmethod
     def from_craft(
         cls,
-        simple: CraftSpreadYaml,
+        simple: CraftTestYaml,
         *,
         craft_backend: SpreadBackend,
         artifact: pathlib.Path,

--- a/craft_application/models/spread.py
+++ b/craft_application/models/spread.py
@@ -97,7 +97,7 @@ class CraftSpreadYaml(CraftTestYaml):
     This is different than a standard spread.yaml, which is used directly with spread.
 
     The deprecated craft test spread.yaml is a subset of a standard spread.yaml. It
-    doesn't allow the 'path', 'environment', and 'include 'keys.
+    doesn't allow the 'path', 'environment', and 'include' keys.
     """
 
     project: str | None = None

--- a/craft_application/services/lifecycle.py
+++ b/craft_application/services/lifecycle.py
@@ -264,12 +264,17 @@ class LifecycleService(base.AppService):
             *self._app.source_ignore_patterns,
         ]
 
-        # Ignore spread.yaml, .spread-reuse.* and spread to prevent repulling sources
-        # when test files are changed.
+        # Ignore the test config file, the deprecated spread.yaml file,
+        # .spread-reuse.* and spread to prevent repulling sources when test
+        # files are changed.
         ignore_outdated = (
             source_ignore_patterns
             + [".spread-reuse.*"]
-            + (["spread.yaml", "spread"] if Path("spread/.extension").exists() else [])
+            + (
+                [f"{self._app.name}-test.yaml", "spread.yaml", "spread"]
+                if Path("spread/.extension").exists()
+                else []
+            )
         )
 
         try:

--- a/craft_application/services/testing.py
+++ b/craft_application/services/testing.py
@@ -26,9 +26,12 @@ from collections.abc import Iterable
 
 import craft_platforms
 import distro
+import pydantic
 from craft_cli import CraftError, emit
 
 from craft_application import models, util
+from craft_application.errors import TestFileError
+from craft_application.util.error_formatting import format_pydantic_errors
 
 from . import base
 
@@ -37,6 +40,12 @@ class TestingService(base.AppService):
     """Service class for testing a project."""
 
     __test__ = False  # Tell pytest this service is not a test class.
+
+    _resolved_test_config_path: pathlib.Path | None = None
+    """The resolved test config path.
+
+    Cached for performance and to avoid re-emitting deprecation warnings.
+    """
 
     def test(
         self,
@@ -52,7 +61,8 @@ class TestingService(base.AppService):
 
         This method is likely the all you need to call.
 
-        :param project_path: The path to the project directory containing spread.yaml.
+        :param project_path: The path to the project directory containing the
+            test config file or the deprecated spread.yaml file.
         :param pack_state: An object containing the list of packed artifacts.
         :param test_expressions: A list of spread test expressions.
         :param shell: Whether to shell into the spread test instance.
@@ -76,31 +86,116 @@ class TestingService(base.AppService):
                 debug=debug,
             )
 
-    def parse_spread_yaml(self) -> models.CraftSpreadYaml:
-        """Read and parse the spread.yaml file for this project."""
-        spread_path = pathlib.Path("spread.yaml")
-        if not spread_path.is_file():
+    def parse_spread_yaml(self) -> models.CraftTestYaml:
+        """Read and parse the test config file for this project.
+
+        :raises TestFileError: if the test config file is invalid.
+        """
+        test_path = self._resolve_test_config_path()
+        with test_path.open() as file:
+            data = util.safe_yaml_load(file)
+
+        if test_path.name == "spread.yaml":
+            model = models.CraftSpreadYaml
+        else:
+            model = models.CraftTestYaml
+
+        try:
+            parsed = model.unmarshal(data)
+        except pydantic.ValidationError as exc:
+            raise TestFileError(
+                format_pydantic_errors(exc.errors(), file_name=test_path.name),
+                reportable=False,
+                retcode=os.EX_DATAERR,
+            ) from exc
+
+        return parsed
+
+    def _resolve_test_config_path(self) -> pathlib.Path:
+        """Locate the test config file.
+
+        :raises CraftError: if no usable test config file is found
+        """
+        if self._resolved_test_config_path is not None:
+            return self._resolved_test_config_path
+
+        # If '<app-name>-test.yaml' exists, parse it.
+        test_file_name = f"{self._app.name}-test.yaml"
+        test_path = pathlib.Path(test_file_name)
+        if test_path.is_file():
+            self._resolved_test_config_path = test_path
+            return test_path
+
+        # If '<app-name>-test.yaml' doesn't exist, check for a deprecated spread.yaml
+        # that contains a craft backend.
+        spread_yaml_path = pathlib.Path("spread.yaml")
+        if not (
+            spread_yaml_path.is_file() and self._is_craft_test_file(spread_yaml_path)
+        ):
             raise CraftError(
-                "Could not find 'spread.yaml' in the current directory.",
-                resolution="Ensure you are in the correct directory or create a spread.yaml file.",
+                f"Could not find {test_file_name!r}.",
+                resolution=(
+                    "Ensure you are in the correct directory or create a "
+                    f"{test_file_name!r} file with '{self._app.name} init --profile test'."
+                ),
                 reportable=False,
                 logpath_report=False,
                 retcode=os.EX_CONFIG,
             )
 
-        with spread_path.open() as file:
-            data = util.safe_yaml_load(file)
+        # If the app isn't allowed to parse spread files, raise an error.
+        if not self._app.allow_spread_yaml:
+            raise CraftError(
+                f"'spread.yaml' cannot be used for '{self._app.name} test'.",
+                resolution=(
+                    f"Rename 'spread.yaml' to '{test_file_name}' and "
+                    "remove the 'project' key, if defined."
+                ),
+                reportable=False,
+                logpath_report=False,
+                retcode=os.EX_CONFIG,
+            )
 
-        return models.CraftSpreadYaml.unmarshal(data)
+        # If the app is allowed to parse spread files, emit a deprecation warning and parse it.
+        if not util.is_managed_mode():
+            emit.warning(
+                f"'spread.yaml' is deprecated for '{self._app.name} test'. "
+                f"Rename it to '{test_file_name}' and remove the 'project' key, if defined."
+            )
+
+        self._resolved_test_config_path = spread_yaml_path
+        return spread_yaml_path
+
+    @staticmethod
+    def _is_craft_test_file(path: pathlib.Path) -> bool:
+        """Check whether a spread config file is used for craft tests.
+
+        This is a simple check that looks for a 'craft' backend.
+
+        The intent is to sort out projects that used spread.yaml for the 'test' command
+        versus projects that used spread and had their own spread.yaml
+        """
+        try:
+            with path.open() as file:
+                data = util.safe_yaml_load(file)
+        except (OSError, CraftError):
+            return False
+
+        if not isinstance(data, dict):
+            return False
+
+        backends = data.get("backends")
+        return isinstance(backends, dict) and "craft" in backends
 
     def process_spread_yaml(
         self, dest: pathlib.Path, pack_state: models.PackState
     ) -> None:
-        """Process the spread configuration file.
+        """Process the test config file into a spread config file.
 
-        :param dest: the output path for spread.yaml.
+        :param dest: the output path for the generated spread.yaml file.
         """
-        emit.debug("Processing spread.yaml.")
+        test_path = self._resolve_test_config_path()
+        emit.debug(f"Processing '{test_path.name}'.")
 
         simple = self.parse_spread_yaml()
 

--- a/craft_application/services/testing.py
+++ b/craft_application/services/testing.py
@@ -86,9 +86,10 @@ class TestingService(base.AppService):
                 debug=debug,
             )
 
-    def parse_spread_yaml(self) -> models.CraftTestYaml:
+    def parse_test_config(self) -> models.CraftTestYaml:
         """Read and parse the test config file for this project.
 
+        :raises CraftError: if no usable test config file is found.
         :raises TestFileError: if the test config file is invalid.
         """
         test_path = self._resolve_test_config_path()
@@ -197,7 +198,7 @@ class TestingService(base.AppService):
         test_path = self._resolve_test_config_path()
         emit.debug(f"Processing '{test_path.name}'.")
 
-        simple = self.parse_spread_yaml()
+        simple = self.parse_test_config()
 
         craft_backend = self._get_backend()
 

--- a/craft_application/services/testing.py
+++ b/craft_application/services/testing.py
@@ -179,8 +179,8 @@ class TestingService(base.AppService):
         try:
             with path.open() as file:
                 data = util.safe_yaml_load(file)
-        except (OSError, CraftError):
-            return False
+        except OSError as err:
+            raise CraftError(f"Could not read {str(path)!r}.") from err
 
         if not isinstance(data, dict):
             return False

--- a/docs/reference/changelog.rst
+++ b/docs/reference/changelog.rst
@@ -15,6 +15,22 @@ Changelog
 
     For a complete list of commits, check out the `1.2.3`_ release on GitHub.
 
+7.3.0 (unreleased)
+------------------
+
+Application
+===========
+
+- A new ``AppMetadata.allow_spread_yaml`` setting controls whether the ``test`` command
+  can fall back to the deprecated ``spread.yaml``.
+
+Commands
+========
+
+- The ``spread.yaml`` file for the ``test`` command has been deprecated in favor
+  of ``<app-name>-test.yaml``.
+
+
 7.2.0 (2028-08-11)
 ------------------
 

--- a/tests/integration/commands/test_lifecycle.py
+++ b/tests/integration/commands/test_lifecycle.py
@@ -60,7 +60,7 @@ def test_test_with_bad_spread_yaml(
     """Initialise a project."""
     app.add_command_group("Lifecycle", [TestCommand], ordered=True)
     monkeypatch.setattr("sys.argv", ["testcraft", "test"])
-    spread_file = new_dir / "spread.yaml"
+    spread_file = new_dir / "testcraft-test.yaml"
     spread_file.write_text("summary: An incomplete test file.")
 
     retcode = app.run()
@@ -68,6 +68,6 @@ def test_test_with_bad_spread_yaml(
 
     assert retcode == os.EX_DATAERR
     assert re.match(
-        r"^Bad spread.yaml content:\n- field 'backends' required in top-level configuration",
+        r"^Bad testcraft-test.yaml content:\n- field 'backends' required in top-level configuration",
         stderr,
     )

--- a/tests/spread/testcraft/test-cmd/task.yaml
+++ b/tests/spread/testcraft/test-cmd/task.yaml
@@ -5,14 +5,22 @@ systems:
 
 environment:
   CI: "1"
+  CRAFT_VERBOSITY_LEVEL: TRACE
 
 execute: |
-  CRAFT_VERBOSITY_LEVEL=TRACE testcraft test 2>&1 | tee test_out.log
+  testcraft test 2>&1 | tee test_out.log
   grep -q "platform 'a'" test_out.log
   grep -q "platform 'b'" test_out.log
   testcraft test other:...:tests/spread/my-suite/my-task 2>&1 | MATCH "No matches"
 
+  # verify deprecated spread.yaml can be used
+  mv testcraft-test.yaml spread.yaml
+
+  testcraft test 2>&1 | tee deprecated_test_out.log
+  MATCH "'spread.yaml' is deprecated for 'testcraft test'" < deprecated_test_out.log
+
 restore: |
   rm -f *.testcraft
   testcraft clean
-  rm -f test_out.log retest_out.log
+  rm -f test_out.log deprecated_test_out.log retest_out.log
+  mv -f spread.yaml testcraft-test.yaml 2>/dev/null || true

--- a/tests/spread/testcraft/test-cmd/testcraft-test.yaml
+++ b/tests/spread/testcraft/test-cmd/testcraft-test.yaml
@@ -1,5 +1,3 @@
-project: test-cmd
-
 backends:
   craft:
     type: craft
@@ -32,4 +30,3 @@ suites:
       https_proxy: '$(HOST: echo "$https_proxy")'
       NO_PROXY: '$(HOST: echo "$NO_PROXY")'
       no_proxy: '$(HOST: echo "$no_proxy")'
-

--- a/tests/unit/models/test_spread.py
+++ b/tests/unit/models/test_spread.py
@@ -18,6 +18,7 @@
 import io
 import pathlib
 
+import pydantic
 import pytest
 from craft_application import util
 from craft_application.models import spread as model
@@ -197,3 +198,38 @@ def test_spread_yaml_from_craft_spread():
 def test_translate_resource_name(name, var):
     var_name = model.SpreadYaml._translate_resource_name(name)
     assert var_name == var
+
+
+@pytest.mark.parametrize("key", ["project", "path", "environment", "include"])
+def test_craft_test_yaml_spread_keys_error(key):
+    """Error when using spread keys that aren't allowed in <app-name>-test.yaml."""
+    data = {
+        "backends": {"craft": {"systems": []}},
+        "suites": {},
+        key: "value",
+    }
+    with pytest.raises(pydantic.ValidationError):
+        model.CraftTestYaml.unmarshal(data)
+
+
+@pytest.mark.parametrize("key", ["path", "environment", "include"])
+def test_craft_spread_yaml_spread_keys_error(key):
+    """Error when using spread keys that aren't allowed in spread.yaml."""
+    data = {
+        "backends": {"craft": {"systems": []}},
+        "suites": {},
+        key: "value",
+    }
+    with pytest.raises(pydantic.ValidationError):
+        model.CraftSpreadYaml.unmarshal(data)
+
+
+def test_craft_spread_yaml_allows_project():
+    """'spread.yaml' allows the 'project' key."""
+    data = {
+        "backends": {"craft": {"systems": []}},
+        "suites": {},
+        "project": "my-project",
+    }
+    parsed = model.CraftSpreadYaml.unmarshal(data)
+    assert parsed.project == "my-project"

--- a/tests/unit/services/test_lifecycle.py
+++ b/tests/unit/services/test_lifecycle.py
@@ -356,6 +356,7 @@ def test_init_parts_ignore_test_files(
         "*.charm",
         "*.starcraft",
         ".spread-reuse.*",
+        "testcraft-test.yaml",
         "spread.yaml",
         "spread",
     ]

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -15,6 +15,7 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for the TestingService."""
 
+import dataclasses
 import pathlib
 import stat
 from collections.abc import Iterable
@@ -26,6 +27,7 @@ import craft_cli.messages
 import craft_platforms
 import pytest
 from craft_application import models
+from craft_application.errors import TestFileError
 from craft_application.services.testing import TestingService
 from craft_cli import CraftError
 
@@ -204,8 +206,149 @@ def test_get_app_spread_executable_error(
 
 def test_process_without_spread_file(new_dir, testing_service):
     state = models.PackState(artifacts=[])
-    with pytest.raises(CraftError, match="Could not find 'spread.yaml'"):
+    with pytest.raises(CraftError, match="Could not find 'testcraft-test.yaml'"):
         testing_service.process_spread_yaml(new_dir / "wherever", state)
+
+
+def test_parse_spread_yaml_uses_craft_test_yaml(
+    in_project_path: pathlib.Path, default_app_metadata, emitter
+):
+    """Prefer a test config file is used and over a spread.yaml"""
+    testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
+
+    (in_project_path / "testcraft-test.yaml").write_text(
+        "backends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+    # A deprecated spread.yaml file with a craft backend should be ignored
+    # when the test config file is present.
+    (in_project_path / "spread.yaml").write_text(
+        "backends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+
+    testing_service.parse_spread_yaml()
+
+    emitter.assert_interactions(None)
+
+
+def test_parse_spread_yaml_spread_yaml(
+    in_project_path: pathlib.Path, default_app_metadata, emitter
+):
+    """Warn when a spread.yaml is used."""
+    testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
+
+    (in_project_path / "spread.yaml").write_text(
+        "backends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+
+    testing_service.parse_spread_yaml()
+
+    emitter.assert_warning(
+        "'spread.yaml' is deprecated for 'testcraft test'. "
+        "Rename it to 'testcraft-test.yaml' and "
+        "remove the 'project' key, if defined."
+    )
+
+
+def test_parse_spread_yaml_single_warning(
+    in_project_path: pathlib.Path, default_app_metadata, emitter
+):
+    """The deprecation warning is only emitted once."""
+    testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
+
+    (in_project_path / "spread.yaml").write_text(
+        "backends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+
+    testing_service.parse_spread_yaml()
+    testing_service.parse_spread_yaml()
+
+    warning_calls = [call for call in emitter.interactions if call.args[0] == "warning"]
+    assert len(warning_calls) == 1
+
+
+def test_parse_spread_yaml_no_warning_in_managed_mode(
+    in_project_path: pathlib.Path, default_app_metadata, emitter, managed_mode
+):
+    """The deprecation warning is suppressed inside managed instances."""
+    testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
+
+    (in_project_path / "spread.yaml").write_text(
+        "backends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+
+    testing_service.parse_spread_yaml()
+
+    emitter.assert_interactions(None)
+
+
+def test_parse_spread_yaml_ignores_non_craft_test_spread_yaml(
+    in_project_path: pathlib.Path, default_app_metadata, emitter
+):
+    """Ignore spread.yaml if it lacks a craft backend."""
+    testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
+
+    (in_project_path / "spread.yaml").write_text(
+        "backends:\n  other:\n    systems: []\nsuites: {}\n"
+    )
+
+    with pytest.raises(CraftError, match="Could not find 'testcraft-test.yaml'"):
+        testing_service.parse_spread_yaml()
+
+    emitter.assert_interactions(None)
+
+
+def test_parse_spread_yaml_fallback_disabled(
+    in_project_path: pathlib.Path, default_app_metadata, emitter
+):
+    """Error on parsing spread.yaml if allow_spread is False."""
+    disabled_app_metadata = dataclasses.replace(
+        default_app_metadata, allow_spread_yaml=False
+    )
+    testing_service = TestingService(
+        app=disabled_app_metadata,
+        services=mock.Mock(),
+    )
+
+    (in_project_path / "spread.yaml").write_text(
+        "backends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+
+    with pytest.raises(CraftError, match="'spread.yaml' cannot be used") as raised:
+        testing_service.parse_spread_yaml()
+
+    assert raised.value.resolution is not None
+    assert "testcraft-test.yaml" in raised.value.resolution
+    emitter.assert_interactions(None)
+
+
+def test_parse_spread_yaml_ignores_project_key(
+    in_project_path: pathlib.Path, default_app_metadata
+):
+    """A 'project' key in a spread.yaml is silently unused."""
+    testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
+
+    (in_project_path / "spread.yaml").write_text(
+        "project: my-project\nbackends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+
+    parsed = testing_service.parse_spread_yaml()
+
+    assert isinstance(parsed, models.CraftSpreadYaml)
+    assert parsed.project == "my-project"
+
+
+def test_parse_spread_yaml_app_test_yaml_rejects_legacy_keys(
+    in_project_path: pathlib.Path, default_app_metadata
+):
+    """Unsupported keys, like `project`, raise an error when parsing a craft test file."""
+    testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
+
+    (in_project_path / "testcraft-test.yaml").write_text(
+        "project: my-project\nbackends:\n  craft:\n    systems: []\nsuites: {}\n"
+    )
+
+    with pytest.raises(TestFileError):
+        testing_service.parse_spread_yaml()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -27,7 +27,7 @@ import craft_cli.messages
 import craft_platforms
 import pytest
 from craft_application import models
-from craft_application.errors import TestFileError
+from craft_application.errors import TestFileError, YamlError
 from craft_application.services.testing import TestingService
 from craft_cli import CraftError
 
@@ -210,10 +210,52 @@ def test_process_without_spread_file(new_dir, testing_service):
         testing_service.process_spread_yaml(new_dir / "wherever", state)
 
 
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param(
+            "backends:\n  craft:\n    systems: []\nsuites: {}\n",
+            True,
+            id="craft-test-file",
+        ),
+        pytest.param(
+            "backends:\n  other:\n    systems: []\nsuites: {}\n",
+            False,
+            id="not-a-craft-test-file",
+        ),
+        pytest.param("- item1\n- item2\n", False, id="not-a-dict"),
+    ],
+)
+def test_is_craft_test_file(tmp_path, content, expected):
+    """Return whether spread.yaml is a craft test file."""
+    spread_path = tmp_path / "spread.yaml"
+    spread_path.write_text(content)
+
+    assert TestingService._is_craft_test_file(spread_path) is expected
+
+
+def test_is_craft_test_file_read_error(tmp_path):
+    """Error if spread.yaml can't be read."""
+    spread_path = tmp_path / "spread.yaml"
+    spread_path.mkdir()
+
+    with pytest.raises(CraftError, match="Could not read"):
+        TestingService._is_craft_test_file(spread_path)
+
+
+def test_is_craft_test_file_invalid_yaml(tmp_path):
+    """Error if spread.yaml is invalid yaml."""
+    spread_path = tmp_path / "spread.yaml"
+    spread_path.write_text("backends: [unclosed")
+
+    with pytest.raises(YamlError):
+        TestingService._is_craft_test_file(spread_path)
+
+
 def test_parse_test_config_uses_craft_test_yaml(
     in_project_path: pathlib.Path, default_app_metadata, emitter
 ):
-    """Prefer the test config file and over spread.yaml"""
+    """Prefer the test config file over spread.yaml"""
     testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
 
     (in_project_path / "testcraft-test.yaml").write_text(

--- a/tests/unit/services/test_testing.py
+++ b/tests/unit/services/test_testing.py
@@ -210,10 +210,10 @@ def test_process_without_spread_file(new_dir, testing_service):
         testing_service.process_spread_yaml(new_dir / "wherever", state)
 
 
-def test_parse_spread_yaml_uses_craft_test_yaml(
+def test_parse_test_config_uses_craft_test_yaml(
     in_project_path: pathlib.Path, default_app_metadata, emitter
 ):
-    """Prefer a test config file is used and over a spread.yaml"""
+    """Prefer the test config file and over spread.yaml"""
     testing_service = TestingService(app=default_app_metadata, services=mock.Mock())
 
     (in_project_path / "testcraft-test.yaml").write_text(
@@ -225,12 +225,12 @@ def test_parse_spread_yaml_uses_craft_test_yaml(
         "backends:\n  craft:\n    systems: []\nsuites: {}\n"
     )
 
-    testing_service.parse_spread_yaml()
+    testing_service.parse_test_config()
 
     emitter.assert_interactions(None)
 
 
-def test_parse_spread_yaml_spread_yaml(
+def test_parse_test_config_spread_yaml(
     in_project_path: pathlib.Path, default_app_metadata, emitter
 ):
     """Warn when a spread.yaml is used."""
@@ -240,7 +240,7 @@ def test_parse_spread_yaml_spread_yaml(
         "backends:\n  craft:\n    systems: []\nsuites: {}\n"
     )
 
-    testing_service.parse_spread_yaml()
+    testing_service.parse_test_config()
 
     emitter.assert_warning(
         "'spread.yaml' is deprecated for 'testcraft test'. "
@@ -249,7 +249,7 @@ def test_parse_spread_yaml_spread_yaml(
     )
 
 
-def test_parse_spread_yaml_single_warning(
+def test_parse_test_config_single_warning(
     in_project_path: pathlib.Path, default_app_metadata, emitter
 ):
     """The deprecation warning is only emitted once."""
@@ -259,14 +259,14 @@ def test_parse_spread_yaml_single_warning(
         "backends:\n  craft:\n    systems: []\nsuites: {}\n"
     )
 
-    testing_service.parse_spread_yaml()
-    testing_service.parse_spread_yaml()
+    testing_service.parse_test_config()
+    testing_service.parse_test_config()
 
     warning_calls = [call for call in emitter.interactions if call.args[0] == "warning"]
     assert len(warning_calls) == 1
 
 
-def test_parse_spread_yaml_no_warning_in_managed_mode(
+def test_parse_test_config_no_warning_in_managed_mode(
     in_project_path: pathlib.Path, default_app_metadata, emitter, managed_mode
 ):
     """The deprecation warning is suppressed inside managed instances."""
@@ -276,12 +276,12 @@ def test_parse_spread_yaml_no_warning_in_managed_mode(
         "backends:\n  craft:\n    systems: []\nsuites: {}\n"
     )
 
-    testing_service.parse_spread_yaml()
+    testing_service.parse_test_config()
 
     emitter.assert_interactions(None)
 
 
-def test_parse_spread_yaml_ignores_non_craft_test_spread_yaml(
+def test_parse_test_config_ignores_non_craft_test_spread_yaml(
     in_project_path: pathlib.Path, default_app_metadata, emitter
 ):
     """Ignore spread.yaml if it lacks a craft backend."""
@@ -292,12 +292,12 @@ def test_parse_spread_yaml_ignores_non_craft_test_spread_yaml(
     )
 
     with pytest.raises(CraftError, match="Could not find 'testcraft-test.yaml'"):
-        testing_service.parse_spread_yaml()
+        testing_service.parse_test_config()
 
     emitter.assert_interactions(None)
 
 
-def test_parse_spread_yaml_fallback_disabled(
+def test_parse_test_config_fallback_disabled(
     in_project_path: pathlib.Path, default_app_metadata, emitter
 ):
     """Error on parsing spread.yaml if allow_spread is False."""
@@ -314,14 +314,14 @@ def test_parse_spread_yaml_fallback_disabled(
     )
 
     with pytest.raises(CraftError, match="'spread.yaml' cannot be used") as raised:
-        testing_service.parse_spread_yaml()
+        testing_service.parse_test_config()
 
     assert raised.value.resolution is not None
     assert "testcraft-test.yaml" in raised.value.resolution
     emitter.assert_interactions(None)
 
 
-def test_parse_spread_yaml_ignores_project_key(
+def test_parse_test_config_ignores_project_key(
     in_project_path: pathlib.Path, default_app_metadata
 ):
     """A 'project' key in a spread.yaml is silently unused."""
@@ -331,13 +331,13 @@ def test_parse_spread_yaml_ignores_project_key(
         "project: my-project\nbackends:\n  craft:\n    systems: []\nsuites: {}\n"
     )
 
-    parsed = testing_service.parse_spread_yaml()
+    parsed = testing_service.parse_test_config()
 
     assert isinstance(parsed, models.CraftSpreadYaml)
     assert parsed.project == "my-project"
 
 
-def test_parse_spread_yaml_app_test_yaml_rejects_legacy_keys(
+def test_parse_test_config_app_test_yaml_rejects_legacy_keys(
     in_project_path: pathlib.Path, default_app_metadata
 ):
     """Unsupported keys, like `project`, raise an error when parsing a craft test file."""
@@ -348,7 +348,7 @@ def test_parse_spread_yaml_app_test_yaml_rejects_legacy_keys(
     )
 
     with pytest.raises(TestFileError):
-        testing_service.parse_spread_yaml()
+        testing_service.parse_test_config()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---

Allows parsing `<app-name>-test.yaml` and adds a deprecation warning when parsing existing `spread.yaml`.

(CRAFT-5282)