### PR TITLE
ci: isolate Launchpad network tests into dedicated job

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -25,7 +25,7 @@ jobs:
       lowest-python-platform: ubuntu-22.04
       lowest-python-version: "3.10"
       use-lxd: true
-      pytest-markers: "not flaky"
+      pytest-markers: "not flaky and not launchpad"
   test-flaky:
     uses: canonical/starflow/.github/workflows/test-python.yaml@main
     with:
@@ -35,4 +35,14 @@ jobs:
       lowest-python-platform: ubuntu-22.04
       lowest-python-version: "3.10"
       use-lxd: true
-      pytest-markers: "flaky"
+      pytest-markers: "flaky and not launchpad"
+  test-launchpad:
+    uses: canonical/starflow/.github/workflows/test-python.yaml@main
+    with:
+      fast-test-platforms: ""
+      slow-test-platforms: '["ubuntu-24.04"]'
+      slow-test-python-versions: '["3.12"]'
+      lowest-python-platform: ""
+      lowest-python-version: ""
+      use-lxd: false
+      pytest-markers: "launchpad"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ endif
 
 include common.mk
 
+.PHONY: test-launchpad
+test-launchpad:  ##- Run Launchpad network tests (isolated, slow+flaky)
+	uv run pytest -m 'launchpad'
+
 .PHONY: format
 format: format-ruff format-codespell format-prettier  ## Run all automatic formatters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,7 @@ markers = [
     "enable_features: Tests that require specific features",
     "slow: Tests that take a long time",
     "flaky: Tests that are known to be flaky and may need reruns (e.g. network-dependent)",
+    "launchpad: Tests that require live network access to the Launchpad API (staging/production)",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/launchpad/test_anonymous_access.py
+++ b/tests/integration/launchpad/test_anonymous_access.py
@@ -35,6 +35,7 @@ _IGNORE_STAGING = _ignore_staging()
     ],
 )
 @pytest.mark.slow
+@pytest.mark.launchpad
 def test_anonymous_login(tmp_path, root):
     cache_dir = tmp_path / "cache"
     assert not cache_dir.exists()
@@ -69,6 +70,7 @@ def test_anonymous_login(tmp_path, root):
     ],
 )
 @pytest.mark.slow
+@pytest.mark.launchpad
 def test_get_real_repository_by_path(anonymous_lp, name, path):
     repo = anonymous_lp.get_repository(path=path)
 
@@ -86,6 +88,7 @@ def test_get_real_repository_by_path(anonymous_lp, name, path):
     ],
 )
 @pytest.mark.slow
+@pytest.mark.launchpad
 def test_get_real_repository_by_name(anonymous_lp, name, owner, project):
     repo = anonymous_lp.get_repository(name=name, owner=owner, project=project)
 

--- a/tests/integration/launchpad/test_anonymous_access.py
+++ b/tests/integration/launchpad/test_anonymous_access.py
@@ -17,26 +17,14 @@ def _ignore_staging() -> bool:
     return api_result.status_code >= 500
 
 
-_IGNORE_STAGING = _ignore_staging()
-
-
 @pytest.mark.flaky(reruns=3, reason="Launchpad staging is often unreachable")
-@pytest.mark.parametrize(
-    "root",
-    [
-        pytest.param(
-            "staging",
-            marks=pytest.mark.skipif(
-                _IGNORE_STAGING,
-                reason="staging endpoint is offline",
-            ),
-        ),
-        "production",
-    ],
-)
+@pytest.mark.parametrize("root", ["staging", "production"])
 @pytest.mark.slow
 @pytest.mark.launchpad
 def test_anonymous_login(tmp_path, root):
+    if root == "staging" and _ignore_staging():
+        pytest.skip("staging endpoint is offline")
+
     cache_dir = tmp_path / "cache"
     assert not cache_dir.exists()
 


### PR DESCRIPTION
## Summary
Isolate tests that hit the real Launchpad API into their own CI job.

## Context
Tests in `tests/integration/launchpad/test_anonymous_access.py:1` make live HTTP calls to `api.launchpad.net` / `api.staging.launchpad.net` (`Launchpad.anonymous:42`, `get_repository:73,90`). They are `slow`+`flaky` (reruns=3) and currently run in the `test-flaky` matrix on 6 runners, blocking fast feedback when staging is down (`_IGNORE_STAGING:20`).

## Changes (surgical, minimal)
- `pyproject.toml:241` — add `launchpad` marker
- `tests/integration/launchpad/test_anonymous_access.py:38,72,88` — annotate 3 tests (7 parametrized cases) with `@pytest.mark.launchpad`
- `.github/workflows/qa.yaml:28,38` — exclude from main jobs (`not launchpad`) and add `test-launchpad` job (single runner `ubuntu-24.04`/`3.12`, no LXD, no lowest) via `canonical/starflow` reusable workflow (`secret-guard` sanitized)
- `Makefile:21` — add `make test-launchpad` helper (`uv run pytest -m launchpad`)

Validated: `uv run pytest -m launchpad --collect-only` → 7 tests; marker composition verified against starflow (`slow and (launchpad)`, `not launchpad`).

## Follow-up
Decide branch protection for `test-launchpad` — recommend required on `main`, `continue-on-error` on PRs to avoid staging flakiness blocking contributors.

## QA steps
- [ ] `uv run pytest -m launchpad`
- [ ] `uv run pytest -m "not launchpad"` collects 5973 tests
- [ ] CI shows 3 jobs: `test`, `test-flaky`, `test-launchpad` with no double-run
- [ ] `make test-launchpad` works

Fixes: internal request to separate Launchpad network tests.

