### PR TITLE
chore: block snap auto-refreshes during tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -206,6 +206,9 @@ prepare: |
   fi
 
   sudo snap wait system seed.loaded
+  sudo snap set system refresh.hold=forever
+  timeout 5m sudo snap watch --last=refresh || true
+
   # IDK why but if we don't sleep after this we get:
   # error: cannot install "snapd": Post "https://api.snapcraft.io/v2/snaps/refresh": context canceled
   sleep 4


### PR DESCRIPTION
Prevent spread test errors caused by snap refreshes in progress.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?
- [ ] Have you added an entry to the changelog (`docs/reference/changelog.rst`)?

---
